### PR TITLE
WIP Loading shelves from yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ py==1.4.32
 pyparsing==2.1.10
 -e .
 six==1.10.0
-SQLAlchemy==1.1.9
+SQLAlchemy==1.2.0b2
 sqlparse==0.2.2
 tablib==0.12.1

--- a/src/recipe/extensions.py
+++ b/src/recipe/extensions.py
@@ -305,10 +305,10 @@ class Anonymize(RecipeExtension):
         for ingredient in self.recipe._cauldron.values():
             if hasattr(ingredient.meta, 'anonymizer'):
                 if ingredient.meta.anonymizer not in ingredient.formatters \
-                    and self._anonymize:
+                        and self._anonymize:
                     ingredient.formatters.append(ingredient.meta.anonymizer)
                 if ingredient.meta.anonymizer in ingredient.formatters \
-                    and not self._anonymize:
+                        and not self._anonymize:
                     ingredient.formatters.remove(ingredient.meta.anonymizer)
 
 
@@ -384,7 +384,7 @@ class BlendRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .blend() '
                                         'recipe subquery'.format(
-                            id + suffix))
+                                            id + suffix))
 
             # For all dimensions in the blend recipe
             # Use the dimension in the base recipe and
@@ -405,7 +405,7 @@ class BlendRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .blend() '
                                         'recipe subquery'.format(
-                            id + suffix))
+                                            id + suffix))
 
             base_dim = self.recipe._cauldron[join_base]
             blend_dim = blend_recipe._cauldron[join_blend]
@@ -482,7 +482,7 @@ class CompareRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .compare() '
                                         'recipe subquery'.format(
-                            id + suffix))
+                                            id + suffix))
 
             join_conditions = []
             for dim in compare_recipe.dimension_ids:

--- a/src/recipe/extensions.py
+++ b/src/recipe/extensions.py
@@ -1,6 +1,4 @@
 # TODO ask jason about methods of doing this
-from copy import copy
-
 from sqlalchemy import and_
 from sqlalchemy import func
 from sqlalchemy import text
@@ -22,8 +20,8 @@ class RecipeExtension(object):
 
     recipe generates a query in the following way
 
-        (RECIPE) recipe checks its dirty state and all extension dirty states to
-        determine if the cached query needs to be regenerated
+        (RECIPE) recipe checks its dirty state and all extension dirty
+        states to determine if the cached query needs to be regenerated
 
         (EXTENSIONS) all extension ``add_ingredients`` run to inject
         ingredients directly on the recipe
@@ -59,7 +57,8 @@ class RecipeExtension(object):
     When the recipe fetches data the results will be ``enchanted`` to add
     fields to the result. ``RecipeExtensions`` can modify result rows with
 
-        enchant_add_fields: Return a tuple of field names to add to a result row
+        enchant_add_fields: Return a tuple of field names to add to a
+        result row
 
         enchant_row(row): Return a tuple of field values for each row in
         results.
@@ -262,8 +261,9 @@ class SummarizeOver(RecipeExtension):
             if subq_col is not None:
                 order_by_columns.append(subq_col)
 
-        postquery_parts['query'] = self.recipe._session.query(*(group_by_columns +
-                                                                metric_columns)).group_by(
+        postquery_parts['query'] = self.recipe._session.query(
+            *(group_by_columns +
+              metric_columns)).group_by(
             *group_by_columns).order_by(*order_by_columns)
 
         # Remove the summarized dimension
@@ -305,10 +305,10 @@ class Anonymize(RecipeExtension):
         for ingredient in self.recipe._cauldron.values():
             if hasattr(ingredient.meta, 'anonymizer'):
                 if ingredient.meta.anonymizer not in ingredient.formatters \
-                        and self._anonymize:
+                    and self._anonymize:
                     ingredient.formatters.append(ingredient.meta.anonymizer)
                 if ingredient.meta.anonymizer in ingredient.formatters \
-                        and not self._anonymize:
+                    and not self._anonymize:
                     ingredient.formatters.remove(ingredient.meta.anonymizer)
 
 
@@ -384,7 +384,7 @@ class BlendRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .blend() '
                                         'recipe subquery'.format(
-                                            id + suffix))
+                            id + suffix))
 
             # For all dimensions in the blend recipe
             # Use the dimension in the base recipe and
@@ -405,7 +405,7 @@ class BlendRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .blend() '
                                         'recipe subquery'.format(
-                                            id + suffix))
+                            id + suffix))
 
             base_dim = self.recipe._cauldron[join_base]
             blend_dim = blend_recipe._cauldron[join_blend]
@@ -482,7 +482,7 @@ class CompareRecipe(RecipeExtension):
                     else:
                         raise BadRecipe('{} could not be found in .compare() '
                                         'recipe subquery'.format(
-                                            id + suffix))
+                            id + suffix))
 
             join_conditions = []
             for dim in compare_recipe.dimension_ids:

--- a/src/recipe/ingredients.py
+++ b/src/recipe/ingredients.py
@@ -33,7 +33,7 @@ def ingredient_from_dict(ingr_dict):
     if IngredientClass is None:
         raise BadIngredient('Bad ingredient kind')
     args = ingr_dict.pop('expression', None)
-    if isinstance(args, basestring):
+    if not isinstance(args, (list, tuple)):
         args = [args]
     if args is None:
         raise BadIngredient('expression is required')
@@ -436,7 +436,6 @@ class LookupDimension(Dimension):
 class Metric(Ingredient):
     """ A simple metric created from a single expression
     """
-    @deferred
     def __init__(self, expression, **kwargs):
         super(Metric, self).__init__(**kwargs)
         self.columns = [expression]

--- a/src/recipe/ingredients.py
+++ b/src/recipe/ingredients.py
@@ -93,6 +93,7 @@ class deferred:
 class Ingredient(object):
     """ Ingredients combine to make a SQLAlchemy query.
     """
+
     def __init__(self, **kwargs):
         """ Initializing an instance of the Ingredient Class
 
@@ -156,7 +157,7 @@ class Ingredient(object):
                 if isinstance(arg, basestring):
                     disaggregate = False
                     if getattr(self, 'shelf', None) and \
-                        getattr('table', self.shelf.Meta, None):
+                            getattr('table', self.shelf.Meta, None):
                         # Convert the argument to a sqlalchemy statement
                         statement = alchemify(arg, self.shelf.Meta.table)
                         arg = eval(statement)
@@ -436,6 +437,7 @@ class LookupDimension(Dimension):
 class Metric(Ingredient):
     """ A simple metric created from a single expression
     """
+
     def __init__(self, expression, **kwargs):
         super(Metric, self).__init__(**kwargs)
         self.columns = [expression]

--- a/src/recipe/shelf.py
+++ b/src/recipe/shelf.py
@@ -137,28 +137,21 @@ class Shelf(AttrDict):
                 raise BadRecipe('{} is not a {}'.format(
                     obj, filter_to_class))
 
-            ingredient.resolve(self)
             if set_descending:
                 ingredient.ordering = 'desc'
 
             return ingredient
         elif isinstance(obj, filter_to_class):
-            obj.resolve(self)
             return obj
         else:
             raise BadRecipe('{} is not a {}'.format(obj,
                                                     type(filter_to_class)))
-
-    def resolve(self):
-        for ingr in self.ingredients():
-            ingr.resolve(self)
 
     def brew_query_parts(self):
         """ Make columns, group_bys, filters, havings
         """
         columns, group_bys, filters, havings = [], [], set(), set()
         for ingredient in self.ingredients():
-            ingredient.resolve(self)
             if ingredient.query_columns:
                 columns.extend(ingredient.query_columns)
             if ingredient.group_by:

--- a/src/recipe/shelf.py
+++ b/src/recipe/shelf.py
@@ -21,11 +21,15 @@ class Shelf(AttrDict):
     Returns:
         A Shelf object
     """
+
     class Meta:
         anonymize = False
+        table = None
 
     def __init__(self, *args, **kwargs):
         super(Shelf, self).__init__(*args, **kwargs)
+
+        self.Meta.table = kwargs.pop('table', None)
 
         # Set the ids of all ingredients on the shelf to the key
         for k, ingredient in self.items():

--- a/src/recipe/shelf.py
+++ b/src/recipe/shelf.py
@@ -31,6 +31,7 @@ class Shelf(AttrDict):
     def __init__(self, *args, **kwargs):
         super(Shelf, self).__init__(*args, **kwargs)
 
+        self.Meta.ingredient_order = []
         self.Meta.table = kwargs.pop('table', None)
 
         # Set the ids of all ingredients on the shelf to the key
@@ -74,6 +75,32 @@ class Shelf(AttrDict):
         return tuple(d.id for d in self.values() if
                      isinstance(d, Metric))
 
+    @property
+    def dimension_ids(self):
+        """ Return the Dimensions on this shelf in the order in which
+        they were used."""
+        return tuple(
+            sorted(
+                [d.id for d in self.values()
+                 if isinstance(d, Dimension)],
+                key=lambda id: self.Meta.ingredient_order.index(id) \
+                    if id in self.Meta.ingredient_order else 9999
+            )
+        )
+
+    @property
+    def metric_ids(self):
+        """ Return the Metrics on this shelf in the order in which
+        they were used. """
+        return tuple(
+            sorted(
+                [d.id for d in self.values()
+                 if isinstance(d, Metric)],
+                key=lambda id: self.Meta.ingredient_order.index(id) \
+                    if id in self.Meta.ingredient_order else 9999
+            )
+        )
+
     def __repr__(self):
         """ A string representation of the ingredients used in a recipe
         ordered by Dimensions, Metrics, Filters, then Havings
@@ -85,6 +112,8 @@ class Shelf(AttrDict):
         return '\n'.join(lines)
 
     def use(self, ingredient):
+        # Track the order in which ingredients are added.
+        self.Meta.ingredient_order.append(ingredient.id)
         self[ingredient.id] = ingredient
 
     @classmethod

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4752,17 +4752,6 @@ census_shelf = Shelf({
 })
 
 
-deferred_shelf = Shelf({
-    'state': Dimension(Census.state),
-    'sex': Dimension(Census.sex),
-    'age': Dimension(Census.age),
-    'avgage': WtdAvgMetric(Census.age, Census.pop2000),
-    'pop2000': Metric(func.sum(Census.pop2000)),
-    'pop2008': Metric(func.sum(Census.pop2008)),
-    'div': DivideMetric('pop2000', 'pop2008'),
-})
-
-
 statefact_shelf = Shelf({
     'state': Dimension(StateFact.name),
     'abbreviation': Dimension(StateFact.abbreviation),

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -338,9 +338,9 @@ class TestDivideMetric(object):
         d = DivideMetric(func.sum(MyTable.age), func.sum(MyTable.age),
                          ifzero='zero')
         assert str(d.columns[0]) == \
-               'CASE WHEN (CAST(sum(foo.age) AS FLOAT) = :param_1) THEN ' \
-               ':param_2 ELSE CAST(sum(foo.age) AS FLOAT) / ' \
-               'CAST(sum(foo.age) AS FLOAT) END'
+            'CASE WHEN (CAST(sum(foo.age) AS FLOAT) = :param_1) THEN ' \
+            ':param_2 ELSE CAST(sum(foo.age) AS FLOAT) / ' \
+            'CAST(sum(foo.age) AS FLOAT) END'
 
 
 class TestSumIfMetric(object):
@@ -359,7 +359,7 @@ class TestSumIfMetric(object):
 
         # Generate numerator / (denominator+epsilon) by default
         assert str(d.columns[0]) == \
-               'sum(CASE WHEN (foo.age > :age_1) THEN sum(foo.age) END)'
+            'sum(CASE WHEN (foo.age > :age_1) THEN sum(foo.age) END)'
 
 
 class TestCountIfMetric(object):
@@ -378,7 +378,7 @@ class TestCountIfMetric(object):
 
         # Generate numerator / (denominator+epsilon) by default
         assert str(d.columns[0]) == \
-               'count(DISTINCT CASE WHEN (foo.age > :age_1) THEN foo.first END)'
+            'count(DISTINCT CASE WHEN (foo.age > :age_1) THEN foo.first END)'
 
         d = CountIfMetric(MyTable.age > 5, MyTable.first, distinct=False)
         assert len(d.columns) == 1
@@ -387,7 +387,7 @@ class TestCountIfMetric(object):
 
         # Generate numerator / (denominator+epsilon) by default
         assert str(d.columns[0]) == \
-               'count(CASE WHEN (foo.age > :age_1) THEN foo.first END)'
+            'count(CASE WHEN (foo.age > :age_1) THEN foo.first END)'
 
 
 class TestIngredientFromObj(object):
@@ -458,4 +458,4 @@ class TestAlchemify(object):
         expression = eval(statement)
         assert isinstance(expression, (InstrumentedAttribute,
                                        FunctionElement, basestring))
-        assert unicode(expression) == unicode("squee")
+        assert unicode(expression) == unicode('squee')

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -409,7 +409,7 @@ class TestIngredientFromObj(object):
 
 
 class TestParse(object):
-    def test_parse_field(self):
+    def test_parse_field_aggregation(self):
         data = [
             # Basic fields
             ('moo', 'func.sum(MyTable.moo)'),
@@ -437,6 +437,18 @@ class TestParse(object):
                   'in': (1, 2)
               }},
              'func.sum(case when MyTable.cow in (1, 2) then MyTable.moo end)'),
+        ]
+        for input_field, expected_result in data:
+            result = parse_field(input_field, table='MyTable')
+            assert result == expected_result
+
+    def test_parse_field_add_subtract(self):
+        data = [
+            # Basic fields
+            ('moo+foo', 'func.sum(MyTable.moo + MyTable.foo)'),
+            ('moo-foo', 'func.sum(MyTable.moo - MyTable.foo)'),
+            ('moo-foo-sue', 'func.sum(MyTable.moo - MyTable.foo - '
+                            'MyTable.sue)'),
         ]
         for input_field, expected_result in data:
             result = parse_field(input_field, table='MyTable')

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -158,52 +158,6 @@ Utah,30.63622231900565,Utah
 """
 
 
-class TestDeferredMetrics(object):
-    def setup(self):
-        # create a Session
-        self.session = Session()
-        self.shelf = Shelf({
-            'state': Dimension(Census.state),
-            'sex': Dimension(Census.sex),
-            'age': Dimension(Census.age),
-            'avgage': WtdAvgMetric('age', '`pop2000'),
-            'avgage2': WtdAvgMetric(Census.age, Census.pop2000),
-            'pop2000': Metric(func.sum(Census.pop2000)),
-            'pop2008': Metric(func.sum(Census.pop2008)),
-            'div': DivideMetric('pop2000', 'pop2008'),
-        })
-
-    def recipe(self, **kwargs):
-        return Recipe(shelf=self.shelf, session=self.session, **kwargs)
-
-    def test_deferred_metric(self):
-        recipe = self.recipe().metrics('div').dimensions('state')
-
-        assert recipe.to_sql() == """SELECT census.state AS state,
-       CAST(sum(census.pop2000) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS div
-FROM census
-GROUP BY census.state"""
-        print recipe.all()[0]
-        assert recipe.all()[0].state == 'Alabama'
-        assert abs(recipe.all()[0].div - 0.9546587739793394) < 0.000000001
-        assert recipe.stats.rows == 51
-
-    def test_deferred_avgage(self):
-        """ A deferred metric that uses disaggregate """
-        recipe = self.recipe().metrics('avgage', 'avgage2').dimensions('state')
-
-        assert recipe.to_sql() == """SELECT census.state AS state,
-       CAST(sum(census.age * (census.pop2000)) AS FLOAT) / (coalesce(CAST(sum((census.pop2000)) AS FLOAT), 0.0) + 1e-09) AS avgage,
-       CAST(sum(census.age * census.pop2000) AS FLOAT) / (coalesce(CAST(sum(census.pop2000) AS FLOAT), 0.0) + 1e-09) AS avgage2
-FROM census
-GROUP BY census.state"""
-        print recipe.all()[0]
-        assert recipe.all()[0].state == 'Alabama'
-        assert abs(recipe.all()[0].avgage - 36.27787892421841) < 0.000000001
-        assert abs(recipe.all()[0].avgage2 - 36.27787892421841) < 0.000000001
-        assert recipe.stats.rows == 51
-
-
 class TestStats(object):
     def setup(self):
         # create a Session

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -1,9 +1,5 @@
 import pytest
 from copy import copy
-from sqlalchemy import func
-from yaml import safe_load
-
-from recipe.ingredients import alchemify, ingredient_from_dict
 from .test_base import *
 
 from recipe import BadRecipe
@@ -124,13 +120,13 @@ class TestShelfFromYaml(object):
         self.shelf = Shelf.from_yaml("""
 first:
     kind: Dimension
-    expression: '{first}'
+    field: first
 last:
     kind: Dimension
-    expression: '{last}'
+    field: last
 age:
     kind: Metric
-    expression: sum({age})
+    field: age
 """, MyTable)
         self.shelf.Meta.anonymize = False
 

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -116,6 +116,137 @@ class TestShelf(object):
         assert len(self.shelf) == 0
 
 
+
+
+class TestShelfFromYaml(object):
+    def setup(self):
+        # create a Session
+        self.shelf = Shelf.from_yaml("""
+first:
+    kind: Dimension
+    expression: {first}
+last:
+    kind: Dimension
+    expression: {last}
+age:
+    kind: Metric
+    expression: sum({age})
+""", 'MyTable')
+        print(self.shelf)
+        print('%'*80)
+        # self.shelf = copy(mytable_shelf)
+        print(self.shelf)
+        self.shelf.Meta.anonymize = False
+
+    def test_find(self):
+        """ Find ingredients on the shelf """
+        ingredient = self.shelf.find('first', Dimension)
+        assert ingredient.id == 'first'
+
+        # Raise if the wrong type
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('first', Metric)
+
+        # Raise if key not present in shelf
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        # Raise if key is not an ingredient or string
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find(2.0, Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find(2.0, Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        self.shelf['foo'] = Dimension(MyTable.last)
+        ingredient = self.shelf.find('last', Dimension)
+        assert ingredient.id == 'last'
+
+    def test_repr(self):
+        """ Find ingredients on the shelf """
+        print('%'*80)
+        print('%'*80)
+        print(self.shelf.__repr__())
+        print('%'*80)
+        print('%'*80)
+        assert self.shelf.__repr__() == """(Dimension)first first
+(Dimension)last last
+(Metric)age sum({age})"""
+        self.shelf.resolve()
+
+
+    def test_update(self):
+        """ Shelves can be updated with other shelves """
+        new_shelf = Shelf({
+            'squee': Dimension(MyTable.first),
+        })
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+
+    def test_update_key_value(self):
+        """ Shelves can be built with key_values and updated """
+        new_shelf = Shelf(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
+    def test_update_key_value_direct(self):
+        """ Shelves can be updated directly with key_value"""
+        assert len(self.shelf) == 3
+        self.shelf.update(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
+    def test_brew(self):
+        recipe_parts = self.shelf.brew_query_parts()
+        assert len(recipe_parts['columns']) == 3
+        assert len(recipe_parts['group_bys']) == 2
+        assert len(recipe_parts['filters']) == 0
+        assert len(recipe_parts['havings']) == 0
+
+    def test_anonymize(self):
+        """ We can save and store anonymization context """
+        assert self.shelf.Meta.anonymize == False
+        self.shelf.Meta.anonymize = True
+        assert self.shelf.Meta.anonymize == True
+
+    def test_get(self):
+        """ Find ingredients on the shelf """
+        ingredient = self.shelf.first
+        assert ingredient.id == 'first'
+
+        ingredient = self.shelf.get('first', None)
+        assert ingredient.id == 'first'
+
+        ingredient = self.shelf.get('primo', None)
+        assert ingredient is None
+
+    def test_add_to_shelf(self):
+        """ We can add an ingredient to a shelf """
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        self.shelf['foo'] = Dimension(MyTable.last)
+        ingredient = self.shelf.find('last', Dimension)
+        assert ingredient.id == 'last'
+
+    def test_clear(self):
+        assert len(self.shelf) == 3
+        self.shelf.clear()
+        assert len(self.shelf) == 0
+
+
 class TestAutomaticShelf(object):
     def setup(self):
         self.shelf = AutomaticShelf(MyTable)

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -172,7 +172,6 @@ age:
         assert self.shelf.__repr__() == """(Dimension)first MyTable.first
 (Dimension)last MyTable.last
 (Metric)age sum(foo.age)"""
-        self.shelf.resolve()
 
     def test_update(self):
         """ Shelves can be updated with other shelves """

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -53,6 +53,30 @@ class TestShelf(object):
 (Dimension)last MyTable.last
 (Metric)age sum(foo.age)"""
 
+    def test_update(self):
+        """ Shelves can be updated with other shelves """
+        new_shelf = Shelf({
+            'squee': Dimension(MyTable.first),
+        })
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+
+    def test_update_key_value(self):
+        """ Shelves can be built with key_values and updated """
+        new_shelf = Shelf(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
+    def test_update_key_value_direct(self):
+        """ Shelves can be updated directly with key_value"""
+        assert len(self.shelf) == 3
+        self.shelf.update(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
     def test_brew(self):
         recipe_parts = self.shelf.brew_query_parts()
         assert len(recipe_parts['columns']) == 3

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -1,6 +1,9 @@
 import pytest
 from copy import copy
 from sqlalchemy import func
+from yaml import safe_load
+
+from recipe.ingredients import alchemify, ingredient_from_dict
 from .test_base import *
 
 from recipe import BadRecipe
@@ -116,26 +119,19 @@ class TestShelf(object):
         assert len(self.shelf) == 0
 
 
-
-
 class TestShelfFromYaml(object):
     def setup(self):
-        # create a Session
         self.shelf = Shelf.from_yaml("""
 first:
     kind: Dimension
-    expression: {first}
+    expression: '{first}'
 last:
     kind: Dimension
-    expression: {last}
+    expression: '{last}'
 age:
     kind: Metric
     expression: sum({age})
-""", 'MyTable')
-        print(self.shelf)
-        print('%'*80)
-        # self.shelf = copy(mytable_shelf)
-        print(self.shelf)
+""", MyTable)
         self.shelf.Meta.anonymize = False
 
     def test_find(self):
@@ -173,16 +169,10 @@ age:
 
     def test_repr(self):
         """ Find ingredients on the shelf """
-        print('%'*80)
-        print('%'*80)
-        print(self.shelf.__repr__())
-        print('%'*80)
-        print('%'*80)
-        assert self.shelf.__repr__() == """(Dimension)first first
-(Dimension)last last
-(Metric)age sum({age})"""
+        assert self.shelf.__repr__() == """(Dimension)first MyTable.first
+(Dimension)last MyTable.last
+(Metric)age sum(foo.age)"""
         self.shelf.resolve()
-
 
     def test_update(self):
         """ Shelves can be updated with other shelves """
@@ -268,15 +258,15 @@ class TestAutomaticShelf(object):
         with pytest.raises(BadRecipe):
             ingredient = self.shelf.find(2.0, Dimension)
 
-        # We can choose not to raise
-        # ingredient = self.shelf.find('foo', Dimension)
-        # assert ingredient == 'foo'
-        #
-        # ingredient = self.shelf.find(2.0, Dimension)
-        # assert ingredient == 2.0
-        #
-        # ingredient = self.shelf.find('first', Metric)
-        # assert ingredient == 'first'
+            # We can choose not to raise
+            # ingredient = self.shelf.find('foo', Dimension)
+            # assert ingredient == 'foo'
+            #
+            # ingredient = self.shelf.find(2.0, Dimension)
+            # assert ingredient == 2.0
+            #
+            # ingredient = self.shelf.find('first', Metric)
+            # assert ingredient == 'first'
 
     def test_get(self):
         """ Find ingredients on the shelf """

--- a/yaml_shelf_readme.md
+++ b/yaml_shelf_readme.md
@@ -1,0 +1,217 @@
+Shelves can be defined in YAML.
+
+
+
+### Kinds of Ingredients
+
+Ingredients always require a `kind`. It can be one of
+
+- Dimension
+- LookupDimension
+- IdValueDimension
+- Metric
+- DivideMetric
+- WtdAvgMetric
+- ConditionalMetric
+- SumIfMetric
+- AvgIfMetric
+- CountIfMetric
+
+Ingredients may require one or two fields. Fields look like this
+
+    # This is a field using the default table
+    field: moo
+    # MyTable.moo
+
+    # This is the same as above
+    # MyTable.moo
+    field:
+        value: moo
+
+    # This is also the same as above
+    # MyTable.moo
+    field:
+        value: moo
+        aggregation: none
+
+    # Fields can also define conditions that apply inside of the
+    # aggregation
+    # case when MyTable.sales_id in (1,2,3) then MyTable.moo end
+    field:
+        value: moo
+        condition:
+            field: sales_id
+            in: [1,2,3]
+
+    # Aggregations can exits
+    # func.sum(MyTable.moo)
+    field:
+        value: moo
+        aggregation: sum
+
+    # Conditions work inside of the aggregation
+    # func.max(case when MyTable.sales_id in (1,2,3) then MyTable.moo end)
+    field:
+        value: moo
+        aggregation: max
+        condition:
+            field: sales_id
+            in: [1,2,3]
+
+Potential aggregations are
+
+- sum
+- min
+- max
+- avg
+- count
+- count_distinct
+
+#### Dimension
+
+    foo:
+        kind: Dimension
+        field: moo
+
+#### LookupDimension
+
+field and lookup are required
+
+    foo:
+        kind: LookupDimension
+        field: moo
+        lookup_default: Unknown
+        lookup:
+            NY: New York
+            VT: Vermont
+            GA: Georgia
+
+This creates
+
+    'foo': LookupDimension(MyTable.moo,
+                           lookup={
+                             'NY': 'New York',
+                             'VT': 'Vermont',
+                             'GA': 'Georgia'
+                           },
+                           default='Unknown')
+
+#### IdValueDimension
+
+field is required.
+id_field is based on field+'_id' if not provided
+
+    foo:
+        kind: IdValueDimension
+        field: moo
+        id_field: moo_id
+
+This creates
+
+    'foo': IdValueDimension(MyTable.moo, MyTable.moo_id)
+
+#### Metric
+
+field is required. All metric fields are aggregated using `sum` by default
+
+
+A field can take a string or an object.
+
+    foo:
+        kind: Metric
+        field: foo
+
+This creates
+
+    'foo': Metric(func.sum(foo)),
+
+
+aggregation is optional
+
+    foo:
+        kind: Metric
+        field:
+            value: foo
+            aggregation: max
+
+This creates
+
+    'foo': Metric(func.max(MyTable.foo)),
+
+You can define a conditional field that operates on the aggregation
+
+    foo:
+        kind: Metric
+        field:
+            value: sales
+            condition:
+                field: sale_date
+                range: last_year
+
+This creates
+
+    'foo': Metric(func.sum(
+      case when MyTable.sale_date between
+        cur_date() - '1 year' and cur_date() then MyTable.sales))
+
+
+Here is another example of a condition.
+
+    foo:
+        kind: Metric
+        field:
+            value: sales
+            condition:
+                field: sale_date
+                gt: 2015-01-01
+
+This creates
+
+    'foo': Metric(func.sum(
+      case when MyTable.sale_date > '2015-01-01' then MyTable.sales))
+
+#### DivideMetric
+
+numerator_field and denominator_field are required.
+
+    foo:
+        kind: DivideMetric
+        numerator_field: sales
+        denominator_field: count(distinct(sales))
+
+How to define the important pct teenage calculation
+
+    pct_teen:
+        kind: DivideMetric
+        numerator_field:
+            value: person_id
+            aggregation: count_distinct
+            condition:
+                field: age
+                between: [13, 19]
+        denominator_field:
+            value: person_id
+            aggregation: count_distinct
+
+How to define the important average price of product sold
+
+    avg_price:
+        kind: DivideMetric
+        numerator_field: sales
+        denominator_field: quantity
+
+
+
+
+#### WtdAvgMetric
+
+#### CountIfMetric
+
+#### SumIfMetric
+
+#### Filter
+
+#### Having
+from recipe.ingredients import Ingredient, Dimension, LookupDimension, \
+    IdValueDimension, Metric, DivideMetric, WtdAvgMetric, CountIfMetric, \
+    SumIfMetric, Filter, Having


### PR DESCRIPTION
Supports loading shelves from yaml definitions. A sample yaml definition of a shelf looks like this

```
first:
    kind: Dimension
    expression: '{first}'
last:
    kind: Dimension
    expression: '{last}'
age:
    kind: Metric
    expression: sum({age})
```

This is the same as 

```
Shelf({
   'first': Dimension(MyTable.first),
   'last': Dimension(MyTable.last),
   'age': Metric(func.sum(MyTable.age))
})
```

Fields are referenced with curly brackets like `{fieldname}`. Common functions are expanded from `sum` to `func.sum`.

**TODO**
- [ ] Syntax for field references is error prone (must be surrounded by quotes
- [ ] SQLAlchemy expressions are *eval*ed