### PR TITLE
remove SumIfMetric and CountIfMetric from __all__

### DIFF
--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -37,6 +37,6 @@ __version__ = '0.2.0'
 __all__ = [
     'BadIngredient', 'BadRecipe', 'Ingredient', 'Dimension', 'LookupDimension',
     'IdValueDimension', 'Metric', 'DivideMetric', 'WtdAvgMetric',
-    'CountIfMetric', 'SumIfMetric', 'Filter', 'Having', 'Recipe', 'Shelf',
+    'Filter', 'Having', 'Recipe', 'Shelf',
     'AutomaticShelf', 'SETTINGS', 'get_oven'
 ]


### PR DESCRIPTION
#11 Removed SumIfMetric and CountIfMetric, but they were still listed in `__all__`. This causes `import recipe.*` to fail.