### PR TITLE
Add cerberus

### DIFF
--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -71,11 +71,6 @@ class RecipeSchemas(object):
                 'type': 'string',
                 'required': True,
             },
-            '_aggregation': {
-                'default_setter': 'aggregation',
-                'nullable': True,
-                'readonly': True
-            },
             'operators': {
                 'required': False,
                 'type': 'list',
@@ -139,11 +134,6 @@ class RecipeSchemas(object):
                 'coerce': 'to_field_dict',
                 'allow_unknown': False,
                 'required': True
-            },
-            '_condition': {
-                'default_setter': 'condition',
-                'nullable': True,
-                'readonly': True
             },
         }
 

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -1,0 +1,202 @@
+"""
+Registers recipe schemas
+"""
+
+import logging
+from collections import OrderedDict
+from copy import deepcopy
+
+from cerberus import Validator, schema_registry
+from cerberus.platform import _int_types, _str_type
+
+logging.captureWarnings(True)
+
+
+class RecipeSchemas(object):
+
+    def __init__(
+        self, allowed_aggregations, allowed_operators=['+', '-', '*', '/']
+    ):
+        self.allowed_aggregations = allowed_aggregations
+        self.allowed_operators = allowed_operators
+
+        self.scalar_conditions = ('gt', 'gte', 'lt', 'lte', 'eq', 'ne')
+        self.nonscalar_conditions = ('in',)
+
+        # A structure containing ingredient classes and the required
+        # parameters IN THE ORDER that they are passed to the class
+        # constructor.
+        self.ingredient_kinds = {
+            'Ingredient': {
+                'field': 'field'
+            },
+            'Dimension': {
+                'field': 'field'
+            },
+            'LookupDimension': {
+                'field': 'field'
+            },
+            'IdValueDimension':
+                OrderedDict({
+                    'id_field': 'field',
+                    'field': 'field'
+                }),
+            'Metric': {
+                'field': 'aggregated_field'
+            },
+            'DivideMetric':
+                OrderedDict({
+                    'numerator_field': 'aggregated_field',
+                    'denominator_field': 'aggregated_field'
+                }),
+            'WtdAvgMetric':
+                OrderedDict({
+                    'field': 'field',
+                    'weight': 'field'
+                }),
+            # FIXME: what to do about these guys, field isn't the right
+            # SQLAlchemy structure
+            'Filter': {
+                'field': 'field'
+            },
+            'Having': {
+                'field': 'field'
+            },
+        }
+        self.register_schemas()
+
+    def _register_field_schemas(self):
+        default_field_schema = {
+            'value': {
+                'type': 'string',
+                'required': True,
+            },
+            '_aggregation': {
+                'default_setter': 'aggregation',
+                'nullable': True,
+                'readonly': True
+            },
+            'operators': {
+                'required': False,
+                'type': 'list',
+                'schema': {
+                    'schema': 'operator',
+                }
+            },
+            'aggregation': {
+                'type': 'string',
+                'required': False,
+                # Allowed values are the keys of IngredientValidator.aggregation_lookup
+                'allowed': self.allowed_aggregations,
+                'nullable': True,
+                'default': None,
+            },
+            'condition': {
+                'schema':
+                    'condition',
+                'contains_oneof':
+                    list(self.nonscalar_conditions + self.scalar_conditions),
+                'required':
+                    False,
+                'allow_unknown':
+                    False
+            }
+        }
+
+        # Aggregated fields coerce null values to the default aggregation
+        aggregated_field_schema = deepcopy(default_field_schema)
+        aggregated_field_schema['aggregation']['required'] = True
+        aggregated_field_schema['aggregation']['nullable'] = False
+        aggregated_field_schema['aggregation']['coerce'
+                                              ] = 'to_aggregation_with_default'
+
+        schema_registry.add('field', deepcopy(default_field_schema))
+        schema_registry.add('aggregated_field', aggregated_field_schema)
+
+    def _register_operator_schema(self):
+        operator_schema = {
+            'operator': {
+                'type': 'string',
+                'allowed': self.allowed_operators,
+                'required': True
+            },
+            'field': {
+                'schema': 'field',
+                'type': 'dict',
+                'coerce': 'to_field_dict',
+                'allow_unknown': False,
+                'required': True
+            },
+        }
+
+        schema_registry.add('operator', operator_schema)
+
+    def _register_condition_schema(self):
+        condition_schema = {
+            'field': {
+                'schema': 'field',
+                'type': 'dict',
+                'coerce': 'to_field_dict',
+                'allow_unknown': False,
+                'required': True
+            },
+            '_condition': {
+                'default_setter': 'condition',
+                'nullable': True,
+                'readonly': True
+            },
+        }
+
+        for nonscalar_cond in self.nonscalar_conditions:
+            condition_schema[nonscalar_cond] = {
+                'required': False,
+                'type': 'list',
+                'coerce': 'to_list'
+            }
+        for scalar_cond in self.scalar_conditions:
+            condition_schema[scalar_cond] = {
+                'required': False,
+                'type': 'scalar'
+            }
+
+        schema_registry.add('condition', condition_schema)
+
+    def _register_ingredient_schemas(self):
+        ingredient_schema_root = {
+            'kind': {
+                'type': 'string',
+                'required': True,
+                'allowed': self.ingredient_kinds.keys(),
+                'default': 'Metric'
+            },
+            '_fields': {
+                'nullable': True,
+                'readonly': True,
+                'type': 'list',
+                'default': [],
+            },
+            'format': {
+                'type': 'string',
+                'coerce': 'to_format_with_lookup'
+            }
+        }
+
+        for kind, extras in self.ingredient_kinds.items():
+            # Build a schema for each kind of ingredient
+            schema = deepcopy(ingredient_schema_root)
+            schema['_fields']['default'] = extras.keys()
+            for field_name, field_schema in extras.items():
+                schema[field_name] = {
+                    'schema': field_schema,
+                    'type': 'dict',
+                    'coerce': 'to_field_dict',
+                    'allow_unknown': False,
+                    'required': True
+                }
+            schema_registry.add(kind, schema)
+
+    def register_schemas(self):
+        self._register_field_schemas()
+        self._register_operator_schema()
+        self._register_condition_schema()
+        self._register_ingredient_schemas()

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -354,14 +354,9 @@ def ingredient_from_validated_dict(ingr_dict, table=''):
     tablename = table.__name__
     locals()[tablename] = table
 
-    print '%' * 100
-    print ingr_dict['kind']
     validator = IngredientValidator(schema=ingr_dict['kind'])
-    from pprint import pprint
-    pprint(validator.schema)
     assert validator.validate(ingr_dict)
     ingr_dict = validator.document
-    pprint(ingr_dict)
 
     kind = ingr_dict.pop('kind', 'Metric')
     IngredientClass = ingredient_class_for_name(kind)

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -327,16 +327,7 @@ def parse_validated_field(fld, table=''):
     for operator in fld.get('operators', []):
         op = operator['operator']
         other_field = parse_validated_field(operator['field'], table=table)
-        if op == '+':
-            field = field.__add__(other_field)
-        elif op == '-':
-            field = field.__sub__(other_field)
-        elif op == '*':
-            field = field.__mul__(other_field)
-        elif op == '/':
-            field = field._div__(other_field)
-        else:
-            raise BadIngredient('Unknown operator {}'.format(operator))
+        field = IngredientValidator.operator_lookup[op](field)(other_field)
 
     condition = fld.get('condition', None)
     if condition:

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -376,7 +376,6 @@ class IngredientValidator(Validator):
         return None
 
     def _normalize_default_setter_aggregation(self, document):
-        print '_normalize_default_setter_aggregation', document
         aggr = document.get('aggregation', None)
         try:
             return self.aggregation_lookup.get(aggr, None)

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -251,4 +251,29 @@ class IngredientValidator(Validator):
 
     def _normalize_default_setter_aggregation(self, document):
         aggr = document.get('aggregation', None)
-        return self.aggregation_lookup.get(aggr, None)
+        try:
+            return self.aggregation_lookup.get(aggr, None)
+        except TypeError:
+            # aggr is something we can't lookup (like a list)
+            return None
+
+    def test_aggregation_condition(self, subdocument=None):
+        """ Test that _aggregation and _condition have been added to a
+        normalized document and pop them out so that the rest of the document
+        can be checked against an expected value """
+        if subdocument is None:
+            # Start with the normalized document
+            subdocument = self.document
+        if isinstance(subdocument, dict):
+            for k in subdocument.keys():
+                if k == '_condition':
+                    assert callable(subdocument.get(k, None))
+                    subdocument.pop(k)
+                if k == '_aggregation':
+                    assert callable(subdocument.get(k, None))
+                    subdocument.pop(k)
+                if k in ('field', 'condition'):
+                    self.test_aggregation_condition(subdocument=subdocument[k])
+        if isinstance(subdocument, list):
+            for itm in subdocument:
+                self.test_aggregation_condition(subdocument=itm)

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -376,6 +376,7 @@ class IngredientValidator(Validator):
         return None
 
     def _normalize_default_setter_aggregation(self, document):
+        print '_normalize_default_setter_aggregation', document
         aggr = document.get('aggregation', None)
         try:
             return self.aggregation_lookup.get(aggr, None)

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -1,0 +1,204 @@
+import logging
+from datetime import date, datetime
+
+from cerberus import Validator, schema_registry
+from cerberus.platform import _int_types, _str_type
+from sqlalchemy import Float, Integer, String, case, distinct, func
+
+logging.captureWarnings(True)
+
+
+class IngredientValidator(Validator):
+
+    def __init__(self, *args, **kwargs):
+        super(IngredientValidator, self).__init__(*args, **kwargs)
+
+        self.format_lookup = {
+            'comma': ',.0f',
+            'dollar': '$,.0f',
+            'percent': '.0%',
+            'comma1': ',.1f',
+            'dollar1': '$,.1f',
+            'percent1': '.1%',
+            'comma2': ',.2f',
+            'dollar2': '$,.2f',
+            'percent2': '.2%',
+        }
+        self.aggregation_lookup = {
+            'sum': func.sum,
+            'min': func.min,
+            'max': func.max,
+            'avg': func.avg,
+            'count': func.count,
+            'count_distinct': lambda fld: func.count(distinct(fld)),
+            'month': lambda fld: func.date_trunc('month', fld),
+            'week': lambda fld: func.date_trunc('week', fld),
+            'year': lambda fld: func.date_trunc('year', fld),
+            'quarter': lambda fld: func.date_trunc('quarter', fld),
+            'age': lambda fld: func.date_part('year', func.age(fld)),
+            None: lambda fld: fld,
+        }
+        self.condition_lookup = {
+            'in': lambda fld: getattr(fld, 'in_'),
+            'gt': lambda fld: getattr(fld, '__gt__'),
+            'gte': lambda fld: getattr(fld, '__ge__'),
+            'lt': lambda fld: getattr(fld, '__lt__'),
+            'lte': lambda fld: getattr(fld, '__le__'),
+            'eq': lambda fld: getattr(fld, '__eq__'),
+            'ne': lambda fld: getattr(fld, '__ne__'),
+        }
+        self.default_aggregation = 'sum'
+
+    def _normalize_coerce_to_format(self, v):
+        return self.format_lookup.get(v, v)
+
+    def _normalize_coerce_to_field(self, v):
+        if isinstance(v, _str_type):
+            return {'field': v}
+        else:
+            return v
+
+    def _normalize_coerce_to_list(self, v):
+        if self._validate_type_scalar(v):
+            return [v]
+        else:
+            return v
+
+    def _normalize_default_setter_utcnow(self, document):
+        print document
+        return datetime.utcnow()
+
+    def _validate_type_scalar(self, value):
+        """ Is not a list or a dict """
+        if isinstance(
+            value, _int_types + (_str_type, float, date, datetime, bool)
+        ):
+            return True
+
+    def _validate_contains_oneof(self, keys, field, value):
+        """ Validates that exactly one of the keys exists in value """
+        results = [k for k in keys if k in value]
+
+        if len(results) == 0:
+            self._error(field, 'Must contain one of {}'.format(keys))
+        elif len(results) > 1:
+            self._error(field, 'Must contain only one of {}'.format(keys))
+
+
+ingredient_schema = {
+    'kind': {
+        'type': 'string',
+        'required': False,
+        'default': 'Metric'
+    },
+    'field': {
+        'schema': 'field',
+        'type': 'dict',
+        'coerce': 'to_field'
+    },
+    'format': {
+        'type': 'string',
+        'coerce': 'to_format'
+    },
+    'ts': {
+        'default_setter': 'utcnow'
+    }
+}
+
+field_schema = {
+    'value': {
+        'type': 'string',
+        'required': True,
+    },
+    'aggregation': {
+        'type': 'string',
+        'required': False,
+        'nullable': True,
+        'default': None,
+    },
+    'condition': {
+        'schema': 'condition',
+        'contains_oneof': ['in', 'gt'],
+        'required': False,
+        'default': None,
+        'allow_unknown': False
+    }
+}
+
+condition_schema = {
+    'condition': {
+        'type': 'string',
+        'required': False
+    },
+    'field': {
+        'schema': 'field',
+        'allow_unknown': False,
+        'required': True
+    },
+    'in': {
+        'required': False,
+        'type': 'list',
+        'coerce': 'to_list'
+    },
+    'gt': {
+        'required': False,
+        'type': 'scalar'
+    },
+    'gte': {
+        'required': False,
+        'type': 'scalar'
+    },
+    'lt': {
+        'required': False,
+        'type': 'scalar'
+    },
+    'lte': {
+        'required': False,
+        'type': 'scalar'
+    },
+    'eq': {
+        'required': False,
+        'type': 'scalar'
+    },
+    'ne': {
+        'required': False,
+        'type': 'scalar'
+    }
+}
+
+schema_registry.add('field', field_schema)
+schema_registry.add('condition', condition_schema)
+schema_registry.add('ingredient', ingredient_schema)
+
+if __name__ == '__main__':
+    v = IngredientValidator(ingredient_schema, allow_unknown=True)
+    testers = [
+        {
+            'kind': 'moo',
+            'format': 'comma'
+        },
+        {
+            'kind': 'moo',
+            'format': 'comma',
+            'icon': 'foo',
+            'field': {
+                'value': 'cow',
+                'condition': {
+                    'field': 'moo2',
+                    'in': 'wo',
+                    # 'gt': 2
+                }
+            }
+        }
+    ]
+
+    from pprint import pprint
+    for d in testers:
+        print('\n\nTESTING')
+        pprint(d)
+        if v.validate(d):
+            print "We're good! Normalized is..."
+            pprint(v.normalized(d))
+        else:
+            print 'Not good!'
+            print v.errors

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -53,6 +53,11 @@ default_field_schema = {
         'type': 'string',
         'required': True,
     },
+    '_aggregation': {
+        'default_setter': 'aggregation',
+        'nullable': True,
+        'readonly': True
+    },
     'aggregation': {
         'type':
             'string',
@@ -93,7 +98,6 @@ aggregated_field_schema = deepcopy(default_field_schema)
 aggregated_field_schema['aggregation']['required'] = True
 aggregated_field_schema['aggregation']['nullable'] = False
 aggregated_field_schema['aggregation']['coerce'] = 'to_aggregation_with_default'
-# del aggregated_field_schema['aggregation']['default']
 
 condition_schema = {
     'field': {
@@ -102,6 +106,11 @@ condition_schema = {
         'coerce': 'to_field_dict',
         'allow_unknown': False,
         'required': True
+    },
+    '_condition': {
+        'default_setter': 'condition',
+        'nullable': True,
+        'readonly': True
     },
     'in': {
         'required': False,
@@ -233,3 +242,13 @@ class IngredientValidator(Validator):
             self._error(field, 'Must contain only one of {}'.format(keys))
             return False
         return True
+
+    def _normalize_default_setter_condition(self, document):
+        for k in self.condition_lookup.keys():
+            if k in document:
+                return self.condition_lookup[k]
+        return None
+
+    def _normalize_default_setter_aggregation(self, document):
+        aggr = document.get('aggregation', None)
+        return self.aggregation_lookup.get(aggr, None)

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -161,53 +161,6 @@ class IngredientValidator(Validator):
             return False
         return True
 
-    def _normalize_default_setter_condition(self, document):
-        for k in self.condition_lookup.keys():
-            if k in document:
-                value = document[k]
-                cond = self.condition_lookup[k]
-                return lambda fld: getattr(fld, cond)(value)
-        return None
-
-    def _normalize_default_setter_condition(self, document):
-        for k in self.condition_lookup.keys():
-            if k in document:
-                value = document[k]
-                cond = self.condition_lookup[k]
-                return lambda fld: getattr(fld, cond)(value)
-        return None
-
-    def _normalize_default_setter_aggregation(self, document):
-        aggr = document.get('aggregation', None)
-        try:
-            return self.aggregation_lookup.get(aggr, None)
-        except TypeError:
-            # aggr is something we can't lookup (like a list)
-            return None
-
-    def test_aggregation_condition(self, subdocument=None):
-        """ Test that _aggregation and _condition have been added to a
-        normalized document and pop them out so that the rest of the document
-        can be checked against an expected value """
-        if subdocument is None:
-            # Start with the normalized document
-            subdocument = self.document
-        if isinstance(subdocument, dict):
-            for k in subdocument.keys():
-                if k == '_condition':
-                    assert callable(subdocument.get(k, None))
-                    subdocument.pop(k)
-                if k == '_fields':
-                    subdocument.pop(k)
-                if k == '_aggregation':
-                    assert callable(subdocument.get(k, None))
-                    subdocument.pop(k)
-                if k in ('field', 'condition', 'operators'):
-                    self.test_aggregation_condition(subdocument=subdocument[k])
-        if isinstance(subdocument, list):
-            for itm in subdocument:
-                self.test_aggregation_condition(subdocument=itm)
-
 
 RecipeSchemas(
     allowed_aggregations=IngredientValidator.aggregation_lookup.keys()

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -1,4 +1,12 @@
+"""
+Validators use cerberus to validate ingredients.yaml definitions
+and convert them to
+
+
+"""
+
 import logging
+from copy import deepcopy
 from datetime import date, datetime
 
 from cerberus import Validator, schema_registry
@@ -7,84 +15,6 @@ from sqlalchemy import Float, Integer, String, case, distinct, func
 
 logging.captureWarnings(True)
 
-
-class IngredientValidator(Validator):
-
-    def __init__(self, *args, **kwargs):
-        super(IngredientValidator, self).__init__(*args, **kwargs)
-
-        self.format_lookup = {
-            'comma': ',.0f',
-            'dollar': '$,.0f',
-            'percent': '.0%',
-            'comma1': ',.1f',
-            'dollar1': '$,.1f',
-            'percent1': '.1%',
-            'comma2': ',.2f',
-            'dollar2': '$,.2f',
-            'percent2': '.2%',
-        }
-        self.aggregation_lookup = {
-            'sum': func.sum,
-            'min': func.min,
-            'max': func.max,
-            'avg': func.avg,
-            'count': func.count,
-            'count_distinct': lambda fld: func.count(distinct(fld)),
-            'month': lambda fld: func.date_trunc('month', fld),
-            'week': lambda fld: func.date_trunc('week', fld),
-            'year': lambda fld: func.date_trunc('year', fld),
-            'quarter': lambda fld: func.date_trunc('quarter', fld),
-            'age': lambda fld: func.date_part('year', func.age(fld)),
-            None: lambda fld: fld,
-        }
-        self.condition_lookup = {
-            'in': lambda fld: getattr(fld, 'in_'),
-            'gt': lambda fld: getattr(fld, '__gt__'),
-            'gte': lambda fld: getattr(fld, '__ge__'),
-            'lt': lambda fld: getattr(fld, '__lt__'),
-            'lte': lambda fld: getattr(fld, '__le__'),
-            'eq': lambda fld: getattr(fld, '__eq__'),
-            'ne': lambda fld: getattr(fld, '__ne__'),
-        }
-        self.default_aggregation = 'sum'
-
-    def _normalize_coerce_to_format(self, v):
-        return self.format_lookup.get(v, v)
-
-    def _normalize_coerce_to_field(self, v):
-        if isinstance(v, _str_type):
-            return {'field': v}
-        else:
-            return v
-
-    def _normalize_coerce_to_list(self, v):
-        if self._validate_type_scalar(v):
-            return [v]
-        else:
-            return v
-
-    def _normalize_default_setter_utcnow(self, document):
-        print document
-        return datetime.utcnow()
-
-    def _validate_type_scalar(self, value):
-        """ Is not a list or a dict """
-        if isinstance(
-            value, _int_types + (_str_type, float, date, datetime, bool)
-        ):
-            return True
-
-    def _validate_contains_oneof(self, keys, field, value):
-        """ Validates that exactly one of the keys exists in value """
-        results = [k for k in keys if k in value]
-
-        if len(results) == 0:
-            self._error(field, 'Must contain one of {}'.format(keys))
-        elif len(results) > 1:
-            self._error(field, 'Must contain only one of {}'.format(keys))
-
-
 ingredient_schema = {
     'kind': {
         'type': 'string',
@@ -92,20 +22,21 @@ ingredient_schema = {
         'default': 'Metric'
     },
     'field': {
-        'schema': 'field',
+        'schema': 'aggregated_field',
         'type': 'dict',
-        'coerce': 'to_field'
+        'coerce': 'to_field',
+        # 'required': True
     },
     'format': {
         'type': 'string',
-        'coerce': 'to_format'
+        'coerce': 'to_format_with_lookup'
     },
-    'ts': {
-        'default_setter': 'utcnow'
-    }
+    # 'ts': {
+    #     'default_setter': 'utcnow'
+    # }
 }
 
-field_schema = {
+default_field_schema = {
     'value': {
         'type': 'string',
         'required': True,
@@ -118,12 +49,20 @@ field_schema = {
     },
     'condition': {
         'schema': 'condition',
-        'contains_oneof': ['in', 'gt'],
+        'contains_oneof': ['in', 'gt', 'gte', 'lt', 'lte', 'eq', 'ne'],
         'required': False,
         'default': None,
         'allow_unknown': False
     }
 }
+
+field_schema = deepcopy(default_field_schema)
+
+aggregated_field_schema = deepcopy(default_field_schema)
+aggregated_field_schema['aggregation']['required'] = True
+# aggregated_field_schema['aggregation']['nullable'] = False
+aggregated_field_schema['aggregation']['coerce'] = 'to_aggregation_with_default'
+# del aggregated_field_schema['aggregation']['default']
 
 condition_schema = {
     'condition': {
@@ -167,38 +106,128 @@ condition_schema = {
 }
 
 schema_registry.add('field', field_schema)
+schema_registry.add('aggregated_field', aggregated_field_schema)
 schema_registry.add('condition', condition_schema)
 schema_registry.add('ingredient', ingredient_schema)
 
-if __name__ == '__main__':
-    v = IngredientValidator(ingredient_schema, allow_unknown=True)
-    testers = [
-        {
-            'kind': 'moo',
-            'format': 'comma'
-        },
-        {
-            'kind': 'moo',
-            'format': 'comma',
-            'icon': 'foo',
-            'field': {
-                'value': 'cow',
-                'condition': {
-                    'field': 'moo2',
-                    'in': 'wo',
-                    # 'gt': 2
-                }
-            }
-        }
-    ]
 
-    from pprint import pprint
-    for d in testers:
-        print('\n\nTESTING')
-        pprint(d)
-        if v.validate(d):
-            print "We're good! Normalized is..."
-            pprint(v.normalized(d))
+class IngredientValidator(Validator):
+    format_lookup = {
+        'comma': ',.0f',
+        'dollar': '$,.0f',
+        'percent': '.0%',
+        'comma1': ',.1f',
+        'dollar1': '$,.1f',
+        'percent1': '.1%',
+        'comma2': ',.2f',
+        'dollar2': '$,.2f',
+        'percent2': '.2%',
+    }
+
+    aggregation_lookup = {
+        'sum': func.sum,
+        'min': func.min,
+        'max': func.max,
+        'avg': func.avg,
+        'count': func.count,
+        'count_distinct': lambda fld: func.count(distinct(fld)),
+        'month': lambda fld: func.date_trunc('month', fld),
+        'week': lambda fld: func.date_trunc('week', fld),
+        'year': lambda fld: func.date_trunc('year', fld),
+        'quarter': lambda fld: func.date_trunc('quarter', fld),
+        'age': lambda fld: func.date_part('year', func.age(fld)),
+        None: lambda fld: fld,
+    }
+
+    condition_lookup = {
+        'in': lambda fld: getattr(fld, 'in_'),
+        'gt': lambda fld: getattr(fld, '__gt__'),
+        'gte': lambda fld: getattr(fld, '__ge__'),
+        'lt': lambda fld: getattr(fld, '__lt__'),
+        'lte': lambda fld: getattr(fld, '__le__'),
+        'eq': lambda fld: getattr(fld, '__eq__'),
+        'ne': lambda fld: getattr(fld, '__ne__'),
+    }
+
+    default_aggregation = 'sum'
+
+    def __init__(self, *args, **kwargs):
+        kwargs['schema'] = ingredient_schema
+        kwargs['allow_unknown'] = True
+        super(IngredientValidator, self).__init__(*args, **kwargs)
+
+    def _normalize_coerce_to_format_with_lookup(self, v):
+        """ Replace a format with a default """
+        return self.format_lookup.get(v, v)
+
+    def _normalize_coerce_to_aggregation_with_default(self, v):
+        if v is None:
+            return self.default_aggregation
         else:
-            print 'Not good!'
-            print v.errors
+            return v
+
+    def _normalize_coerce_to_field(self, v):
+        if isinstance(v, _str_type):
+            return {'field': v}
+        else:
+            return v
+
+    def _normalize_coerce_to_list(self, v):
+        if self._validate_type_scalar(v):
+            return [v]
+        else:
+            return v
+
+    def _normalize_default_setter_utcnow(self, document):
+        return datetime.utcnow()
+
+    def _validate_type_scalar(self, value):
+        """ Is not a list or a dict """
+        if isinstance(
+            value, _int_types + (_str_type, float, date, datetime, bool)
+        ):
+            return True
+
+    def _validate_contains_oneof(self, keys, field, value):
+        """ Validates that exactly one of the keys exists in value """
+        results = [k for k in keys if k in value]
+
+        if len(results) == 0:
+            self._error(field, 'Must contain one of {}'.format(keys))
+        elif len(results) > 1:
+            self._error(field, 'Must contain only one of {}'.format(keys))
+
+
+v = IngredientValidator()
+# if __name__ == '__main__':
+#     v = IngredientValidator(ingredient_schema, allow_unknown=True)
+#     testers = [
+#         {
+#             'kind': 'moo',
+#             'format': 'comma'
+#         },
+#         {
+#             'kind': 'moo',
+#             'format': 'comma',
+#             'icon': 'foo',
+#             'field': {
+#                 'value': 'cow',
+#                 'condition': {
+#                     'field': 'moo2',
+#                     'in': 'wo',
+#                     # 'gt': 2
+#                 }
+#             }
+#         }
+#     ]
+
+#     from pprint import pprint
+#     for d in testers:
+#         print('\n\nTESTING')
+#         pprint(d)
+#         if v.validate(d):
+#             print "We're good! Normalized is..."
+#             pprint(v.normalized(d))
+#         else:
+#             print 'Not good!'
+#             print v.errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ SQLAlchemy==1.2.2
 sqlparse==0.2.2
 stevedore==1.27.1
 tablib==0.12.1
-Cerberus==1.1
+# Dependency on unreleased version of cerberus
+git+git://github.com/pyeve/cerberus.git#egg=Cerberus-1.1
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ SQLAlchemy==1.2.2
 sqlparse==0.2.2
 stevedore==1.27.1
 tablib==0.12.1
+Cerberus==1.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if sys.argv[-1] == 'test':
 
 # yapf: disable
 install = [
+    'Cerberus==1.1',
     'orderedset',
     'six',
     'sqlalchemy>=1.2.2',
@@ -64,6 +65,9 @@ setup(
     ],
     tests_require=['pytest', 'pytest-cov'],
     install_requires=install,
+    dependency_links=[
+        'git+git://github.com/pyeve/cerberus.git#egg=Cerberus-1.1',
+    ],
     entry_points={
         'recipe.oven.drivers': [
             'standard = recipe.oven.drivers.standard_oven:StandardOven',

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -833,8 +833,6 @@ ORDER BY census.state"""
 
         assert len(r.all()) == 2
         tennesseerow, vermontrow = r.all()[0], r.all()[1]
-        print(tennesseerow)
-        print(vermontrow)
         assert tennesseerow.state == 'Tennessee'
         assert tennesseerow.state_id == 'Tennessee'
         assert tennesseerow.abbreviation == 'TN'

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -242,6 +242,126 @@ age:
         assert len(self.shelf) == 0
 
 
+class TestShelfFromValidatedYaml(object):
+
+    def setup(self):
+        self.shelf = Shelf.from_validated_yaml(
+            """
+first:
+    kind: Dimension
+    field: first
+last:
+    kind: Dimension
+    field: last
+age:
+    kind: Metric
+    field: age
+""", MyTable
+        )
+        self.shelf.Meta.anonymize = False
+
+    def test_find(self):
+        """ Find ingredients on the shelf """
+        ingredient = self.shelf.find('first', Dimension)
+        assert ingredient.id == 'first'
+
+        # Raise if the wrong type
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('first', Metric)
+
+        # Raise if key not present in shelf
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        # Raise if key is not an ingredient or string
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find(2.0, Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find(2.0, Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        self.shelf['foo'] = Dimension(MyTable.last)
+        ingredient = self.shelf.find('last', Dimension)
+        assert ingredient.id == 'last'
+
+    def test_repr(self):
+        """ Find ingredients on the shelf """
+        assert self.shelf.__repr__() == """(Dimension)first MyTable.first
+(Dimension)last MyTable.last
+(Metric)age sum(foo.age)"""
+
+    def test_update(self):
+        """ Shelves can be updated with other shelves """
+        new_shelf = Shelf({
+            'squee': Dimension(MyTable.first),
+        })
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+
+    def test_update_key_value(self):
+        """ Shelves can be built with key_values and updated """
+        new_shelf = Shelf(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 3
+        self.shelf.update(new_shelf)
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
+    def test_update_key_value_direct(self):
+        """ Shelves can be updated directly with key_value"""
+        assert len(self.shelf) == 3
+        self.shelf.update(squee=Dimension(MyTable.first))
+        assert len(self.shelf) == 4
+        assert isinstance(self.shelf.get('squee'), Dimension)
+
+    def test_brew(self):
+        recipe_parts = self.shelf.brew_query_parts()
+        assert len(recipe_parts['columns']) == 3
+        assert len(recipe_parts['group_bys']) == 2
+        assert len(recipe_parts['filters']) == 0
+        assert len(recipe_parts['havings']) == 0
+
+    def test_anonymize(self):
+        """ We can save and store anonymization context """
+        assert self.shelf.Meta.anonymize is False
+        self.shelf.Meta.anonymize = True
+        assert self.shelf.Meta.anonymize is True
+
+    def test_get(self):
+        """ Find ingredients on the shelf """
+        ingredient = self.shelf.first
+        assert ingredient.id == 'first'
+
+        ingredient = self.shelf.get('first', None)
+        assert ingredient.id == 'first'
+
+        ingredient = self.shelf.get('primo', None)
+        assert ingredient is None
+
+    def test_add_to_shelf(self):
+        """ We can add an ingredient to a shelf """
+        with pytest.raises(BadRecipe):
+            ingredient = self.shelf.find('foo', Dimension)
+
+        self.shelf['foo'] = Dimension(MyTable.last)
+        ingredient = self.shelf.find('last', Dimension)
+        assert ingredient.id == 'last'
+
+    def test_clear(self):
+        assert len(self.shelf) == 3
+        self.shelf.clear()
+        assert len(self.shelf) == 0
+
+
 class TestAutomaticShelf(object):
 
     def setup(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from sqlalchemy import func
+from tests.test_base import MyTable
+
+from recipe.utils import AttrDict, disaggregate, replace_whitespace_with_space
+
+
+class TestValidators(object):
+
+    def test_good(self):
+        testers = [
+            {
+                'kind': 'moo',
+                # 'field': 'moo',
+                'format': 'comma'
+            },
+            {
+                'kind': 'moo',
+                'format': 'comma',
+                'icon': 'foo',
+                'field': {
+                    'value': 'cow',
+                    'condition': {
+                        'field': 'moo2',
+                        'in': 'wo',
+                        # 'gt': 2
+                    }
+                }
+            }
+        ]
+        from recipe.validators import v
+        for d in testers:
+            assert v.validate(d)
+
+    def test_ingredient(self):
+        # kind is required
+        from recipe.validators import IngredientValidator
+        v = IngredientValidator()
+        assert v.validate({})
+        # assert v.normalized({'field': 'foo'}) == {
+        #     'kind': 'Metric',
+        #     'field': 'foo'
+        # }

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -40,12 +40,54 @@ class TestValidateIngredient(object):
                 'format': 'comma'
             }, {
                 'field': {
-                    'aggregation': None,
-                    'value': 'moo',
-                    '+': {
-                        'aggregation': None,
-                        'value': 'foo',
-                    }
+                    'aggregation':
+                        None,
+                    'value':
+                        'moo',
+                    'operators': [{
+                        'operator': '+',
+                        'field': {
+                            'aggregation': None,
+                            'value': 'foo',
+                        }
+                    }]
+                },
+                'kind': 'Metric',
+                'format': ',.0f'
+            }),
+            ({
+                'kind': 'Metric',
+                'field': 'moo+foo-coo+cow',
+                'format': 'comma'
+            }, {
+                'field': {
+                    'aggregation':
+                        None,
+                    'value':
+                        'moo',
+                    'operators': [
+                        {
+                            'operator': '+',
+                            'field': {
+                                'aggregation': None,
+                                'value': 'foo',
+                            }
+                        },
+                        {
+                            'operator': '-',
+                            'field': {
+                                'aggregation': None,
+                                'value': 'coo',
+                            }
+                        },
+                        {
+                            'operator': '+',
+                            'field': {
+                                'aggregation': None,
+                                'value': 'cow',
+                            }
+                        },
+                    ]
                 },
                 'kind': 'Metric',
                 'format': ',.0f'
@@ -160,7 +202,6 @@ class TestValidateIngredient(object):
                 },
                 'format': 'cow'
             }),
-            # FIXME: Why is this not 'field': {'value': 'grass'}
             ({
                 'format': 'cow',
                 'field': 'grass'
@@ -242,10 +283,12 @@ class TestValidateIngredient(object):
             ({
                 'field': 2.1
             }, "{'field': ['must be of dict type']}"),
-            # TODO: Why don't these fail validation
-            # ({'field': tuple()}, "{'field': ['must be of dict type']}"),
-            # ({'field': []}, "{'field': ['must be of dict type']}"),
-            # ({'field': ['comma']}, "{'field': ['must be of dict type']}"),
+            ({
+                'field': tuple()
+            }, "{'field': ['must be of dict type']}"),
+            ({
+                'field': []
+            }, "{'field': ['must be of dict type']}"),
         ]
         for document, errors in bad_values:
             assert not self.validator.validate(document)
@@ -525,6 +568,12 @@ class TestValidateCondition(object):
         for document, expected in good_values:
             assert self.validator.validate(document)
             self.validator.test_aggregation_condition()
+            print 'doc'
+            print self.validator.document
+            print
+            print 'expected'
+            print expected
+
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors they make

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -64,14 +64,7 @@ class TestValidateIngredient(object):
         ]
         for document, expected in testers:
             assert self.validator.validate(document)
-            if 'condition' in self.validator.document['field']:
-                assert callable(
-                    self.validator.document['field']['condition'].get(
-                        '_condition', None
-                    )
-                )
-                self.validator.document['field']['condition'].pop('_condition')
-
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
     def test_ingredient_kind(self):
@@ -97,6 +90,7 @@ class TestValidateIngredient(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -165,6 +159,7 @@ class TestValidateIngredient(object):
         ]
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # We can add new format_lookups
@@ -184,6 +179,7 @@ class TestValidateIngredient(object):
         ]
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -219,6 +215,7 @@ class TestValidateIngredient(object):
         IngredientValidator.format_lookup['cow'] = '.0f "moos"'
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -266,6 +263,7 @@ class TestValidateField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -334,6 +332,7 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         for k in IngredientValidator.aggregation_lookup.keys():
@@ -391,6 +390,7 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -404,7 +404,11 @@ class TestValidateAggregatedField(object):
             }, "{'aggregation': ['unallowed value cow']}"),
             ({
                 'value': 'foo',
-                'aggregation': ['cow']
+                'aggregation': 2
+            }, "{'aggregation': ['must be of string type']}"),
+            ({
+                'value': 'foo',
+                'aggregation': ['sum']
             }, "{'aggregation': ['must be of string type']}"),
         ]
         for document, errors in bad_values:
@@ -437,10 +441,7 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            assert callable(
-                self.validator.document['condition'].get('_condition', None)
-            )
-            self.validator.document['condition'].pop('_condition')
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -507,8 +508,7 @@ class TestValidateCondition(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            assert callable(self.validator.document.get('_condition', None))
-            self.validator.document.pop('_condition')
+            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors they make

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -34,23 +34,22 @@ class TestValidateIngredient(object):
                 'kind': 'Metric',
                 'format': ',.0f'
             }),
-            (
-                {
-                    'kind': 'Metric',
-                    'field': 'moo',
-                    # '+': 'foo',
-                    'format': 'comma'
-                },
-                {
-                    'field': {
+            ({
+                'kind': 'Metric',
+                'field': 'moo+foo',
+                'format': 'comma'
+            }, {
+                'field': {
+                    'aggregation': None,
+                    'value': 'moo',
+                    '+': {
                         'aggregation': None,
-                        'value': 'moo',
-                        # '+': 'foo'
-                    },
-                    'kind': 'Metric',
-                    'format': ',.0f'
-                }
-            ),
+                        'value': 'foo',
+                    }
+                },
+                'kind': 'Metric',
+                'format': ',.0f'
+            }),
             ({
                 'kind': 'Metric',
                 'format': 'comma',

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from cerberus import Validator
+from cerberus.tests import assert_normalized, assert_success
 from sqlalchemy import func
 from tests.test_base import MyTable
 
 from recipe.utils import AttrDict, disaggregate, replace_whitespace_with_space
 from recipe.validators import (
-    IngredientValidator, aggregated_field_schema, default_field_schema
+    IngredientValidator, aggregated_field_schema, condition_schema,
+    default_field_schema
 )
 
 
@@ -39,31 +41,43 @@ class TestValidateIngredient(object):
             }
         ]
         for d in testers:
-            if not self.validator.validate(d):
-                assert False
             assert self.validator.validate(d)
 
     def test_ingredient_kind(self):
         # Dicts to validate and the results
-        good_values = [({}, {
-            'kind': 'Metric'
-        }), ({
-            'kind': 'Ingredient'
+        good_values = [({
+            'field': 'moo'
         }, {
-            'kind': 'Ingredient'
+            'kind': 'Metric',
+            'field': {
+                'value': 'moo',
+                'aggregation': None
+            }
+        }), ({
+            'kind': 'Ingredient',
+            'field': 'moo',
+        }, {
+            'kind': 'Ingredient',
+            'field': {
+                'value': 'moo',
+                'aggregation': None
+            }
         })]
 
         for d, result in good_values:
-            assert self.validator.validate(d)
-            self.validator.normalized(d) == result
+            assert_success(d, validator=self.validator)
+            # assert self.validator.validate(d)
+            # self.validator.normalized(d) == result
 
         # Dicts that fail to validate and the errors
         bad_values = [
             ({
-                'kind': 'asa'
+                'kind': 'asa',
+                'field': 'moo'
             }, "{'kind': ['unallowed value asa']}"),
             ({
-                'kind': 'Sque'
+                'kind': 'Sque',
+                'field': 'moo'
             }, "{'kind': ['unallowed value Sque']}"),
         ]
         for d, result in bad_values:
@@ -74,58 +88,92 @@ class TestValidateIngredient(object):
         # Dicts to validate and the results
         good_values = [
             ({
-                'format': 'comma'
+                'format': 'comma',
+                'field': 'moo',
             }, {
                 'kind': 'Metric',
-                'format': ',.0f'
+                'format': ',.0f',
+                'field': {
+                    'value': 'moo',
+                    'aggregation': None
+                }
             }),
             ({
-                'format': ',.0f'
+                'format': ',.0f',
+                'field': 'moo'
             }, {
                 'kind': 'Metric',
-                'format': ',.0f'
+                'format': ',.0f',
+                'field': {
+                    'value': 'moo',
+                    'aggregation': None
+                }
             }),
             ({
-                'format': 'cow'
+                'format': 'cow',
+                'field': 'moo'
             }, {
                 'kind': 'Metric',
+                'field': {
+                    'value': 'moo',
+                    'aggregation': None
+                },
                 'format': 'cow'
+            }),
+            # FIXME: Why is this not 'field': {'value': 'grass'}
+            ({
+                'format': 'cow',
+                'field': 'grass'
+            }, {
+                'kind': 'Metric',
+                'format': 'cow',
+                'field': {
+                    'value': 'grass',
+                    'aggregation': None
+                }
             }),
         ]
-        IngredientValidator.format_lookup['cow'] = '.0f "moos"'
-        for d, result in good_values:
-            assert self.validator.validate(d)
-            self.validator.normalized(d) == result
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
 
         # We can add new format_lookups
         IngredientValidator.format_lookup['cow'] = '.0f "moos"'
         good_values = [
             ({
-                'format': 'cow'
+                'format': 'cow',
+                'field': 'grass',
             }, {
                 'kind': 'Metric',
+                'field': {
+                    'value': 'grass',
+                    'aggregation': None
+                },
                 'format': '.0f "moos"'
             }),
         ]
-        for d, result in good_values:
-            assert self.validator.validate(d)
-            self.validator.normalized(d) == result
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            self.validator.document == expected
 
         # Dicts that fail to validate and the errors
         bad_values = [
             ({
-                'format': 2
+                'format': 2,
+                'field': 'moo',
             }, "{'format': ['must be of string type']}"),
             ({
-                'format': []
+                'format': [],
+                'field': 'moo',
             }, "{'format': ['must be of string type']}"),
             ({
-                'format': ['comma']
+                'format': ['comma'],
+                'field': 'moo',
             }, "{'format': ['must be of string type']}"),
         ]
-        for d, result in bad_values:
-            assert self.validator.validate(d) == False
-            assert str(self.validator.errors) == result
+        for document, errors in bad_values:
+            assert not self.validator.validate(document)
+            assert str(self.validator.errors) == errors
 
     def test_ingredient_field(self):
         # Dicts to validate and the results
@@ -134,13 +182,14 @@ class TestValidateIngredient(object):
         }, {
             'kind': 'Metric',
             'field': {
-                'value': 'moo'
+                'value': 'moo',
+                'aggregation': None
             }
         })]
         IngredientValidator.format_lookup['cow'] = '.0f "moos"'
-        for d, result in good_values:
-            assert self.validator.validate(d)
-            self.validator.normalized(d) == result
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
         bad_values = [
@@ -155,9 +204,9 @@ class TestValidateIngredient(object):
             # ({'field': []}, "{'field': ['must be of dict type']}"),
             # ({'field': ['comma']}, "{'field': ['must be of dict type']}"),
         ]
-        for d, result in bad_values:
-            assert self.validator.validate(d) == False
-            assert str(self.validator.errors) == result
+        for document, errors in bad_values:
+            assert not self.validator.validate(document)
+            assert str(self.validator.errors) == errors
 
 
 class TestValidateField(object):
@@ -173,20 +222,228 @@ class TestValidateField(object):
             ({
                 'value': 'foo'
             }, {
-                'value': 'foo'
+                'value': 'foo',
+                'aggregation': None,
+            }),
+            ({
+                'value': 'foo',
+                'aggregation': 'sum'
+            }, {
+                'value': 'foo',
+                'aggregation': 'sum'
             }),
         ]
 
-        for d, result in good_values:
-            assert self.validator.validate(d)
-            self.validator.normalized(d) == result
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
         bad_values = [
             ({
                 'kind': 'asa'
-            }, " {'kind': ['unknown field'], 'value': ['required field']}"),
+            }, "{'kind': ['unknown field'], 'value': ['required field']}"),
+            ({
+                'value': 'foo',
+                'aggregation': 'cow'
+            }, "{'aggregation': ['unallowed value cow']}"),
         ]
-        for d, result in bad_values:
-            assert self.validator.validate(d) == False
-            assert str(self.validator.errors) == result
+        for document, errors in bad_values:
+            assert not self.validator.validate(document)
+            assert str(self.validator.errors) == errors
+
+
+class TestValidateAggregatedField(object):
+
+    def setup(self):
+        self.validator = IngredientValidator(
+            schema=aggregated_field_schema, allow_unknown=False
+        )
+
+    def test_field_value(self):
+        # Dicts to validate and the results
+        good_values = [
+            # Aggregation gets injected
+            ({
+                'value': 'moo'
+            }, {
+                'value': 'moo',
+                'aggregation': 'sum'
+            }),
+            # None gets overridden with default_aggregation
+            ({
+                'value': 'qoo',
+                'aggregation': None
+            }, {
+                'value': 'qoo',
+                'aggregation': 'sum'
+            }),
+            ({
+                'value': 'foo',
+                'aggregation': 'none'
+            }, {
+                'value': 'foo',
+                'aggregation': 'none'
+            }),
+            # Other aggregations are untouched
+            ({
+                'value': 'foo',
+                'aggregation': 'sum'
+            }, {
+                'value': 'foo',
+                'aggregation': 'sum'
+            }),
+            ({
+                'value': 'foo',
+                'aggregation': 'count'
+            }, {
+                'value': 'foo',
+                'aggregation': 'count'
+            }),
+        ]
+
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
+
+        # We can change the default aggregation
+        IngredientValidator.default_aggregation = 'count'
+        good_values = [
+            # Aggregation gets injected
+            ({
+                'value': 'moo'
+            }, {
+                'value': 'moo',
+                'aggregation': 'count'
+            }),
+            # None gets overridden with default_aggregation
+            ({
+                'value': 'qoo',
+                'aggregation': None
+            }, {
+                'value': 'qoo',
+                'aggregation': 'count'
+            }),
+            # Other aggregations are untouched
+            ({
+                'value': 'foo',
+                'aggregation': 'none'
+            }, {
+                'value': 'foo',
+                'aggregation': 'none'
+            }),
+            ({
+                'value': 'foo',
+                'aggregation': 'sum'
+            }, {
+                'value': 'foo',
+                'aggregation': 'sum'
+            }),
+            ({
+                'value': 'foo',
+                'aggregation': 'count'
+            }, {
+                'value': 'foo',
+                'aggregation': 'count'
+            }),
+        ]
+
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
+
+        # Dicts that fail to validate and the errors
+        bad_values = [
+            ({
+                'kind': 'asa'
+            }, "{'kind': ['unknown field'], 'value': ['required field']}"),
+            ({
+                'value': 'foo',
+                'aggregation': 'cow'
+            }, "{'aggregation': ['unallowed value cow']}"),
+            ({
+                'value': 'foo',
+                'aggregation': ['cow']
+            }, "{'aggregation': ['must be of string type']}"),
+        ]
+        for document, errors in bad_values:
+            assert not self.validator.validate(document)
+            assert str(self.validator.errors) == errors
+
+    def test_field_condition(self):
+        # Dicts to validate and the results
+        good_values = [
+            # Aggregation gets injected
+            ({
+                'value': 'moo',
+                'aggregation': 'sum',
+                'condition': {
+                    'field': 'cow',
+                    'in': ['1', '2']
+                }
+            }, {
+                'value': 'moo',
+                'aggregation': 'sum',
+                'condition': {
+                    'field': {
+                        'aggregation': None,
+                        'value': 'cow'
+                    },
+                    'in': ['1', '2']
+                }
+            }),
+        ]
+
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
+
+
+class TestValidateCondition(object):
+
+    def setup(self):
+        self.validator = IngredientValidator(
+            schema=condition_schema, allow_unknown=False
+        )
+
+    def test_condition(self):
+        # Dicts to validate and the results
+        good_values = [
+            ({
+                'field': 'foo',
+                'in': ['1', '2']
+            }, {
+                'field': {
+                    'aggregation': None,
+                    'value': 'foo'
+                },
+                'in': ['1', '2']
+            }),
+            # Scalars get turned into lists where appropriate
+            ({
+                'field': 'foo',
+                'in': '1'
+            }, {
+                'field': {
+                    'aggregation': None,
+                    'value': 'foo'
+                },
+                'in': ['1']
+            }),
+        ]
+
+        for document, expected in good_values:
+            assert self.validator.validate(document)
+            assert self.validator.document == expected
+
+        # Dicts that fail to validate and the errors they make
+        bad_values = [
+            ({
+                'field': 'foo',
+                'kind': 'asa'
+            }, "{'kind': ['unknown field']}"),
+            ({}, "{'field': ['required field']}"),
+        ]
+        for document, errors in bad_values:
+            assert not self.validator.validate(document)
+            assert str(self.validator.errors) == errors

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -23,6 +23,7 @@ class TestValidateIngredient(object):
                     'value': 'moo'
                 },
                 'kind': 'Metric',
+                '_fields': ['field'],
                 'format': ',.0f'
             }),
             ({
@@ -44,6 +45,7 @@ class TestValidateIngredient(object):
                     }]
                 },
                 'kind': 'Metric',
+                '_fields': ['field'],
                 'format': ',.0f'
             }),
             ({
@@ -80,6 +82,7 @@ class TestValidateIngredient(object):
                         },
                     ]
                 },
+                '_fields': ['field'],
                 'kind': 'Metric',
                 'format': ',.0f'
             }),
@@ -106,6 +109,7 @@ class TestValidateIngredient(object):
                     'value': 'cow',
                     'aggregation': 'sum'
                 },
+                '_fields': ['field'],
                 'kind': 'Metric',
                 'format': ',.0f',
                 'icon': 'foo'
@@ -116,7 +120,6 @@ class TestValidateIngredient(object):
                 schema=document.get('kind', 'Metric')
             )
             assert validator.validate(document)
-            validator.test_aggregation_condition()
             assert validator.document == expected
 
     def test_ingredient_kind(self):
@@ -125,6 +128,7 @@ class TestValidateIngredient(object):
             'field': 'moo'
         }, {
             'kind': 'Metric',
+            '_fields': ['field'],
             'field': {
                 'value': 'moo',
                 'aggregation': None
@@ -134,6 +138,7 @@ class TestValidateIngredient(object):
             'field': 'moo',
         }, {
             'kind': 'Ingredient',
+            '_fields': ['field'],
             'field': {
                 'value': 'moo',
                 'aggregation': None
@@ -142,7 +147,6 @@ class TestValidateIngredient(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -169,6 +173,7 @@ class TestValidateIngredient(object):
             }, {
                 'kind': 'Metric',
                 'format': ',.0f',
+                '_fields': ['field'],
                 'field': {
                     'value': 'moo',
                     'aggregation': None
@@ -180,6 +185,7 @@ class TestValidateIngredient(object):
             }, {
                 'kind': 'Metric',
                 'format': ',.0f',
+                '_fields': ['field'],
                 'field': {
                     'value': 'moo',
                     'aggregation': None
@@ -190,6 +196,7 @@ class TestValidateIngredient(object):
                 'field': 'moo'
             }, {
                 'kind': 'Metric',
+                '_fields': ['field'],
                 'field': {
                     'value': 'moo',
                     'aggregation': None
@@ -201,6 +208,7 @@ class TestValidateIngredient(object):
                 'field': 'grass'
             }, {
                 'kind': 'Metric',
+                '_fields': ['field'],
                 'format': 'cow',
                 'field': {
                     'value': 'grass',
@@ -210,7 +218,6 @@ class TestValidateIngredient(object):
         ]
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # We can add new format_lookups
@@ -230,7 +237,6 @@ class TestValidateIngredient(object):
         ]
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -258,6 +264,7 @@ class TestValidateIngredient(object):
             'field': 'moo'
         }, {
             'kind': 'Metric',
+            '_fields': ['field'],
             'field': {
                 'value': 'moo',
                 'aggregation': None
@@ -266,7 +273,6 @@ class TestValidateIngredient(object):
         IngredientValidator.format_lookup['cow'] = '.0f "moos"'
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -316,7 +322,6 @@ class TestValidateField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -385,7 +390,6 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         for k in IngredientValidator.aggregation_lookup.keys():
@@ -443,7 +447,6 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -494,7 +497,6 @@ class TestValidateAggregatedField(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors
@@ -561,7 +563,6 @@ class TestValidateCondition(object):
 
         for document, expected in good_values:
             assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors they make

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,23 +1,14 @@
 # -*- coding: utf-8 -*-
-from cerberus import Validator
-from cerberus.tests import assert_normalized, assert_success
 from sqlalchemy import func
-from tests.test_base import MyTable
 
 from recipe.utils import AttrDict, disaggregate, replace_whitespace_with_space
-from recipe.validators import (
-    IngredientValidator, aggregated_field_schema, condition_schema,
-    default_field_schema
-)
+from recipe.validators import IngredientValidator
 
 
 class TestValidateIngredient(object):
 
     def setup(self):
         self.validator = IngredientValidator(schema='Ingredient')
-        self.field_validator = Validator(
-            schema=default_field_schema, allow_unknown=False
-        )
 
     def test_ingredients(self):
         """ Test full ingredients """

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,21 +1,31 @@
 # -*- coding: utf-8 -*-
+from cerberus import Validator
 from sqlalchemy import func
 from tests.test_base import MyTable
 
 from recipe.utils import AttrDict, disaggregate, replace_whitespace_with_space
+from recipe.validators import (
+    IngredientValidator, aggregated_field_schema, default_field_schema
+)
 
 
-class TestValidators(object):
+class TestValidateIngredient(object):
+
+    def setup(self):
+        self.validator = IngredientValidator()
+        self.field_validator = Validator(
+            schema=default_field_schema, allow_unknown=False
+        )
 
     def test_good(self):
         testers = [
             {
-                'kind': 'moo',
-                # 'field': 'moo',
+                'kind': 'Metric',
+                'field': 'moo',
                 'format': 'comma'
             },
             {
-                'kind': 'moo',
+                'kind': 'Metric',
                 'format': 'comma',
                 'icon': 'foo',
                 'field': {
@@ -28,16 +38,155 @@ class TestValidators(object):
                 }
             }
         ]
-        from recipe.validators import v
         for d in testers:
-            assert v.validate(d)
+            if not self.validator.validate(d):
+                assert False
+            assert self.validator.validate(d)
 
-    def test_ingredient(self):
-        # kind is required
-        from recipe.validators import IngredientValidator
-        v = IngredientValidator()
-        assert v.validate({})
-        # assert v.normalized({'field': 'foo'}) == {
-        #     'kind': 'Metric',
-        #     'field': 'foo'
-        # }
+    def test_ingredient_kind(self):
+        # Dicts to validate and the results
+        good_values = [({}, {
+            'kind': 'Metric'
+        }), ({
+            'kind': 'Ingredient'
+        }, {
+            'kind': 'Ingredient'
+        })]
+
+        for d, result in good_values:
+            assert self.validator.validate(d)
+            self.validator.normalized(d) == result
+
+        # Dicts that fail to validate and the errors
+        bad_values = [
+            ({
+                'kind': 'asa'
+            }, "{'kind': ['unallowed value asa']}"),
+            ({
+                'kind': 'Sque'
+            }, "{'kind': ['unallowed value Sque']}"),
+        ]
+        for d, result in bad_values:
+            assert self.validator.validate(d) == False
+            assert str(self.validator.errors) == result
+
+    def test_ingredient_format(self):
+        # Dicts to validate and the results
+        good_values = [
+            ({
+                'format': 'comma'
+            }, {
+                'kind': 'Metric',
+                'format': ',.0f'
+            }),
+            ({
+                'format': ',.0f'
+            }, {
+                'kind': 'Metric',
+                'format': ',.0f'
+            }),
+            ({
+                'format': 'cow'
+            }, {
+                'kind': 'Metric',
+                'format': 'cow'
+            }),
+        ]
+        IngredientValidator.format_lookup['cow'] = '.0f "moos"'
+        for d, result in good_values:
+            assert self.validator.validate(d)
+            self.validator.normalized(d) == result
+
+        # We can add new format_lookups
+        IngredientValidator.format_lookup['cow'] = '.0f "moos"'
+        good_values = [
+            ({
+                'format': 'cow'
+            }, {
+                'kind': 'Metric',
+                'format': '.0f "moos"'
+            }),
+        ]
+        for d, result in good_values:
+            assert self.validator.validate(d)
+            self.validator.normalized(d) == result
+
+        # Dicts that fail to validate and the errors
+        bad_values = [
+            ({
+                'format': 2
+            }, "{'format': ['must be of string type']}"),
+            ({
+                'format': []
+            }, "{'format': ['must be of string type']}"),
+            ({
+                'format': ['comma']
+            }, "{'format': ['must be of string type']}"),
+        ]
+        for d, result in bad_values:
+            assert self.validator.validate(d) == False
+            assert str(self.validator.errors) == result
+
+    def test_ingredient_field(self):
+        # Dicts to validate and the results
+        good_values = [({
+            'field': 'moo'
+        }, {
+            'kind': 'Metric',
+            'field': {
+                'value': 'moo'
+            }
+        })]
+        IngredientValidator.format_lookup['cow'] = '.0f "moos"'
+        for d, result in good_values:
+            assert self.validator.validate(d)
+            self.validator.normalized(d) == result
+
+        # Dicts that fail to validate and the errors
+        bad_values = [
+            ({
+                'field': 2
+            }, "{'field': ['must be of dict type']}"),
+            ({
+                'field': 2.1
+            }, "{'field': ['must be of dict type']}"),
+            # TODO: Why don't these fail validation
+            # ({'field': tuple()}, "{'field': ['must be of dict type']}"),
+            # ({'field': []}, "{'field': ['must be of dict type']}"),
+            # ({'field': ['comma']}, "{'field': ['must be of dict type']}"),
+        ]
+        for d, result in bad_values:
+            assert self.validator.validate(d) == False
+            assert str(self.validator.errors) == result
+
+
+class TestValidateField(object):
+
+    def setup(self):
+        self.validator = IngredientValidator(
+            schema=default_field_schema, allow_unknown=False
+        )
+
+    def test_field_value(self):
+        # Dicts to validate and the results
+        good_values = [
+            ({
+                'value': 'foo'
+            }, {
+                'value': 'foo'
+            }),
+        ]
+
+        for d, result in good_values:
+            assert self.validator.validate(d)
+            self.validator.normalized(d) == result
+
+        # Dicts that fail to validate and the errors
+        bad_values = [
+            ({
+                'kind': 'asa'
+            }, " {'kind': ['unknown field'], 'value': ['required field']}"),
+        ]
+        for d, result in bad_values:
+            assert self.validator.validate(d) == False
+            assert str(self.validator.errors) == result

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -14,7 +14,7 @@ from recipe.validators import (
 class TestValidateIngredient(object):
 
     def setup(self):
-        self.validator = IngredientValidator()
+        self.validator = IngredientValidator(schema='Ingredient')
         self.field_validator = Validator(
             schema=default_field_schema, allow_unknown=False
         )
@@ -34,6 +34,23 @@ class TestValidateIngredient(object):
                 'kind': 'Metric',
                 'format': ',.0f'
             }),
+            (
+                {
+                    'kind': 'Metric',
+                    'field': 'moo',
+                    # '+': 'foo',
+                    'format': 'comma'
+                },
+                {
+                    'field': {
+                        'aggregation': None,
+                        'value': 'moo',
+                        # '+': 'foo'
+                    },
+                    'kind': 'Metric',
+                    'format': ',.0f'
+                }
+            ),
             ({
                 'kind': 'Metric',
                 'format': 'comma',
@@ -240,7 +257,7 @@ class TestValidateField(object):
 
     def setup(self):
         self.validator = IngredientValidator(
-            schema=default_field_schema, allow_unknown=False
+            schema='field', allow_unknown=False
         )
 
     def test_field_value(self):
@@ -285,7 +302,7 @@ class TestValidateAggregatedField(object):
 
     def setup(self):
         self.validator = IngredientValidator(
-            schema=aggregated_field_schema, allow_unknown=False
+            schema='aggregated_field', allow_unknown=False
         )
 
     def test_field_value(self):
@@ -477,7 +494,7 @@ class TestValidateCondition(object):
 
     def setup(self):
         self.validator = IngredientValidator(
-            schema=condition_schema, allow_unknown=False
+            schema='condition', allow_unknown=False
         )
 
     def test_condition(self):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -28,7 +28,7 @@ class TestValidateIngredient(object):
                 'format': 'comma'
             }, {
                 'field': {
-                    'aggregation': None,
+                    'aggregation': 'sum',
                     'value': 'moo'
                 },
                 'kind': 'Metric',
@@ -41,7 +41,7 @@ class TestValidateIngredient(object):
             }, {
                 'field': {
                     'aggregation':
-                        None,
+                        'sum',
                     'value':
                         'moo',
                     'operators': [{
@@ -62,7 +62,7 @@ class TestValidateIngredient(object):
             }, {
                 'field': {
                     'aggregation':
-                        None,
+                        'sum',
                     'value':
                         'moo',
                     'operators': [
@@ -113,7 +113,7 @@ class TestValidateIngredient(object):
                         'in': ['wo']
                     },
                     'value': 'cow',
-                    'aggregation': None
+                    'aggregation': 'sum'
                 },
                 'kind': 'Metric',
                 'format': ',.0f',
@@ -121,9 +121,12 @@ class TestValidateIngredient(object):
             }),
         ]
         for document, expected in testers:
-            assert self.validator.validate(document)
-            self.validator.test_aggregation_condition()
-            assert self.validator.document == expected
+            validator = IngredientValidator(
+                schema=document.get('kind', 'Metric')
+            )
+            assert validator.validate(document)
+            validator.test_aggregation_condition()
+            assert validator.document == expected
 
     def test_ingredient_kind(self):
         # Dicts to validate and the results
@@ -568,12 +571,6 @@ class TestValidateCondition(object):
         for document, expected in good_values:
             assert self.validator.validate(document)
             self.validator.test_aggregation_condition()
-            print 'doc'
-            print self.validator.document
-            print
-            print 'expected'
-            print expected
-
             assert self.validator.document == expected
 
         # Dicts that fail to validate and the errors they make


### PR DESCRIPTION
Ingredients.yaml defines sqlalchemy expressions in yaml. These are used to form recipe Ingredients like Metric and Dimension.

The basic structure of the sqlalchemy expression we are creating is 

```
{{aggregation}(case({condition}, {field})}
```

For instance, a SQLAlchemy expression to calculated total sales in Vermont is:

```
func.sum(case([MyTable.state == 'Vermont', MyTable.sales])
```

This would be defined with the following yaml

```
field: sales
aggregation: sum
condition:
  field: state
  eq: Vermont
```

## Key concepts

- **field**: A field defines a sqlalchemy expression
- **aggregated_field** A field that will always be aggregated, if not supplied a default_aggregation is used.
- **aggregation**: A sqlalchemy function that performs aggregation like func.sum, or func.count
- **condition**: A sqlalchemy boolean expression that uses a field and a condition
- **operators**: A list of operator and fields that can be used to define expressions like `MyTable.a + MyTable.b`

## This PR

This PR introduces a validator **IngredientValidator** that validates ingredients and ensures that a consistent structure is created. Cerberus schema registration is heavily used.

This is used to create a new Shelf.from_validated_yaml that is functionally equivalent to Shelf.from_yaml. These functions generate Shelf objects from a yaml string and a table reference.

