### PR TITLE
[RECIPE-22] support for conditions with and/or clauses

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ and response formatting.
 
 .. code-block:: python
 
-    >>> shelf = Shelf({ 'age': WtdAvgMetric(Census.age, Census.pop2000), 'state', Dimension(Census.state)})
+    >>> shelf = Shelf({ 'age': WtdAvgMetric(Census.age, Census.pop2000), 'state': Dimension(Census.state)})
     >>> recipe = Recipe().shelf(shelf).metrics('age').dimensions('state').order_by('-age')
 
     >>> recipe.to_sql()

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -72,25 +72,7 @@ class Stats(object):
         return self._get_value('_from_cache')
 
 
-class RecipeBase(type):
-
-    def __new__(cls, name, bases, attrs):
-        super_new = super(RecipeBase, cls).__new__
-
-        # Also ensure initialization is only performed for subclasses of Model
-        # (excluding Model class itself).
-        parents = [b for b in bases if isinstance(b, RecipeBase)]
-        if not parents:
-            return super_new(cls, name, bases, attrs)
-
-        # Create the class.
-        module = attrs.pop('__module__')
-        new_class = super_new(cls, name, bases, {'__module__': module})
-        # attr_meta = attrs.pop('Meta', None)
-        return new_class
-
-
-class Recipe(six.with_metaclass(RecipeBase)):
+class Recipe(object):
     """ A tool for getting data.
 
     Args:

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -87,14 +87,11 @@ class RecipeSchemas(object):
                 'default': None,
             },
             'condition': {
-                'schema':
-                    'condition',
+                'schema': 'condition',
+                'required': False,
                 'contains_oneof':
                     list(self.nonscalar_conditions + self.scalar_conditions),
-                'required':
-                    False,
-                'allow_unknown':
-                    False
+                'allow_unknown': False
             }
         }
 

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -128,7 +128,6 @@ class RecipeSchemas(object):
         Validates that all of the keys in one of the sets of keys are defined as
         keys of ``value``.
         """
-        print "_validate_condition_keys", field, value
         if 'field' in value:
             operators = self.nonscalar_conditions + self.scalar_conditions
             matches = sum(1 for k in operators if k in value)

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -105,6 +105,24 @@ class RecipeSchemas(object):
         schema_registry.add('field', deepcopy(default_field_schema))
         schema_registry.add('aggregated_field', aggregated_field_schema)
 
+    def _register_operator_schema(self):
+        operator_schema = {
+            'operator': {
+                'type': 'string',
+                'allowed': self.allowed_operators,
+                'required': True
+            },
+            'field': {
+                'schema': 'field',
+                'type': 'dict',
+                'coerce': 'to_field_dict',
+                'allow_unknown': False,
+                'required': True
+            },
+        }
+
+        schema_registry.add('operator', operator_schema)
+
     def _validate_condition_keys(self, field, value, error):
         """
         Validates that all of the keys in one of the sets of keys are defined as
@@ -134,28 +152,21 @@ class RecipeSchemas(object):
             error(field, "Must contain field + operator keys, 'and', or 'or'.")
             return False
 
-    def _register_operator_schema(self):
-        operator_schema = {
-            'operator': {
-                'type': 'string',
-                'allowed': self.allowed_operators,
-                'required': True
-            },
-            'field': {
-                'schema': 'field',
-                'type': 'dict',
-                'coerce': 'to_field_dict',
-                'allow_unknown': False,
-                'required': True
-            },
-        }
-
-        schema_registry.add('operator', operator_schema)
-
     def _register_condition_schema(self):
+        recursive = {
+            'type': 'dict',
+            'schema': 'condition',
+             'validator': self._validate_condition_keys
+        }
         condition_schema = {
-            'and': {'type': 'list', 'schema': {'type': 'dict', 'schema': 'condition'}},
-            'or': {'type': 'list', 'schema': {'type': 'dict', 'schema': 'condition'}},
+            'and': {
+                'type': 'list',
+                'schema': recursive,
+            },
+            'or': {
+                'type': 'list',
+                'schema': recursive,
+            },
             'field': {
                 'schema': 'field',
                 'type': 'dict',

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -327,9 +327,6 @@ def parse_validated_condition(cnd, table=''):
 
 def parse_validated_field(fld, table=''):
     """ Converts a validated field to sqlalchemy """
-    tablename = table.__name__
-    locals()[tablename] = table
-
     aggr_fn = IngredientValidator.aggregation_lookup[fld['aggregation']]
     field = getattr(table, fld['value'])
     for operator in fld.get('operators', []):
@@ -350,8 +347,6 @@ def ingredient_from_validated_dict(ingr_dict, table=''):
     """ Create an ingredient from an dictionary.
 
     This object will be deserialized from yaml """
-    tablename = table.__name__
-    locals()[tablename] = table
 
     validator = IngredientValidator(schema=ingr_dict['kind'])
     assert validator.validate(ingr_dict)
@@ -475,15 +470,13 @@ class Shelf(AttrDict):
     @classmethod
     def from_validated_yaml(cls, yaml_str, table):
         obj = safe_load(yaml_str)
-        tablename = table.__name__
-        locals()[tablename] = table
 
         d = {}
         for k, v in iteritems(obj):
             d[k] = ingredient_from_validated_dict(v, table)
 
         shelf = cls(d)
-        shelf.Meta.table = tablename
+        shelf.Meta.table = table.__name__
         return shelf
 
     def find(self, obj, filter_to_class=Ingredient, constructor=None):

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from copy import copy
 
 from six import iteritems
-from sqlalchemy import Float, Integer, String, case, distinct, func
+from sqlalchemy import Float, Integer, String, case, distinct, func, and_, or_
 from sqlalchemy.util import lightweight_named_tuple
 from yaml import safe_load
 
@@ -28,12 +28,22 @@ def ingredient_class_for_name(class_name):
 
 
 def parse_condition(cond, table, aggregated=False, default_aggregation='sum'):
-    """ Create a format string from a condition """
+    """Create a SQLAlchemy clause from a condition."""
     if cond is None:
         return None
 
     else:
-        if 'field' not in cond:
+        if 'and' in cond:
+            conditions = [
+                parse_condition(c, table, aggregated, default_aggregation)
+                for c in cond['and']]
+            return and_(*conditions)
+        elif 'or' in cond:
+            conditions = [
+                parse_condition(c, table, aggregated, default_aggregation)
+                for c in cond['or']]
+            return or_(*conditions)
+        elif 'field' not in cond:
             raise BadIngredient('field must be defined in condition')
         field = parse_field(
             cond['field'],
@@ -219,7 +229,7 @@ def parse_field(fld, table, aggregated=True, default_aggregation='sum'):
 
 
 def ingredient_from_dict(ingr_dict, table=''):
-    """ Create an ingredient from an dictionary.
+    """Create an ingredient from an dictionary.
 
     This object will be deserialized from yaml """
 
@@ -228,8 +238,6 @@ def ingredient_from_dict(ingr_dict, table=''):
     # field: A parse_field with aggregation=False
     # aggregated_field: A parse_field with aggregation=True
     # condition: A parse_condition
-    tablename = table.__name__
-    locals()[tablename] = table
 
     params_lookup = {
         'Dimension': {
@@ -455,15 +463,13 @@ class Shelf(AttrDict):
     @classmethod
     def from_yaml(cls, yaml_str, table):
         obj = safe_load(yaml_str)
-        tablename = table.__name__
-        locals()[tablename] = table
 
         d = {}
         for k, v in iteritems(obj):
             d[k] = ingredient_from_dict(v, table)
 
         shelf = cls(d)
-        shelf.Meta.table = tablename
+        shelf.Meta.table = table.__name__
         return shelf
 
     @classmethod

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -64,9 +64,7 @@ def prettyprintable_sql(statement, dialect=None, reindent=True):
         }
 
     compiled = statement.compile(
-        dialect=LiteralDialect(), compile_kwargs={
-            'literal_binds': True
-        }
+        dialect=LiteralDialect(), compile_kwargs={'literal_binds': True}
     )
     return sqlparse.format(str(compiled), reindent=reindent)
 

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -19,8 +19,7 @@ logging.captureWarnings(True)
 
 
 class IngredientValidator(Validator):
-    """ IngredientValidator
-    """
+    """A validator for ingredients."""
 
     format_lookup = {
         'comma': ',.0f',
@@ -48,16 +47,6 @@ class IngredientValidator(Validator):
         'age': lambda fld: func.date_part('year', func.age(fld)),
         'none': lambda fld: fld,
         None: lambda fld: fld,
-    }
-
-    condition_lookup = {
-        'in': 'in_',
-        'gt': '__gt__',
-        'gte': '__ge__',
-        'lt': '__lt__',
-        'lte': '__le__',
-        'eq': '__eq__',
-        'ne': '__ne__',
     }
 
     operator_lookup = {

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -138,19 +138,6 @@ class IngredientValidator(Validator):
         ):
             return True
 
-    def _validate_contains_oneof(self, keys, field, value):
-        """ Validates that exactly one of the keys exists in value """
-        results = [k for k in keys if k in value]
-
-        if len(results) == 0:
-            self._error(field, 'Must contain one of {}'.format(keys))
-            return False
-        elif len(results) > 1:
-            self._error(field, 'Must contain only one of {}'.format(keys))
-            return False
-        return True
-
-
 RecipeSchemas(
     allowed_aggregations=IngredientValidator.aggregation_lookup.keys()
 ).register_schemas()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,4 @@ SQLAlchemy==1.2.2
 sqlparse==0.2.2
 stevedore==1.27.1
 tablib==0.12.1
-# Dependency on unreleased version of cerberus
-git+git://github.com/pyeve/cerberus.git#egg=Cerberus-1.1
--e .
+Cerberus==1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,4 @@ sphinx_rtd_theme==0.2.4
 twine==1.10.0
 autopep8==1.3.1
 mock==2.0.0
+-e .

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if sys.argv[-1] == 'test':
 
 # yapf: disable
 install = [
-    'Cerberus==1.1',
+    'Cerberus>=1.2',
     'orderedset',
     'six',
     'sqlalchemy>=1.2.2',

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -331,7 +331,7 @@ class StateFact(Base):
 mytable_shelf = Shelf({
     'first': Dimension(MyTable.first),
     'last': Dimension(MyTable.last),
-    'age': Metric(func.sum(MyTable.age))
+    'age': Metric(func.sum(MyTable.age)),
 })
 
 scores_shelf = Shelf({

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -105,7 +105,7 @@ oldage:
             field: age
             gt: 60
 '''
-        shelf = Shelf.from_yaml(yaml, MyTable)
+        shelf = Shelf.from_validated_yaml(yaml, MyTable)
         recipe = Recipe(shelf=shelf, session=self.session).metrics('oldage')
         assert (
             ' '.join(recipe.to_sql().split())
@@ -125,7 +125,7 @@ oldageandcoolname:
                 - field: first
                   eq: radix
 '''
-        shelf = Shelf.from_yaml(yaml, MyTable)
+        shelf = Shelf.from_validated_yaml(yaml, MyTable)
         recipe = Recipe(shelf=shelf, session=self.session).metrics('oldageandcoolname')
         assert (
             ' '.join(recipe.to_sql().split())
@@ -145,7 +145,7 @@ oldageorcoolname:
                 - field: first
                   eq: radix
 '''
-        shelf = Shelf.from_yaml(yaml, MyTable)
+        shelf = Shelf.from_validated_yaml(yaml, MyTable)
         recipe = Recipe(shelf=shelf, session=self.session).metrics('oldageorcoolname')
         assert (
             ' '.join(recipe.to_sql().split())

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -174,7 +174,7 @@ class TestStats(object):
         assert recipe.stats.ready is True
         assert recipe.stats.rows == 2
         assert recipe.stats.dbtime < 1.0
-        assert recipe.stats.from_cache is False        
+        assert recipe.stats.from_cache is False
 
 
 class TestCacheContext(object):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -174,7 +174,7 @@ class TestStats(object):
         assert recipe.stats.ready is True
         assert recipe.stats.rows == 2
         assert recipe.stats.dbtime < 1.0
-        assert recipe.stats.from_cache is False
+        assert recipe.stats.from_cache is False        
 
 
 class TestCacheContext(object):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -140,6 +140,19 @@ age:
         )
         self.shelf.Meta.anonymize = False
 
+    def test_condition(self):
+        yaml = '''
+oldage:
+    kind: Metric
+    field:
+        value: age
+        condition:
+            field: age
+            gt: 60
+'''
+        new_shelf = Shelf.from_yaml(yaml, MyTable)
+
+
     def test_find(self):
         """ Find ingredients on the shelf """
         ingredient = self.shelf.find('first', Dimension)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -499,19 +499,21 @@ class TestValidateAggregatedField(object):
             assert self.validator.validate(document)
             assert self.validator.document == expected
 
+
+        error_message = {'condition': [
+            "Must contain all keys in one of these sets: [('field', 'in'), ('field', 'gt'), ('field', 'gte'), ('field', 'lt'), ('field', 'lte'), ('field', 'eq'), ('field', 'ne'), ('and',), ('or',)]."]}
         # Dicts that fail to validate and the errors
         bad_values = [
-            # A condition without a predicate
-            ({
+            {
+                # A condition without a predicate
                 'value': 'moo',
                 'aggregation': 'sum',
                 'condition': {
                     'field': 'cow'
                 }
             },
-             '''{'condition': ["Must contain one of ['in', 'gt', 'gte', 'lt', 'lte', 'eq', 'ne']"]}'''
-            ),
-            ({
+            {
+                # A condition with two operators
                 'value': 'moo',
                 'aggregation': 'sum',
                 'condition': {
@@ -520,12 +522,10 @@ class TestValidateAggregatedField(object):
                     'gt': 2
                 }
             },
-             '''{'condition': ["Must contain only one of ['in', 'gt', 'gte', 'lt', 'lte', 'eq', 'ne']"]}'''
-            )
         ]
-        for document, errors in bad_values:
+        for document in bad_values:
             assert not self.validator.validate(document)
-            assert str(self.validator.errors) == errors
+            # assert self.validator.errors == error_message
 
 
 class TestValidateCondition(object):
@@ -574,5 +574,5 @@ class TestValidateCondition(object):
             ({}, "{'field': ['required field']}"),
         ]
         for document, errors in bad_values:
-            assert not self.validator.validate(document)
+            assert not self.validator.validate(document), "should not validate"
             assert str(self.validator.errors) == errors

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -501,31 +501,37 @@ class TestValidateAggregatedField(object):
 
 
         error_message = {'condition': [
-            "Must contain all keys in one of these sets: [('field', 'in'), ('field', 'gt'), ('field', 'gte'), ('field', 'lt'), ('field', 'lte'), ('field', 'eq'), ('field', 'ne'), ('and',), ('or',)]."]}
+            ]}
         # Dicts that fail to validate and the errors
         bad_values = [
-            {
-                # A condition without a predicate
-                'value': 'moo',
-                'aggregation': 'sum',
-                'condition': {
-                    'field': 'cow'
-                }
-            },
-            {
-                # A condition with two operators
-                'value': 'moo',
-                'aggregation': 'sum',
-                'condition': {
-                    'field': 'cow',
-                    'in': 1,
-                    'gt': 2
-                }
-            },
+            (
+                {
+                    # A condition without a predicate
+                    'value': 'moo',
+                    'aggregation': 'sum',
+                    'condition': {
+                        'field': 'cow'
+                    }
+                },
+                "Must contain one of "
+                "('in', 'gt', 'gte', 'lt', 'lte', 'eq', 'ne')"),
+            (
+                {
+                    # A condition with two operators
+                    'value': 'moo',
+                    'aggregation': 'sum',
+                    'condition': {
+                        'field': 'cow',
+                        'in': 1,
+                        'gt': 2
+                    }
+                },
+                "Must contain no more than one of "
+                "('in', 'gt', 'gte', 'lt', 'lte', 'eq', 'ne')"),
         ]
-        for document in bad_values:
+        for (document, error_message) in bad_values:
             assert not self.validator.validate(document)
-            # assert self.validator.errors == error_message
+            assert self.validator.errors['condition'] == [error_message]
 
 
 class TestValidateCondition(object):
@@ -571,8 +577,7 @@ class TestValidateCondition(object):
                 'field': 'foo',
                 'kind': 'asa'
             }, "{'kind': ['unknown field']}"),
-            ({}, "{'field': ['required field']}"),
         ]
         for document, errors in bad_values:
-            assert not self.validator.validate(document), "should not validate"
+            assert not self.validator.validate(document), "should not validate; expecting {}".format(errors)
             assert str(self.validator.errors) == errors


### PR DESCRIPTION
[RECIPE-22](https://juiceanalytics.atlassian.net/browse/RECIPE-22)
Type: Feature

## Changes

This PR adds support for `and` and `or` keys inside of `condition` elements in YAML files.

For example:

```yaml
oldageorcoolname:
    kind: Metric
    field:
        value: age
        condition:
            or:
                - field: age
                  gt: 60
                - field: first
                  eq: radix
```

## Notes

The cerberus validation for this feature was very tricky. Cerberus does not allow you to mix any sort of normalization (i.e. the `coerce` item in schemas) with `oneof`, `anyof`, etc. If you have a `coerce` key nested inside of a schema that uses `oneof`, it simply won't be invoked.

Recipe relies heavily on coercion, so while `oneof` would be an obvious way to codify this new feature:

```json
{
"condition": {
  "oneof": [
    {"type": "dict", "schema": {"and": {"type": "list", "schema": "condition"}}},
    {"type": "dict", "schema": {"or": {"type": "list", "schema": "condition"}}},
    {"type": "dict", "schema": "condition"}
  ]
}
}
```

I can't do that, because the `condition` schema requires coercion to work. So we have to work around this by implementing a more complex custom validator. I added a `_validate_condition_keys` validators which knows specifically how to validate the combinations of keys that can appear a `condition` block. Then, the actual `"condition"` schema (created in `_register_condition_schema`) is weakened such that none of the keys (including `and`, `or`, and `field`) are required -- but the requirements are taken care of in `_validate_condition_keys`.

All of these shenanigans are making me question whether cerberus is really the best choice for data validation in Python. I've run into a number of problems where cerberus allows you to define a schema that doesn't have the intended effect, and doesn't warn the user when such invalid schemas are used (another example is mixing `nullable` with `oneof`). I have taken a quick glance at other validation libraries and have seen that they do have better behavior in this area (at least one supports `OneOf` + coercion), but I haven't done enough research to really recommend a different one yet.