### PR TITLE
RECIPE-27 Compare recipe needs to aggregate metrics

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -361,6 +361,7 @@ census_shelf = Shelf({
     'sex': Dimension(Census.sex),
     'age': Dimension(Census.age),
     'pop2000': Metric(func.sum(Census.pop2000)),
+    'pop2000_sum': Metric(func.sum(Census.pop2000), summary_aggregation=func.sum),
     'pop2008': Metric(func.sum(Census.pop2008)),
 })
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -634,7 +634,7 @@ class TestCompareRecipeExtension(object):
         assert len(r.all()) == 2
         assert r.to_sql() == """SELECT census.sex AS sex,
        sum(census.pop2000) AS pop2000,
-       anon_1.pop2000 AS pop2000_compare
+       avg(anon_1.pop2000) AS pop2000_compare
 FROM census
 LEFT OUTER JOIN
   (SELECT census.sex AS sex,
@@ -653,6 +653,41 @@ ORDER BY census.sex"""
         assert rowmen.pop2000 == 3059809
         assert rowmen.pop2000_compare == 298532
 
+
+    def test_compare_custom_aggregation(self):
+        """ A basic comparison recipe. The base recipe looks at all data, the
+        comparison only applies to vermont
+
+        Note: Ordering is only preserved on postgres engines.
+        """
+        r = self.recipe().metrics('pop2000').dimensions('sex').order_by('sex')
+        r = r.compare(
+            self.recipe().metrics('pop2000_sum').dimensions('sex')
+            .filters(Census.state == 'Vermont')
+        )
+
+        assert len(r.all()) == 2
+        assert r.to_sql() == """SELECT census.sex AS sex,
+       sum(census.pop2000) AS pop2000,
+       sum(anon_1.pop2000_sum) AS pop2000_sum_compare
+FROM census
+LEFT OUTER JOIN
+  (SELECT census.sex AS sex,
+          sum(census.pop2000) AS pop2000_sum
+   FROM census
+   WHERE census.state = 'Vermont'
+   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+GROUP BY census.sex
+ORDER BY census.sex"""
+        rowwomen, rowmen = r.all()[0], r.all()[1]
+        # We should get the lookup values
+        assert rowwomen.sex == 'F'
+        assert rowwomen.pop2000 == 3234901
+        assert rowwomen.pop2000_sum_compare == 53483056
+        assert rowmen.sex == 'M'
+        assert rowmen.pop2000 == 3059809
+        assert rowmen.pop2000_sum_compare == 51347504
+
     def test_compare_suffix(self):
         """ Test that the proper suffix gets added to the comparison metrics
         """
@@ -667,7 +702,7 @@ ORDER BY census.sex"""
         assert len(r.all()) == 2
         assert r.to_sql() == """SELECT census.sex AS sex,
        sum(census.pop2000) AS pop2000,
-       anon_1.pop2000 AS pop2000_x
+       avg(anon_1.pop2000) AS pop2000_x
 FROM census
 LEFT OUTER JOIN
   (SELECT census.sex AS sex,
@@ -707,8 +742,8 @@ ORDER BY census.sex"""
         assert r.to_sql() == """SELECT census.sex AS sex,
        census.state AS state,
        sum(census.pop2000) AS pop2000,
-       anon_1.pop2000 AS pop2000_vermont,
-       anon_2.pop2000 AS pop2000_total
+       avg(anon_1.pop2000) AS pop2000_vermont,
+       avg(anon_2.pop2000) AS pop2000_total
 FROM census
 LEFT OUTER JOIN
   (SELECT census.sex AS sex,


### PR DESCRIPTION
When using comparison recipes, the comparison metrics are hoisted into the base recipe. These are not aggregated and they should be. This didn't cause a problem in our tests with sqlite but do raise errors in postgres.

This PR uses the same approach as the built in extension `SummarizeOver` to allow developers to supply an optional aggregation function for hoisted metrics called `summary_aggregation`. This will be applied when the metric is hoisted.

```
{
    'pop2000_sum': Metric(func.sum(Census.pop2000), summary_aggregation=func.sum),
}
```