### PR TITLE
make Shelf a regular object with an `_ingredients` attribute, instead a subclass of `dict`

### DIFF
--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -520,8 +520,8 @@ class Shelf(object):
     def update(self, d=None, **kwargs):
         items = []
         if d is not None:
-            items = d.items()
-        for k, v in items + kwargs.items():
+            items = list(d.items())
+        for k, v in items + list(kwargs.items()):
             self[k] = v
 
     def pop(self, k, d=_POP_DEFAULT):

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -430,7 +430,6 @@ class Shelf(object):
         anonymize = False
         table = None
         select_from = None
-        engine = None
         ingredient_order = []
         metadata = None
 
@@ -477,10 +476,10 @@ class Shelf(object):
         # Ensure the ingredient's `anonymize` matches the shelf.
 
         # TODO: this is nasty, but *somewhat* safe because we are (hopefully)
-        # guaranteed to "own" copies of all of our ingredients. It would be much
-        # better if Shelf had logic that ran when anonymize is set to update all
-        # ingredients. Or better yet, the code that anonymizes queries should
-        # just look at the shelf instead of the ingredients.
+        # guaranteed to "own" copies of all of our ingredients. It would be
+        # much better if Shelf had logic that ran when anonymize is set to
+        # update all ingredients. Or better yet, the code that anonymizes
+        # queries should just look at the shelf instead of the ingredients.
 
         # One way in this is "spooky" is:
         # ingr = shelf['foo']

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -440,11 +440,8 @@ class Shelf(object):
         self.Meta.table = kwargs.pop('table', None)
         self.Meta.select_from = kwargs.pop('select_from', None)
         self.Meta.metadata = kwargs.pop('metadata', None)
-
         self._ingredients = {}
-        if args and isinstance(args[0], dict):
-            self._ingredients.update(args[0])
-        self._ingredients.update(kwargs)
+        self.update(*args, **kwargs)
 
         # Set the ids of all ingredients on the shelf to the key
         for k, ingredient in self.items():

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -21,6 +21,8 @@ from recipe.validators import IngredientValidator
 _distinct = distinct
 _case = case
 
+_POP_DEFAULT = object()
+
 
 def ingredient_class_for_name(class_name):
     """Get the class in the recipe.ingredients module with the given name."""
@@ -448,7 +450,7 @@ class Shelf(object):
         for k, ingredient in self.items():
             ingredient.id = k
 
-    ## Dict Interface
+    # Dict Interface
 
     def get(self, k, d=None):
         ingredient = self._ingredients.get(k, d)
@@ -516,15 +518,14 @@ class Shelf(object):
             shelf = {}
         self._ingredients.update(shelf, **kwargs)
 
-    DEFAULT = object()
-    def pop(self, k, d=DEFAULT):
+    def pop(self, k, d=_POP_DEFAULT):
         """Pop an ingredient off of this shelf."""
-        if d is self.DEFAULT:
+        if d is _POP_DEFAULT:
             return self._ingredients.pop(k)
         else:
             return self._ingredients.pop(k, d)
 
-    ## End dict interface
+    # End dict interface
 
     def ingredients(self):
         """ Return the ingredients in this shelf in a deterministic order """

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -473,7 +473,25 @@ class Shelf(object):
     def __getitem__(self, key):
         """ Set the id and anonymize property of the ingredient whenever we
         get or set items """
-        return self._ingredients[key]
+        ingr = self._ingredients[key]
+        # Ensure the ingredient's `anonymize` matches the shelf.
+
+        # TODO: this is nasty, but *somewhat* safe because we are (hopefully)
+        # guaranteed to "own" copies of all of our ingredients. It would be much
+        # better if Shelf had logic that ran when anonymize is set to update all
+        # ingredients. Or better yet, the code that anonymizes queries should
+        # just look at the shelf instead of the ingredients.
+
+        # One way in this is "spooky" is:
+        # ingr = shelf['foo']
+        # # ingr.anonymize is now False
+        # shelf.Meta.anonymize = True
+        # # ingr.anonymize is still False
+        # shelf['foo] # ignore result
+        # # ingr.anonymize is now True
+
+        ingr.anonymize = self.Meta.anonymize
+        return ingr
 
     def __setitem__(self, key, ingredient):
         """ Set the id and anonymize property of the ingredient whenever we

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -488,6 +488,11 @@ class Shelf(object):
     def __setitem__(self, key, ingredient):
         """ Set the id and anonymize property of the ingredient whenever we
         get or set items """
+        if not isinstance(ingredient, Ingredient):
+            raise TypeError(
+                "Can only set Ingredients as items on Shelf. "
+                "Got: {!r}".format(ingredient)
+            )
         ingredient_copy = copy(ingredient)
         ingredient_copy.id = key
         ingredient_copy.anonymize = self.Meta.anonymize
@@ -576,6 +581,12 @@ class Shelf(object):
         return '\n'.join(lines)
 
     def use(self, ingredient):
+        if not isinstance(ingredient, Ingredient):
+            raise TypeError(
+                "Can only set Ingredients as items on Shelf. "
+                "Got: {!r}".format(ingredient)
+            )
+
         # Track the order in which ingredients are added.
         self.Meta.ingredient_order.append(ingredient.id)
         self[ingredient.id] = ingredient

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -501,6 +501,13 @@ class Shelf(object):
         self._ingredients.clear()
 
     def update(self, *args, **kwargs):
+        # This is a little more complicated than it seems it should be, because
+        # apparently `dict.update` special-cases when `dict` is passed. If we
+        # don't special-case the case of `Shelf` being passed, `dict.update`
+        # will merely iterate it and expect to find two-tuples. But if you
+        # iterate a dict normally, it only returns the keys. Therefore, we must
+        # explicitly convert Shelf arguments into two-tuples before passing it
+        # on.
         if len(args) > 0:
             shelf = args[0]
             if isinstance(args[0], Shelf):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -241,6 +241,16 @@ class TestShelf(object):
         ingredient = self.shelf.find('last', Dimension)
         assert ingredient.id == 'last'
 
+    def test_setitem_type_error(self):
+        """Only ingredients can be added to shelves."""
+        with pytest.raises(TypeError):
+            self.shelf['foo'] = 3
+
+    def test_use_type_error(self):
+        """`use` requires Ingredients"""
+        with pytest.raises(TypeError):
+            self.shelf.use(3)
+
     def test_clear(self):
         assert len(self.shelf) == 4
         self.shelf.clear()

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -127,6 +127,18 @@ GROUP BY census.state'''
             find_column(MyTable.first, 'foo')
 
 
+class TestShelfConstruction(object):
+    def test_pass_some_metadata(self):
+        shelf = Shelf(metadata={'a': 'hello'})
+        assert shelf.Meta.metadata['a'] == 'hello'
+
+    def test_Meta_is_not_shared(self):
+        shelf = Shelf(metadata={'a': 'hello'})
+        shelf2 = Shelf(metadata={'b': 'there'})
+        assert shelf.Meta.metadata == {'a': 'hello'}
+        assert shelf2.Meta.metadata == {'b': 'there'}
+
+
 class TestShelf(object):
 
     def setup(self):
@@ -211,7 +223,7 @@ class TestShelf(object):
 
     def test_get(self):
         """ Find ingredients on the shelf """
-        ingredient = self.shelf.first
+        ingredient = self.shelf['first']
         assert ingredient.id == 'first'
 
         ingredient = self.shelf.get('first', None)
@@ -346,7 +358,7 @@ age:
 
     def test_get(self):
         """ Find ingredients on the shelf """
-        ingredient = self.shelf.first
+        ingredient = self.shelf['first']
         assert ingredient.id == 'first'
 
         ingredient = self.shelf.get('first', None)
@@ -564,7 +576,7 @@ class TestAutomaticShelf(object):
 
     def test_get(self):
         """ Find ingredients on the shelf """
-        ingredient = self.shelf.first
+        ingredient = self.shelf['first']
         assert ingredient.id == 'first'
 
         ingredient = self.shelf.get('first', None)

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -378,7 +378,9 @@ age:
         assert self.shelf.Meta.anonymize is True
 
     def test_anonymize_keeps_ingredients_up_to_date(self):
-        """Setting the anonymize attribute causes all ingredients to be updated."""
+        """Setting the anonymize attribute causes all ingredients to be
+        updated.
+        """
         assert self.shelf['first'].anonymize is False
         self.shelf.Meta.anonymize = True
         assert self.shelf['first'].anonymize is True

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from recipe import (
     AutomaticShelf, BadIngredient, BadRecipe, Dimension, Metric, Recipe, Shelf
 )
+from recipe.ingredients import Ingredient
 from recipe.shelf import find_column
 
 from .test_base import Base, Census, MyTable, StateFact, mytable_shelf, oven
@@ -231,6 +232,16 @@ class TestShelf(object):
 
         ingredient = self.shelf.get('primo', None)
         assert ingredient is None
+
+    def test_get_doesnt_mutate(self):
+        """
+        Sharing ingredients between shelves won't cause race conditions on
+        their `.id` and `.anonymize` attributes.
+        """
+        ingr = Ingredient(id='b')
+        shelf = Shelf({'a': ingr})
+        assert shelf['a'].id == 'a'
+        assert ingr.id == 'b'
 
     def test_add_to_shelf(self):
         """ We can add an ingredient to a shelf """

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -377,6 +377,12 @@ age:
         self.shelf.Meta.anonymize = True
         assert self.shelf.Meta.anonymize is True
 
+    def test_anonymize_keeps_ingredients_up_to_date(self):
+        """Setting the anonymize attribute causes all ingredients to be updated."""
+        assert self.shelf['first'].anonymize is False
+        self.shelf.Meta.anonymize = True
+        assert self.shelf['first'].anonymize is True
+
     def test_get(self):
         """ Find ingredients on the shelf """
         ingredient = self.shelf['first']


### PR DESCRIPTION
There were two problems with `Shelf.__init__`:

- keyword arguments like `metadata`, `table`, `select_from` were buggy -- they would be passed on to the dict constructor before being popped out of `kwargs`, so you would end up with unexpected "ingredients" in the Shelf dictionary named `metadata`, `table`, or `select_from`. This would often then immediately blow up at the end of `Shelf.__init__` when it iterated over those non-ingredients and tried to assign the `.id` attribute on them.

- the `Meta` attribute was just a nested class definition on the `Shelf` class. There is only one of them, but each time `Shelf.__init__` is called, it would overwrite some of the attributes.

  This belies a more complex issue, which is that there is no place to store any extra data on an instance that subclasses `AttrDict`, since it subclasses dict and then sets `self.__dict__ = self`, meaning there is no actual attribute dictionary on this object. Before I saw the `self.__dict__ = self` line, the naive thing I tried was to just say `self.Meta = type(self).Meta()` (to instantiate a new copy of the `Meta` class for each `Shelf` instance), but of course this just stored `Meta` as an ingredient on self, because of `__setattr__` and the fact that there is no separate ingredient storage from Shelf attribute storage.

To solve these problems, I changed `Shelf` so it no longer subclasses `AttrDict`, and instead now store ingredients in a plain dictionary at `Shelf._ingredients`. I then implemented the remainder of the `dict` interface that the recipe test suite was relying on in terms of `self._ingredients`. I removed the `__getattr__` and `__setattr__` implementations because they don't seem to actually be used by apps that use recipe.

I also got rid of the mutation of ingredients `id` in `__getitem__` and `__init__`, so that Shelves no longer mutate things that it may not "own" (e.g. have a copy of). Now all mutation goes through `__setitem__`, which copies and annotates the ingredients, so `__getitem__` doesn't need to mutate the ingredients on the way out. *However*, `__getitem__` still sets `anonymize` because that's something that may change over time on the Shelf. Would be nice to have a better mechanism for this in the future.
