### PR TITLE
[RECIPE-29] Recipe.from_config and Shelf.from_config

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -13,7 +13,7 @@ from recipe.compat import str
 from recipe.dynamic_extensions import run_hooks
 from recipe.exceptions import BadRecipe
 from recipe.ingredients import Dimension, Filter, Having, Metric
-from recipe.shelf import Shelf
+from recipe.shelf import Shelf, parse_condition
 from recipe.utils import prettyprintable_sql
 from recipe.schemas import recipe_schema
 
@@ -151,11 +151,15 @@ class Recipe(object):
     def from_config(cls, shelf, obj):
         """Construct a Recipe from a plain Python dictionary."""
         obj = normalize_schema(recipe_schema, obj)
+        filters = [
+            parse_condition(filter, shelf.Meta.select_from) if isinstance(filter, dict) else filter
+            for filter in obj.get('filters', [])
+        ]
         return cls(
             shelf=shelf,
             metrics=obj.get('metrics'),
             dimensions=obj.get('dimensions'),
-            filters=obj.get('filters'),
+            filters=filters,
             order_by=obj.get('order_by'),
         )
 

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import logging
 import time
 import warnings

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -7,6 +7,7 @@ import tablib
 from orderedset import OrderedSet
 from sqlalchemy import alias
 from sqlalchemy.sql.elements import BinaryExpression
+from sureberus import normalize_schema
 
 from recipe.compat import str
 from recipe.dynamic_extensions import run_hooks
@@ -14,6 +15,7 @@ from recipe.exceptions import BadRecipe
 from recipe.ingredients import Dimension, Filter, Having, Metric
 from recipe.shelf import Shelf
 from recipe.utils import prettyprintable_sql
+from recipe.schemas import recipe_schema
 
 ALLOW_QUERY_CACHING = True
 
@@ -144,6 +146,18 @@ class Recipe(object):
             self.recipe_extensions.append(ExtensionClass(self))
 
         self.dynamic_extensions = dynamic_extensions
+
+    @classmethod
+    def from_config(cls, shelf, obj):
+        """Construct a Recipe from a plain Python dictionary."""
+        obj = normalize_schema(recipe_schema, obj)
+        return cls(
+            shelf=shelf,
+            metrics=obj.get('metrics'),
+            dimensions=obj.get('dimensions'),
+            filters=obj.get('filters'),
+            order_by=obj.get('order_by'),
+        )
 
     # -------
     # Builder for parts of the recipe.

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -148,11 +148,13 @@ class Recipe(object):
         self.dynamic_extensions = dynamic_extensions
 
     @classmethod
-    def from_config(cls, shelf, obj):
+    def from_config(cls, shelf, obj, **kwargs):
         """
         Construct a Recipe from a plain Python dictionary.
 
-        Most of the directives only support named things retrieved from the shelf, but 
+        Most of the directives only support named ingredients, specified as
+        strings, and looked up on the shelf. But filters can be specified as
+        objects.
         """
         obj = normalize_schema(recipe_schema, obj)
         obj['filters'] = [
@@ -161,13 +163,8 @@ class Recipe(object):
             else filter
             for filter in obj.get('filters', [])
         ]
-        recipe = cls(shelf=shelf)
-        for directive, values in obj.items():
-            directive_handler = getattr(recipe, directive, None)
-            if not directive_handler:
-                raise BadRecipe("{} is an unhandled directive".format(directive))
-            recipe = directive_handler(*values)
-        return recipe
+        obj.update(kwargs)
+        return cls(shelf=shelf, **obj)
 
     # -------
     # Builder for parts of the recipe.

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -152,7 +152,9 @@ class Recipe(object):
         """Construct a Recipe from a plain Python dictionary."""
         obj = normalize_schema(recipe_schema, obj)
         filters = [
-            parse_condition(filter, shelf.Meta.select_from) if isinstance(filter, dict) else filter
+            parse_condition(filter, shelf.Meta.select_from)
+            if isinstance(filter, dict)
+            else filter
             for filter in obj.get('filters', [])
         ]
         return cls(

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -392,9 +392,19 @@ class Anonymize(RecipeExtension):
     AnonymizeRecipe should occur last
     """
 
+    recipe_schema = {
+        'anonymize': {'type': 'boolean'},
+    }
+
     def __init__(self, *args, **kwargs):
         super(Anonymize, self).__init__(*args, **kwargs)
         self._anonymize = False
+
+    def from_config(self, obj):
+        anonymize = obj.get('anonymize')
+        if anonymize is not None:
+            self.anonymize(anonymize)
+        return self.recipe
 
     def anonymize(self, value):
         """ Should this recipe be anonymized"""

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -136,6 +136,7 @@ def handle_directives(directives, handlers):
             raise BadRecipe("Directive {} isn't handled".format(k))
         method(v)
 
+
 class AutomaticFilters(RecipeExtension):
     """Automatic generation and addition of Filters to a recipe.
 
@@ -146,8 +147,14 @@ class AutomaticFilters(RecipeExtension):
 
     recipe_schema = {
         'automatic_filters': {'type': 'dict'},
-        'include_automatic_filter_keys': {'type': 'list', 'schema': {'type': 'string'}},
-        'exclude_automatic_filter_keys': {'type': 'list', 'schema': {'type': 'string'}},
+        'include_automatic_filter_keys': {
+            'type': 'list',
+            'schema': {'type': 'string'}
+        },
+        'exclude_automatic_filter_keys': {
+            'type': 'list',
+            'schema': {'type': 'string'}
+        },
         'apply_automatic_filters': {'type': 'boolean'},
     }
 
@@ -164,8 +171,10 @@ class AutomaticFilters(RecipeExtension):
             {
                 'automatic_filters': self.automatic_filters,
                 'apply_automatic_filters': self.apply_automatic_filters,
-                'include_automatic_filter_keys': lambda v: self.include_automatic_filter_keys(*v),
-                'exclude_automatic_filter_keys': lambda v: self.exclude_automatic_filter_keys(*v),
+                'include_automatic_filter_keys':
+                    lambda v: self.include_automatic_filter_keys(*v),
+                'exclude_automatic_filter_keys':
+                    lambda v: self.exclude_automatic_filter_keys(*v),
             }
         )
         return self.recipe

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -241,7 +241,7 @@ recipe_schema = {
         },
         'filters': {
             'type': 'list',
-            'schema': {'type': 'dict'},
+            'schema': {'type': 'string'},
         },
         'order_by': {
             'type': 'list',

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -228,7 +228,7 @@ class RecipeSchemas(object):
 
 
 def _coerce_filter(v):
-    # For now, we'll delegate to the validator / normalizer that using
+    # For now, we'll delegate to the validator / normalizer using
     # Cerberus.
     from recipe.validators import IngredientValidator
     validator = IngredientValidator(schema='Filter')

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -241,7 +241,12 @@ recipe_schema = {
         },
         'filters': {
             'type': 'list',
-            'schema': {'type': 'string'},
+            'schema': {
+                'oneof': [
+                    {'type': 'string'},
+                    {'type': 'dict'},
+                ]
+            },
         },
         'order_by': {
             'type': 'list',

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -225,3 +225,27 @@ class RecipeSchemas(object):
         self._register_operator_schema()
         self._register_condition_schema()
         self._register_ingredient_schemas()
+
+
+# This schema is used with sureberus
+recipe_schema = {
+    'type': 'dict',
+    'schema': {
+        'metrics': {
+            'type': 'list',
+            'schema': {'type': 'string'},
+        },
+        'dimensions': {
+            'type': 'list',
+            'schema': {'type': 'string'},
+        },
+        'filters': {
+            'type': 'list',
+            'schema': {'type': 'dict'},
+        },
+        'order_by': {
+            'type': 'list',
+            'schema': {'type': 'string'},
+        },
+    }
+}

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -227,6 +227,17 @@ class RecipeSchemas(object):
         self._register_ingredient_schemas()
 
 
+def _coerce_filter(v):
+    # For now, we'll delegate to the validator / normalizer that using
+    # Cerberus.
+    from recipe.validators import IngredientValidator
+    validator = IngredientValidator(schema='Filter')
+    if not validator.validate(v):
+        raise Exception(validator.errors)
+    validator.document['kind'] = 'Filter'
+    return validator.document
+
+
 # This schema is used with sureberus
 recipe_schema = {
     'type': 'dict',
@@ -244,7 +255,10 @@ recipe_schema = {
             'schema': {
                 'oneof': [
                     {'type': 'string'},
-                    {'type': 'dict'},
+                    {
+                        'type': 'dict',
+                        'coerce': _coerce_filter,
+                    },
                 ]
             },
         },

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -242,6 +242,8 @@ def _coerce_filter(v):
 recipe_schema = {
     'type': 'dict',
     'schema': {
+        # These directives correspond with the names of methods on the `Recipe`
+        # class.
         'metrics': {
             'type': 'list',
             'schema': {'type': 'string'},

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -242,7 +242,7 @@ def _coerce_filter(v):
 recipe_schema = {
     'type': 'dict',
     'schema': {
-        # These directives correspond with the names of methods on the `Recipe`
+        # These directives correspond with the keyword arguments of Recipe
         # class.
         'metrics': {
             'type': 'list',

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -600,8 +600,11 @@ class Shelf(object):
         """Create a shelf using a dict shelf definition.
 
         :param obj: A Python dictionary describing a Shelf.
-        :param selectable: A SQLAlchemy Table, a Recipe, or a SQLAlchemy
-            join to select from.
+        :param selectable: A SQLAlchemy Table, a Recipe, a table name, or a
+            SQLAlchemy join to select from.
+        :param metadata: If `selectable` is passed as a table name, then in
+            order to introspect its schema, we must have the SQLAlchemy
+            MetaData object to associate it with.
         :return: A shelf that contains the ingredients defined in obj.
         """
         from recipe import Recipe
@@ -613,18 +616,14 @@ class Shelf(object):
             else:
                 schema, tablename = None, selectable
 
-            kwargs = {'extend_existing': True, 'autoload': True}
-            if schema is not None:
-                kwargs['schema'] = schema
-
-            selectable = Table(tablename, metadata, **kwargs)
+            selectable = Table(
+                tablename, metadata, schema=schema,
+                extend_existing=True, autoload=True
+            )
 
         d = {}
         for k, v in iteritems(obj):
             d[k] = ingredient_constructor(v, selectable)
-
-        kwargs = {}
-
         shelf = cls(d, select_from=selectable)
         return shelf
 

--- a/recipe/validators.py
+++ b/recipe/validators.py
@@ -139,4 +139,4 @@ class IngredientValidator(Validator):
 
 RecipeSchemas(
     allowed_aggregations=list(IngredientValidator.aggregation_lookup.keys())
-).register_schemas()
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ stevedore==1.27.1
 tablib==0.12.1
 Cerberus==1.2
 pyyaml>=4.2b1
+sureberus==0.2

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Float, Integer, String, distinct, func
 from sqlalchemy.ext.declarative import declarative_base
 
-from recipe import Dimension, IdValueDimension, Metric, Shelf, get_oven
+from recipe import Dimension, Filter, IdValueDimension, Metric, Shelf, get_oven
 
 oven = get_oven('sqlite://')
 Base = declarative_base(bind=oven.engine)
@@ -334,6 +334,15 @@ mytable_shelf = Shelf({
     'firstlast': IdValueDimension(MyTable.first, MyTable.last),
     'age': Metric(func.sum(MyTable.age)),
 })
+
+mytable_shelf_with_filter = Shelf({
+    'first': Dimension(MyTable.first),
+    'last': Dimension(MyTable.last),
+    'firstlast': IdValueDimension(MyTable.first, MyTable.last),
+    'age': Metric(func.sum(MyTable.age)),
+    'ageover4': Filter(MyTable.age > 4),
+})
+
 
 scores_shelf = Shelf({
     'username':

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -335,14 +335,6 @@ mytable_shelf = Shelf({
     'age': Metric(func.sum(MyTable.age)),
 })
 
-mytable_shelf_with_filter = Shelf({
-    'first': Dimension(MyTable.first),
-    'last': Dimension(MyTable.last),
-    'firstlast': IdValueDimension(MyTable.first, MyTable.last),
-    'age': Metric(func.sum(MyTable.age)),
-    'ageover4': Filter(MyTable.age > 4),
-})
-
 
 scores_shelf = Shelf({
     'username':

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Float, Integer, String, distinct, func
 from sqlalchemy.ext.declarative import declarative_base
 
-from recipe import Dimension, Filter, IdValueDimension, Metric, Shelf, get_oven
+from recipe import Dimension, IdValueDimension, Metric, Shelf, get_oven
 
 oven = get_oven('sqlite://')
 Base = declarative_base(bind=oven.engine)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -297,6 +297,15 @@ class TestAnonymizeRecipeExtension(object):
             extension_classes=self.extension_classes
         )
 
+    def test_from_config(self):
+        recipe = Recipe.from_config(
+            self.shelf,
+            {'metrics': ['age'], 'dimensions': ['last'], 'anonymize': True},
+            session=self.session,
+            extension_classes=self.extension_classes,
+        )
+        assert recipe.recipe_extensions[0]._anonymize is True
+
     def test_apply(self):
         recipe = self.recipe().metrics('age').dimensions('first')
         recipe.anonymize(True)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -120,7 +120,6 @@ class TestAutomaticFiltersExtension(object):
         assert ext.exclude_keys == ('foo',)
         assert ext.apply is False
 
-
     def test_proxy_calls(self):
         recipe = self.recipe().metrics('age').dimensions('first')
         recipe = recipe.apply_automatic_filters(False)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -220,12 +220,16 @@ GROUP BY foo.last"""
 
     def test_from_config_extra_kwargs(self):
         config = {'dimensions': ['last'], 'metrics': ['age']}
-        from tests.test_extensions import DummyExtension
         recipe = Recipe.from_config(
             self.shelf, config,
-            extension_classes=[DummyExtension]
-        )
-        assert recipe.a() == 'a'
+            order_by=['last'],
+        ).session(self.session)
+        assert recipe.to_sql() == """\
+SELECT foo.last AS last,
+       sum(foo.age) AS age
+FROM foo
+GROUP BY foo.last
+ORDER BY foo.last"""
 
     def test_recipe_empty(self):
         recipe = self.recipe()

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,10 +1,11 @@
 import pytest
 from sqlalchemy import func, join
 from tests.test_base import (
-    Census, MyTable, Scores, StateFact, census_shelf, mytable_shelf, oven
+    Census, MyTable, Scores, StateFact, census_shelf, mytable_shelf,
+    mytable_shelf_with_filter, oven
 )
 
-from recipe import BadRecipe, Dimension, Having, Metric, Recipe, Shelf
+from recipe import BadRecipe, Dimension, Filter, Having, Metric, Recipe, Shelf
 
 
 class TestRecipeIngredients(object):
@@ -175,6 +176,18 @@ ORDER BY foo.first"""
         assert recipe.all()[0].first == 'hi'
         assert recipe.all()[0].age == 15
         assert recipe.stats.rows == 1
+
+    def test_from_config(self):
+        config = {'dimensions': ['first', 'last'], 'metrics': ['age'], 'filters': ['ageover4']}
+        recipe = Recipe.from_config(mytable_shelf_with_filter, config).session(self.session)
+        assert recipe.to_sql() == """\
+SELECT foo.first AS first,
+       foo.last AS last,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.age > 4
+GROUP BY foo.first,
+         foo.last"""
 
     def test_recipe_empty(self):
         recipe = self.recipe()

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -178,7 +178,11 @@ ORDER BY foo.first"""
         assert recipe.stats.rows == 1
 
     def test_from_config(self):
-        config = {'dimensions': ['first', 'last'], 'metrics': ['age'], 'filters': ['ageover4']}
+        config = {
+            'dimensions': ['first', 'last'],
+            'metrics': ['age'],
+            'filters': ['ageover4'],
+        }
         recipe = Recipe.from_config(mytable_shelf_with_filter, config).session(self.session)
         assert recipe.to_sql() == """\
 SELECT foo.first AS first,
@@ -186,6 +190,25 @@ SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 4
+GROUP BY foo.first,
+         foo.last"""
+
+    def test_from_config_filter_object(self):
+        config = {
+            'dimensions': ['last'],
+            'metrics': ['age'],
+            'filters': [
+                {'field': 'age', 'gt': 13},
+            ]
+        }
+
+        recipe = Recipe.from_config(mytable_shelf_with_filter, config).session(self.session)
+        assert recipe.to_sql() == """\
+SELECT foo.first AS first,
+       foo.last AS last,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.age > 13
 GROUP BY foo.first,
          foo.last"""
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -218,6 +218,15 @@ FROM foo
 WHERE foo.age > 13
 GROUP BY foo.last"""
 
+    def test_from_config_extra_kwargs(self):
+        config = {'dimensions': ['last'], 'metrics': ['age']}
+        from tests.test_extensions import DummyExtension
+        recipe = Recipe.from_config(
+            self.shelf, config,
+            extension_classes=[DummyExtension]
+        )
+        assert recipe.a() == 'a'
+
     def test_recipe_empty(self):
         recipe = self.recipe()
         with pytest.raises(BadRecipe):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -619,6 +619,9 @@ class TestAutomaticShelf(object):
         ingredient = self.shelf.get('first', None)
         assert ingredient.id == 'first'
 
+        ingredient = self.shelf['age']
+        assert str(ingredient.columns[0]) == 'sum(foo.age)'
+
         ingredient = self.shelf.get('primo', None)
         assert ingredient is None
 

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -536,6 +536,7 @@ oldage:
         with pytest.raises(Exception):
             self.make_shelf(content)
 
+
 class TestShelfFromConfig(TestShelfFromValidatedYaml):
 
     def make_shelf(self, content, table=MyTable):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy import join
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
+from yaml import safe_load
 
 from recipe import (
     AutomaticShelf, BadIngredient, BadRecipe, Dimension, Metric, Recipe, Shelf
@@ -534,6 +535,12 @@ oldage:
 '''
         with pytest.raises(Exception):
             self.make_shelf(content)
+
+class TestShelfFromConfig(TestShelfFromValidatedYaml):
+
+    def make_shelf(self, content, table=MyTable):
+        obj = safe_load(content)
+        self.shelf = Shelf.from_config(obj, table)
 
 
 class TestShelfFromIntrospection(object):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -10,7 +10,7 @@ from recipe import (
     AutomaticShelf, BadIngredient, BadRecipe, Dimension, Metric, Recipe, Shelf
 )
 from recipe.ingredients import Ingredient
-from recipe.shelf import find_column
+from recipe.shelf import find_column, introspect_table
 
 from .test_base import Base, Census, MyTable, StateFact, mytable_shelf, oven
 
@@ -621,3 +621,11 @@ class TestAutomaticShelf(object):
 
         ingredient = self.shelf.get('primo', None)
         assert ingredient is None
+
+    def test_introspect_table(self):
+        config = introspect_table(MyTable.__table__)
+        assert config == {
+            'age': {'field': 'age', 'kind': 'Metric'},
+            'first': {'field': 'first', 'kind': 'Dimension'},
+            'last': {'field': 'last', 'kind': 'Dimension'}
+        }


### PR DESCRIPTION
Ticket: [RECIPE-29](https://juiceanalytics.atlassian.net/browse/RECIPE-29)
Type: Feature

## Changes

- Added Recipe.from_config, which takes a dict, validates it, and returns a Recipe.
  - This method allows Recipe extensions to provide and handle their own directives. For example, the AutomaticFilters extension allows including an `'automatic_filters': {'foo': ['bar']}` entry in the configuration.
- add dependency on sureberus, and declare a recipe schema that uses it.
- Added Shelf.from_config, and refactor Shelf.from_yaml and Shelf.from_validated_yaml to use it
- Changed `AutomaticShelf` from a class to a function, and refactor the core shelf-generating code out to a separate function that generates a plain dictionary (suitable for passing to `Shelf.from_config`). This lets us invoke it in Juicebox from the code that sets up DataSource, without necessarily constructing a Shelf at that point, when we really just want the plain dictionary.



