### PR TITLE
add a total_count method for getting the number of count of rows returned by a recipe

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -142,6 +142,9 @@ class Recipe(object):
         self.dynamic_extensions = dynamic_extensions
 
     def total_count(self):
+        """Return the number of rows that would be returned by this Recipe,
+        ignoring any `limit` that has been applied.
+        """
         # If there is an ordering we take it off to make this
         # count run faster, then set the recipe to dirty so the
         # query is generated again

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -353,6 +353,12 @@ oldageorcoolname:
             'THEN foo.age END) AS oldageorcoolname FROM foo'
         )
 
+    def test_count(self):
+        recipe = self.recipe().metrics('age').dimensions('first')
+        assert recipe.total_count() == 1
+        recipe = self.recipe().metrics('age').dimensions('last')
+        assert recipe.total_count() == 2
+
 
 class TestStats(object):
 


### PR DESCRIPTION
This is copied from an extension that was in Juicebox.