### PR TITLE
Create sureberus validators for recipe ingredients

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -101,10 +101,10 @@ Dimensions are groupings that exist in your data.
     # A simple dimension
     self.shelf['state'] = Dimension(Census.state)
 
-IdValueDimension
-~~~~~~~~~~~~~~~~
+Adding an id
+~~~~~~~~~~~~
 
-IdValueDimensions support separate properties for ids and values. Consider a
+Dimensions can support separate properties for ids and values. Consider a
 table of employees with an ``employee_id`` and a ``full_name``. If you had
 two employees with the same name you need to be able to distinguish between
 them.
@@ -112,22 +112,23 @@ them.
 .. code-block:: python
 
     # Support an id and a label
-    self.shelf['employee']: IdValueDimension(Employee.id, Employee.full_name)
+    self.shelf['employee']: Dimension(Employee.full_name,
+                                      id_expression=Employee.id)
 
 The id is accessible as ``employee_id`` in each row and their full name is
 available as ``employee``.
 
-LookupDimension
-~~~~~~~~~~~~~~~
+Using lookups
+~~~~~~~~~~~~~
 
-Lookup dimension maps values in your data to descriptive names. The ``_id``
+Lookup maps values in your data to descriptive names. The ``_id``
 property of your dimension contains the original value.
 
 .. code-block:: python
 
     # Convert M/F into Male/Female
-    self.shelf['gender']: LookupDimension(Census.sex, {'M': 'Male',
-        'F': 'Female'}, default='Unknown')
+    self.shelf['gender']: Dimension(Census.sex, lookup={'M': 'Male',
+        'F': 'Female'}, lookup_default='Unknown')
 
 If you use the gender dimension, there will be a ``gender_id`` in each row
 that will be "M" or "F" and a ``gender`` in each row that will be "Male" or

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -372,7 +372,7 @@ def _field_schema(aggregate=True, use_registry=False):
     if aggregate:
         aggr = S.String(
             required=False,
-            allowed=aggregations.keys(),
+            allowed=list(aggregations.keys()),
             default=default_aggregation,
             nullable=True
         )

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -3,10 +3,13 @@ Registers recipe schemas
 """
 
 import logging
+import re
 from collections import OrderedDict
 from copy import deepcopy
 
 from cerberus import schema_registry
+from sqlalchemy import distinct, func
+from sureberus import schema as S
 
 logging.captureWarnings(True)
 
@@ -238,7 +241,6 @@ def _coerce_filter(v):
     return validator.document
 
 
-# This schema is used with sureberus
 recipe_schema = {
     'type': 'dict',
     'schema': {
@@ -246,17 +248,23 @@ recipe_schema = {
         # class.
         'metrics': {
             'type': 'list',
-            'schema': {'type': 'string'},
+            'schema': {
+                'type': 'string'
+            },
         },
         'dimensions': {
             'type': 'list',
-            'schema': {'type': 'string'},
+            'schema': {
+                'type': 'string'
+            },
         },
         'filters': {
             'type': 'list',
             'schema': {
                 'oneof': [
-                    {'type': 'string'},
+                    {
+                        'type': 'string'
+                    },
                     {
                         'type': 'dict',
                         'coerce': _coerce_filter,
@@ -266,7 +274,213 @@ recipe_schema = {
         },
         'order_by': {
             'type': 'list',
-            'schema': {'type': 'string'},
+            'schema': {
+                'type': 'string'
+            },
         },
     }
 }
+
+condition_schema = {}
+# """
+# state:
+#     kind: LookupDimension
+#     field: state
+#     lookup:
+#         Vermont: "The Green Mountain State"
+#         Tennessee: "The Volunteer State"
+# pop2000:
+#     kind: Metric
+#     field:
+#         value: pop2000
+#         condition:
+#             field: age
+#             gt: 40
+# allthemath:
+#     kind: Metric
+#     field: pop2000+pop2008   - pop2000 * pop2008 /pop2000
+# """
+
+default_aggregation = 'sum'
+no_aggregation = 'none'
+aggregations = {
+    'sum': func.sum,
+    'min': func.min,
+    'max': func.max,
+    'avg': func.avg,
+    'count': func.count,
+    'count_distinct': lambda fld: func.count(distinct(fld)),
+    'month': lambda fld: func.date_trunc('month', fld),
+    'week': lambda fld: func.date_trunc('week', fld),
+    'year': lambda fld: func.date_trunc('year', fld),
+    'quarter': lambda fld: func.date_trunc('quarter', fld),
+    'age': lambda fld: func.date_part('year', func.age(fld)),
+    'none': lambda fld: fld,
+    None: lambda fld: fld,
+}
+
+aggr_keys = '|'.join(
+    k for k in aggregations.keys() if isinstance(k, basestring)
+)
+# Match patterns like sum(a)
+field_pattern = re.compile('^({})\((.*)\)$'.format(aggr_keys))
+
+
+def _coerce_string_into_field(value):
+    """ Convert a string into a field """
+    if isinstance(value, basestring):
+        value = value.strip()
+        m = re.match(field_pattern, value)
+        if m:
+            aggr, value = m.groups()
+            return {'value': value, 'aggregation': aggr}
+        else:
+            return {'value': value}
+    else:
+        return value
+
+
+def coerce_aggregations(doc):
+    doc['_aggregation_fn'] = aggregations.get(doc['aggregation'])
+    return doc
+
+
+non_aggregation = S.String(
+    required=False,
+    allowed=[no_aggregation, None],
+    default=no_aggregation,
+    nullable=True
+)
+aggregation = S.String(
+    required=False,
+    allowed=list(aggregations.keys()),
+    default=default_aggregation,
+    nullable=True
+)
+
+
+def _field_schema(aggregation_strategy):
+    """Make a field schema that either aggregates or doesn't. """
+    return S.Dict(
+        schema={
+            'value': S.String(),
+            'aggregation': aggregation_strategy,
+            'condition': S.Dict(required=False)
+        },
+        coerce=_coerce_string_into_field,
+        coerce_post=coerce_aggregations,
+        allow_unknown=False,
+        required=True,
+    )
+
+
+aggregated_field_schema = _field_schema(aggregation)
+non_aggregated_field_schema = _field_schema(non_aggregation)
+metric_schema = S.Dict(
+    allow_unknown=True, schema={
+        'field': aggregated_field_schema
+    }
+)
+dimension_schema = S.Dict(
+    allow_unknown=True, schema={
+        'field': non_aggregated_field_schema
+    }
+)
+
+ingredient_schema = S.DictWhenKeyIs(
+    'kind', {
+        'Metric': metric_schema,
+        'Dimension': dimension_schema
+    }
+)
+
+
+def _condition_schema():
+    return {
+        # 'registry': {
+        #     'condition': {
+        #         'type': 'dict',
+        #         'schema': {
+        #             'oneof': [
+        #                 'and': {
+        #                     'type': 'list',
+        #                     'schema_ref': 'condition'
+        #                 },
+        #                 'or': {
+        #                     'type': 'list',
+        #                     'schema_ref': 'condition'
+        #                 },
+        #                 'field':  _field_schema()
+        #             ]
+        #         }
+        #     }
+        # },
+        'type': 'dict',
+        'schema': _field_schema,
+        # 'schema_ref': 'condition'
+    }
+
+
+condition_schema = _condition_schema()
+
+# Operators are an option for fields
+# """
+# # sum(mytable.foo+mytable.bar)
+# op:
+#     field:
+#         add:
+#         - value: foo
+#         - value: bar
+#         aggregation: sum
+# # max(mytable.foo - mytable.bar)
+# op2:
+#     field:
+#         sub:
+#         - value: foo
+#         - value: bar
+#         aggregation: max
+# # naive divide, see divide_by for divide w strategy
+# # sum((mytable.x+mytable.y+mytable.z)/(mytable.xx-mytable.yy))
+# # sub,div,mul are binary operators, add is multi
+# op3:
+#     field:
+#         div:
+#             - add:
+#                 - x
+#                 - y
+#                 - x
+#             - sub:
+#                 - xx
+#                 - yy
+# # naive weighted avg expressed w operators
+# op4:
+#     field:
+#         div:
+#             - mul:
+#                 - expr
+#                 - wt
+#             - wt
+# # Anywhere a field is displayed
+# """
+
+
+def _operator_schema():
+    return {
+        'registry': {
+            'nested_list': {
+                'type': 'list',
+                'schema': {
+                    'anyof': [
+                        {
+                            'type': 'string'
+                        },
+                        'nested_list',
+                    ],
+                }
+            }
+        },
+        'type': 'dict',
+        'schema': {
+            'things': 'nested_list'
+        },
+    }

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -243,6 +243,7 @@ def _coerce_filter(v):
     return validator.document
 
 
+# This schema is used with sureberus
 recipe_schema = {
     'type': 'dict',
     'schema': {

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -11,6 +11,8 @@ from cerberus import schema_registry
 from sqlalchemy import distinct, func
 from sureberus import schema as S
 
+from recipe.compat import basestring
+
 logging.captureWarnings(True)
 
 IdValueDimensionFields = OrderedDict()
@@ -281,26 +283,6 @@ recipe_schema = {
     }
 }
 
-condition_schema = {}
-# """
-# state:
-#     kind: LookupDimension
-#     field: state
-#     lookup:
-#         Vermont: "The Green Mountain State"
-#         Tennessee: "The Volunteer State"
-# pop2000:
-#     kind: Metric
-#     field:
-#         value: pop2000
-#         condition:
-#             field: age
-#             gt: 40
-# allthemath:
-#     kind: Metric
-#     field: pop2000+pop2008   - pop2000 * pop2008 /pop2000
-# """
-
 format_lookup = {
     'comma': ',.0f',
     'dollar': '$,.0f',
@@ -431,29 +413,6 @@ def _field_schema(aggregate=True, use_registry=False):
         allow_unknown=False,
         required=True,
     )
-
-    # # add, sub, mul, div operators can be performed with fields
-    # add_list_field = S.Dict(
-    #     schema={
-    #         'add': S.List(schema=field_schema, required=True)
-    #     }, allow_unknown=False)
-    # mul_list_field = S.Dict(
-    #     schema={
-    #         'mul': S.List(schema=field_schema)
-    #     }, allow_unknown=False)
-    # sub_list_field = S.Dict(
-    #     schema={
-    #         'sub': S.List(maxlength=2, schema=field_schema)
-    #     }, allow_unknown=False)
-    # div_list_field = S.Dict(
-    #     schema={
-    #         'div': S.List(maxlength=2, schema=field_schema)
-    #     }, allow_unknown=False)
-    # return S.Dict(
-    #     anyof=[field_schema, add_list_field],
-    #     required=False,
-    #     allow_unknown=False)
-
     return field_schema
 
 
@@ -606,43 +565,3 @@ ingredient_schema = S.DictWhenKeyIs(
 shelf_schema = S.Dict(
     valueschema=ingredient_schema, keyschema=S.String(), allow_unknown=True
 )
-
-# Operators are an option for fields
-# """
-# # sum(mytable.foo+mytable.bar)
-# op:
-#     field:
-#         add:
-#         - value: foo
-#         - value: bar
-#         aggregation: sum
-# # max(mytable.foo - mytable.bar)
-# op2:
-#     field:
-#         sub:
-#         - value: foo
-#         - value: bar
-#         aggregation: max
-# # naive divide, see divide_by for divide w strategy
-# # sum((mytable.x+mytable.y+mytable.z)/(mytable.xx-mytable.yy))
-# # sub,div,mul are binary operators, add is multi
-# op3:
-#     field:
-#         div:
-#             - add:
-#                 - x
-#                 - y
-#                 - x
-#             - sub:
-#                 - xx
-#                 - yy
-# # naive weighted avg expressed w operators
-# op4:
-#     field:
-#         div:
-#             - mul:
-#                 - expr
-#                 - wt
-#             - wt
-# # Anywhere a field is displayed
-# """

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -389,6 +389,71 @@ def parse_validated_field(fld, selectable):
     return field
 
 
+def parse_sureberus_validated_condition(cond, selectable):
+    """ Convert a validated condition into a SQLAlchemy boolean expression """
+    if cond is None:
+        return
+
+    if 'and' in cond:
+        conditions = []
+        for c in cond.get('and', []):
+            conditions.append(
+                parse_sureberus_validated_condition(c, selectable)
+            )
+        return and_(*conditions)
+
+    elif 'or' in cond:
+        conditions = []
+        for c in cond.get('or', []):
+            conditions.append(
+                parse_sureberus_validated_condition(c, selectable)
+            )
+        return or_(*conditions)
+
+    elif 'field' in cond:
+        field = parse_sureberus_validated_field(cond.get('field'), selectable)
+        _op = cond.get('_op')
+        _op_value = cond.get('_op_value')
+        return getattr(field, _op)(_op_value)
+
+
+def parse_sureberus_validated_field(fld, selectable):
+    """ Converts a validated field to sqlalchemy. Field references are
+    looked up in selectable """
+    if fld is None:
+        return
+
+    field = find_column(selectable, fld['value'])
+
+    # Apply a condition if it exists
+    cond = parse_sureberus_validated_condition(
+        fld.get('condition', None), selectable
+    )
+    if cond is not None:
+        field = case([(cond, field)])
+
+    aggr_fn = fld.get('_aggregation_fn', lambda x: x)
+    return aggr_fn(field)
+
+
+def ingredient_from_sureberus_validated_dict(ingr_dict, selectable):
+    """ Create an ingredient from an dictionary.
+
+    This object will be deserialized from yaml """
+
+    kind = ingr_dict.pop('kind', 'Metric')
+    IngredientClass = ingredient_class_for_name(kind)
+
+    if IngredientClass is None:
+        raise BadIngredient('Unknown ingredient kind')
+
+    args = []
+    field = ingr_dict.pop('field', None)
+    args.append(parse_sureberus_validated_field(field, selectable))
+
+    return IngredientClass(*args, **ingr_dict)
+
+
 def ingredient_from_validated_dict(ingr_dict, selectable):
     """ Create an ingredient from an dictionary.
 
@@ -601,7 +666,7 @@ class Shelf(object):
         cls,
         obj,
         selectable,
-        ingredient_constructor=ingredient_from_validated_dict,
+        ingredient_constructor=ingredient_from_sureberus_validated_dict,
         metadata=None
     ):
         """Create a shelf using a dict shelf definition.
@@ -631,10 +696,22 @@ class Shelf(object):
                 autoload=True
             )
 
-        d = {}
-        for k, v in iteritems(obj):
-            d[k] = ingredient_constructor(v, selectable)
-        shelf = cls(d, select_from=selectable)
+        if ingredient_constructor is ingredient_from_sureberus_validated_dict:
+            from .schemas import shelf_schema
+            from sureberus import normalize_schema
+            validated_shelf = normalize_schema(
+                shelf_schema, obj, allow_unknown=True
+            )
+            d = {}
+            for k, v in iteritems(validated_shelf):
+                d[k] = ingredient_constructor(v, selectable)
+            shelf = cls(d, select_from=selectable)
+        else:
+            d = {}
+            for k, v in iteritems(obj):
+                d[k] = ingredient_constructor(v, selectable)
+            shelf = cls(d, select_from=selectable)
+
         return shelf
 
     @classmethod

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -425,6 +425,19 @@ def parse_sureberus_validated_field(fld, selectable):
 
     field = find_column(selectable, fld['value'])
 
+    operator_lookup = {
+        'add': lambda fld: getattr(fld, '__add__'),
+        'sub': lambda fld: getattr(fld, '__sub__'),
+        'div': lambda fld: getattr(fld, '__div__'),
+        'mul': lambda fld: getattr(fld, '__mul__'),
+    }
+    for operator in fld.get('operators', []):
+        op = operator['operator']
+        other_field = parse_sureberus_validated_field(
+            operator['field'], selectable
+        )
+        field = operator_lookup[op](field)(other_field)
+
     # Apply a condition if it exists
     cond = parse_sureberus_validated_condition(
         fld.get('condition', None), selectable

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ stevedore==1.27.1
 tablib==0.12.1
 Cerberus==1.2
 pyyaml>=4.2b1
-sureberus==0.2
+sureberus==0.7

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -40,6 +40,44 @@ def test_field_format():
     }
 
 
+def test_field_operators():
+    f = aggregated_field_schema
+    x = normalize_schema(f, 'foo   + moo', allow_unknown=False)
+    assert x == {
+        'value': 'foo',
+        'operators': [{
+            'operator': 'add',
+            'field': {
+                'value': 'moo'
+            }
+        }],
+        '_aggregation_fn': ANY,
+        'aggregation': 'sum'
+    }
+
+    f = aggregated_field_schema
+    x = normalize_schema(f, 'foo   + moo / cows', allow_unknown=False)
+    assert x == {
+        'value':
+            'foo',
+        'operators': [{
+            'operator': 'add',
+            'field': {
+                'value': 'moo'
+            }
+        }, {
+            'operator': 'div',
+            'field': {
+                'value': 'cows'
+            }
+        }],
+        '_aggregation_fn':
+            ANY,
+        'aggregation':
+            'sum'
+    }
+
+
 def test_aggregated_field_schema():
     x = normalize_schema(aggregated_field_schema, 'foo', allow_unknown=False)
     assert x == {'value': 'foo', '_aggregation_fn': ANY, 'aggregation': 'sum'}

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,9 +2,8 @@
 
 import pytest
 from mock import ANY
-from sqlalchemy import funcfilter
 from sureberus import errors as E
-from sureberus import normalize_dict, normalize_schema
+from sureberus import normalize_schema
 
 from recipe.schemas import (
     aggregated_field_schema, condition_schema, ingredient_schema,

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,131 @@
+import pytest
+from mock import ANY
+from sqlalchemy import funcfilter
+from sureberus import errors as E
+from sureberus import normalize_dict, normalize_schema
+
+from recipe.schemas import (
+    aggregated_field_schema, condition_schema, metric_schema,
+    non_aggregated_field_schema
+)
+
+
+def test_field():
+    f = aggregated_field_schema
+    x = normalize_schema(f, {'value': 'foo'}, allow_unknown=False)
+    assert x == {'value': 'foo', '_aggregation_fn': ANY, 'aggregation': 'sum'}
+
+    f = aggregated_field_schema
+    x = normalize_schema(f, 'foo', allow_unknown=False)
+    assert x == {'value': 'foo', '_aggregation_fn': ANY, 'aggregation': 'sum'}
+
+    f = aggregated_field_schema
+    x = normalize_schema(f, 'max(a)', allow_unknown=False)
+    assert x == {'value': 'a', '_aggregation_fn': ANY, 'aggregation': 'max'}
+
+
+def test_aggregated_field_schema():
+    x = normalize_schema(aggregated_field_schema, 'foo', allow_unknown=False)
+    assert x == {'value': 'foo', '_aggregation_fn': ANY, 'aggregation': 'sum'}
+
+    x = normalize_schema(
+        aggregated_field_schema, {'value': 'moo',
+                                  'aggregation': 'max'},
+        allow_unknown=False
+    )
+    assert x == {'value': 'moo', '_aggregation_fn': ANY, 'aggregation': 'max'}
+
+    x = normalize_schema(
+        aggregated_field_schema, {'value': 'moo',
+                                  'aggregation': None},
+        allow_unknown=False
+    )
+    assert x == {'value': 'moo', '_aggregation_fn': ANY, 'aggregation': None}
+
+    with pytest.raises(E.DisallowedValue):
+        normalize_schema(
+            aggregated_field_schema, {'value': 'moo',
+                                      'aggregation': 'squee'},
+            allow_unknown=False
+        )
+
+
+def test_non_aggregated_field_schema():
+    x = normalize_schema(
+        non_aggregated_field_schema, 'foo', allow_unknown=False
+    )
+    assert x == {'value': 'foo', '_aggregation_fn': ANY, 'aggregation': 'none'}
+
+    x = normalize_schema(
+        non_aggregated_field_schema, {'value': 'moo',
+                                      'aggregation': 'none'},
+        allow_unknown=False
+    )
+    assert x == {'value': 'moo', '_aggregation_fn': ANY, 'aggregation': 'none'}
+
+    x = normalize_schema(
+        non_aggregated_field_schema, {'value': 'moo',
+                                      'aggregation': None},
+        allow_unknown=False
+    )
+    assert x == {'value': 'moo', '_aggregation_fn': ANY, 'aggregation': None}
+
+    with pytest.raises(E.DisallowedValue):
+        normalize_schema(
+            non_aggregated_field_schema,
+            {'value': 'moo',
+             'aggregation': 'max'},
+            allow_unknown=False
+        )
+
+    with pytest.raises(E.DisallowedValue):
+        normalize_schema(
+            non_aggregated_field_schema,
+            {'value': 'moo',
+             'aggregation': 'squee'},
+            allow_unknown=False
+        )
+
+
+def test_metric():
+    x = normalize_schema(metric_schema, {'field': 'foo'}, allow_unknown=False)
+    assert x == {
+        'field': {
+            'value': 'foo',
+            '_aggregation_fn': ANY,
+            'aggregation': 'sum'
+        }
+    }
+
+
+def test_valid_metric():
+    valid_metrics = [{
+        'field': 'foo',
+        'icon': 'squee'
+    }, {
+        'field': 'foo',
+        'aggregation': 'sum',
+        'icon': 'squee'
+    }, {
+        'field': 'foo',
+        'condition': {}
+    }]
+
+    for m in valid_metrics:
+        normalize_schema(metric_schema, m)
+
+
+def test_invalid_metric():
+    invalid_metrics = [{
+        'field': {
+            'value': 'foo',
+            'aggregation': 'squee'
+        },
+        'icon': 'squee'
+    }, {
+        'icon': 'squee'
+    }]
+
+    for m in invalid_metrics:
+        with pytest.raises(Exception):
+            normalize_schema(metric_schema, m)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -7,8 +7,8 @@ from sureberus import errors as E
 from sureberus import normalize_dict, normalize_schema
 
 from recipe.schemas import (
-    _field_schema, aggregated_field_schema, condition_schema,
-    ingredient_schema, metric_schema, non_aggregated_field_schema
+    aggregated_field_schema, condition_schema, ingredient_schema,
+    metric_schema, non_aggregated_field_schema, shelf_schema
 )
 
 
@@ -24,6 +24,20 @@ def test_field():
     f = aggregated_field_schema
     x = normalize_schema(f, 'max(a)', allow_unknown=False)
     assert x == {'value': 'a', '_aggregation_fn': ANY, 'aggregation': 'max'}
+
+
+def test_field_format():
+    f = aggregated_field_schema
+    x = normalize_schema(
+        f, {'value': 'foo',
+            'format': 'comma'}, allow_unknown=False
+    )
+    assert x == {
+        'value': 'foo',
+        '_aggregation_fn': ANY,
+        'aggregation': 'sum',
+        'format': ',.0f'
+    }
 
 
 def test_aggregated_field_schema():
@@ -184,7 +198,7 @@ def test_condition():
             'aggregation': 'none',
             'value': 'foo'
         },
-        '_op': 'gt'
+        '_op': '__gt__'
     }
 
 
@@ -209,7 +223,7 @@ def test_and_condition():
                 'value': 'foo'
             },
             '_op_value': [22, 44, 55],
-            '_op': 'in'
+            '_op': 'in_'
         }, {
             'field': {
                 '_aggregation_fn': ANY,
@@ -344,10 +358,25 @@ def test_ingredient():
                     'aggregation': 'none',
                     'value': 'moo'
                 },
-                '_op': 'gt',
+                '_op': '__gt__',
                 '_op_value': 'cow'
             },
             '_aggregation_fn': ANY
         },
         'kind': 'Metric'
+    }
+
+
+def test_shelf():
+    v = {'foo': {'kind': 'Metric', 'field': 'foo'}}
+    x = normalize_schema(shelf_schema, v, allow_unknown=False)
+    assert x == {
+        'foo': {
+            'field': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'sum',
+                'value': 'foo'
+            },
+            'kind': 'Metric'
+        }
     }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,3 +1,5 @@
+""" Test sureberus schemas """
+
 import pytest
 from mock import ANY
 from sqlalchemy import funcfilter
@@ -186,6 +188,40 @@ def test_condition():
     }
 
 
+def test_and_condition():
+    x = normalize_schema(
+        condition_schema, {
+            'and': [{
+                'field': 'foo',
+                'in': [22, 44, 55]
+            }, {
+                'field': 'foo',
+                'notin': [41]
+            }]
+        },
+        allow_unknown=False
+    )
+    assert x == {
+        'and': [{
+            'field': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'none',
+                'value': 'foo'
+            },
+            '_op_value': [22, 44, 55],
+            '_op': 'in'
+        }, {
+            'field': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'none',
+                'value': 'foo'
+            },
+            '_op': 'notin',
+            '_op_value': [41]
+        }]
+    }
+
+
 def test_valid_conditions():
     conditions = [
         {
@@ -219,6 +255,15 @@ def test_valid_conditions():
         {
             'field': 'foo',
             'in': [22, 44, 55]
+        },
+        {
+            'and': [{
+                'field': 'foo',
+                'in': [22, 44, 55]
+            }, {
+                'field': 'foo',
+                'notin': [41]
+            }]
         },
     ]
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -4,14 +4,13 @@ from copy import deepcopy
 
 import pytest
 from mock import ANY
-from sureberus import errors as E
 from sureberus import normalize_schema
 
 from recipe.schemas import shelf_schema
 
 
 def test_field_parsing():
-    v = {'foo': {'kind': 'Metric', 'field': {'value': 'foo',}}}
+    v = {'foo': {'kind': 'Metric', 'field': {'value': 'foo'}}}
     x = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert x == {
         'foo': {

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -551,7 +551,7 @@ oldage:
         aggregation: null
 '''
         self.make_shelf(content)
-        # null conditions are ignored.
+        # Explicit null aggregations are respected, even in metrics
         assert str(self.shelf['oldage']) == '(Metric)oldage MyTable.age'
 
 

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -542,6 +542,18 @@ oldage:
         with pytest.raises(Exception):
             self.make_shelf(content)
 
+    def test_null_aggregation(self):
+        content = '''
+oldage:
+    kind: Metric
+    field:
+        value: age
+        aggregation: null
+'''
+        self.make_shelf(content)
+        # null conditions are ignored.
+        assert str(self.shelf['oldage']) == '(Metric)oldage MyTable.age'
+
 
 class TestShelfFromConfig(TestShelfFromValidatedYaml):
 


### PR DESCRIPTION
This is a first part of doing more advanced work with ingredients.yaml.

This converts normalization to use sureberus (https://github.com/radix/sureberus/)

### Overview

Recipe ingredients contain fields and conditions. These can are used recursively. Fields can be defined using conditions and conditions can in turn use fields. Here's an example.

```
field:
  value: sales
  aggregation: sum
  condition:
     field: region
     eq: 'NE'
```

This would be evaluated to SQLAlchemy

```
func.sum(case([table.region == 'NE', table.sales]))
```

Field can either be a concise string referencing a column, or a dictionary that supplies additional aggregations and conditions.

The existing Cerberus validation **lightly validates** then uses more custom logic to turn the validated ingredient into a SQLAlchemy object.

The new sureberus approach validates and transforms more aggressively to make less work when creating SQLAlchemy objects. 

### Improvements & Changes

1. Full shelf validation in one shot. Existing validation happens on an ingredient by ingredient basis.
2. sureberus has a nicer syntax `DictWhenKeyExists` for defining conditions that is used instead of custom code `_validate_condition_keys` that was used in the Cerberus validation.
3. field aggregations in strings.

when converting a string to a field, if the string matches a "functional" form like `max(sales_dollars)` this gets converted into

```
{ 
  "value": "sales_dollars"
  "aggregation": "max" 
}
```

Previously, users would have to generate this on their own.

### Follow on work

- Remove Cerberus and cerberus validation code.
- Fix how IdValueDimension, WtdAvgMetric, DivideMetric are handled in the schema.
- Allow referencing other ingredient fields and conditions when defining an ingredient.
- Convert operators w sureberus rather than using the existing messy parsing process.
- Create and validate reusable "quickfilters" which will be conditions.
