### PR TITLE
Support divide_by allowing WtdAvgMetric/DivideMetric to be accomplished in regular metric syntax

### DIFF
--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -183,10 +183,18 @@ def ingredient_from_validated_dict(ingr_dict, selectable):
     if IngredientClass is None:
         raise BadIngredient('Unknown ingredient kind')
 
-    args = []
     field = ingr_dict.pop('field', None)
-    args.append(parse_validated_field(field, selectable))
+    divide_by = ingr_dict.pop('divide_by', None)
+    field = parse_validated_field(field, selectable)
+    if divide_by is not None:
+        # Perform a divide by zero safe division
+        divide_by = parse_validated_field(divide_by, selectable)
+        epsilon = 0.000000001
+        field = cast(field, Float) / (
+            func.coalesce(cast(divide_by, Float), 0.0) + epsilon
+        )
 
+    args = [field]
     # Each extra field contains a name and a field
     for extra in ingr_dict.pop('extra_fields', []):
         ingr_dict[extra.get('name')] = \

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -236,6 +236,26 @@ def test_field_operators():
     }
 
 
+def test_field_divide_by():
+    v = {'foo': {'kind': 'Metric', 'field': 'foo', 'divide_by': 'moo'}}
+    x = normalize_schema(shelf_schema, v, allow_unknown=False)
+    assert x == {
+        'foo': {
+            'divide_by': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'sum',
+                'value': 'moo'
+            },
+            'field': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'sum',
+                'value': 'foo'
+            },
+            'kind': 'Metric'
+        }
+    }
+
+
 def test_valid_metric():
     valid_metrics = [{
         'kind': 'Metric',


### PR DESCRIPTION
Add `divide_by` to Metric

## `divide_by`

`divide_by`  is an optional aggregated field that exists on Metric. If divide_by exists, `field` will be divided by `divide_by` in a divide-by-zero-in-SQL-safe-manner.

## Supporting DivideMetric and WtdAvgMetric in config.

DivideMetric and WtdAvgMetric are kinds of Metrics that we used to support.

Here's how these would have been defined in the past.

```
# old syntax
sales_per_user:
  kind: DivideMetric
  numerator_field: sales
  denominator_field:
    value: user
    aggregation: count_distinct
```

With this new syntax, here's how you can define this now (also showing the functional form of defining aggregations)

```
# new syntax
sales_per_user
  kind: Metric
  field: sales
  divide_by: count_distinct(user)
```

When a DivideMetric is presented in config, it is rewritten to the new config before the config is processed in `_adjust_kinds`.

Similarly for WtdAvgMetric

```
# old syntax
avgage:
  kind: WtdAvgMetric
  field: avgage
  weight: population
```

With this new syntax, here's how you can define this now (also showing the functional form of defining aggregations)

```
# new syntax
avgage:
  kind: Metric
  field: avgage*population
  divide_by: population
```

When a WtdAvgMetric is presented in config, it is rewritten to the new config before the config is processed in `_adjust_kinds`. However, this will fail if the `field` or `weight` are not strings. WtdAvgMetric is infrequently used in recipe.