### PR TITLE
Allow ingredients to reference other ingredient's fields

### DIFF
--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -348,6 +348,32 @@ def _adjust_kinds(value):
     return value
 
 
+def _process_ingredient(ingr, shelf):
+    val = ingr.get('field', {}).get('value', '')
+    if val.startswith('@'):
+        ref = val[1:]
+        if ref in shelf and 'field' in shelf.get(ref):
+            # replace the ingredients field with the reference
+            ingr['field'] = shelf[ref]['field']
+
+    val = ingr.get('divide_by', {}).get('value', '')
+    if val.startswith('@'):
+        ref = val[1:]
+        if ref in shelf and 'field' in shelf.get(ref):
+            # replace the ingredients field with the reference
+            ingr['divide_by'] = shelf[ref]['field']
+
+
+def _replace_references(shelf):
+    """ Iterate over the shelf and replace and field.value: @ references
+    with the field in another ingredient """
+    from pprint import pprint
+    pprint(shelf)
+    for ingr in shelf.values():
+        _process_ingredient(ingr, shelf)
+    return shelf
+
+
 condition_schema = _full_condition_schema(aggr=False)
 
 quickfilter_schema = S.List(
@@ -431,7 +457,10 @@ ingredient_schema = S.DictWhenKeyIs(
 )
 
 shelf_schema = S.Dict(
-    valueschema=ingredient_schema, keyschema=S.String(), allow_unknown=True
+    valueschema=ingredient_schema,
+    keyschema=S.String(),
+    allow_unknown=True,
+    coerce_post=_replace_references
 )
 
 # This schema is used with sureberus

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -89,6 +89,9 @@ def _coerce_string_into_field(value, search_for_operators=True):
     """ Convert a string into a field, potentially parsing a functional
     form into a value and aggregation """
     if isinstance(value, basestring):
+        if value.startswith('@'):
+            return {'value': value[1:], 'ref': value[1:]}
+
         # Remove all whitespace
         value = re.sub(r'\s+', '', value, flags=re.UNICODE)
         m = re.match(field_pattern, value)
@@ -172,6 +175,8 @@ def _field_schema(aggr=True, required=True):
                 S.String(),
             'aggregation':
                 ag,
+            'ref':
+                S.String(required=False),
             'condition':
                 'condition',
             'operators':
@@ -377,19 +382,15 @@ def _adjust_kinds(value):
 def _process_ingredient(ingr, shelf):
     # TODO: Support condition references (to filters, dimension/metric
     #  quickfilters, and to field conditions)
-    val = ingr.get('field', {}).get('value', '')
-    if val.startswith('@'):
-        ref = val[1:]
-        if ref in shelf and 'field' in shelf.get(ref):
-            # replace the ingredients field with the reference
-            ingr['field'] = shelf[ref]['field']
+    ref = ingr.get('field', {}).get('ref', '')
+    if ref and ref in shelf and 'field' in shelf.get(ref):
+        # replace the ingredients field with the reference
+        ingr['field'] = shelf[ref]['field']
 
-    val = ingr.get('divide_by', {}).get('value', '')
-    if val.startswith('@'):
-        ref = val[1:]
-        if ref in shelf and 'field' in shelf.get(ref):
-            # replace the ingredients field with the reference
-            ingr['divide_by'] = shelf[ref]['field']
+    ref = ingr.get('divide_by', {}).get('ref', '')
+    if ref and ref in shelf and 'field' in shelf.get(ref):
+        # replace the ingredients field with the reference
+        ingr['divide_by'] = shelf[ref]['field']
 
 
 def _replace_references(shelf):

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -386,28 +386,34 @@ def _replace_refs_in_field(fld, shelf):
         ref = fld['ref']
         if ref in shelf:
             # FIXME: what to do if you can't find the ref
-            fld = shelf[ref]['field']
+            try:
+                fld = shelf[ref]['field']
+            except Exception as e:
+                pass
+    else:
+        # Replace conditions and operators within the field
+        if 'condition' in fld and isinstance(fld['condition'], dict):
+            cond = fld['condition']
+            if 'ref' in cond:
+                cond_ref = cond['ref']
+                # FIXME: what to do if you can't find the ref
+                # What if the field doesn't have a condition
+                try:
+                    new_cond = shelf[cond_ref]['field'].get('condition')
+                    if new_cond is None:
+                        fld.pop('condition', None)
+                    else:
+                        fld['condition'] = new_cond
+                except Exception as e:
+                    pass
 
-    # Replace conditions
-    if 'condition' in fld and isinstance(fld['condition'], dict):
-        cond = fld['condition']
-        if 'ref' in cond:
-            cond_ref = cond['ref']
-            # FIXME: what to do if you can't find the ref
-            # What if the field doesn't have a condition
-            new_cond = shelf[cond_ref]['field'].get('condition')
-            if new_cond is None:
-                fld.pop('condition', None)
-            else:
-                fld['condition'] = new_cond
-
-    if 'operators' in fld:
-        # Walk the operators and replace field references
-        new_operators = [{
-            'operator': op['operator'],
-            'field': _replace_refs_in_field(op['field'], shelf)
-        } for op in fld['operators']]
-        fld['operators'] = new_operators
+        if 'operators' in fld:
+            # Walk the operators and replace field references
+            new_operators = [{
+                'operator': op['operator'],
+                'field': _replace_refs_in_field(op['field'], shelf)
+            } for op in fld['operators']]
+            fld['operators'] = new_operators
 
     return fld
 

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -397,10 +397,7 @@ def _replace_refs_in_field(fld, shelf):
         ref = fld['ref']
         if ref in shelf:
             # FIXME: what to do if you can't find the ref
-            try:
-                fld = shelf[ref]['field']
-            except Exception:
-                pass
+            fld = shelf[ref]['field']
     else:
         # Replace conditions and operators within the field
         if 'condition' in fld and isinstance(fld['condition'], dict):
@@ -409,14 +406,11 @@ def _replace_refs_in_field(fld, shelf):
                 cond_ref = cond['ref']
                 # FIXME: what to do if you can't find the ref
                 # What if the field doesn't have a condition
-                try:
-                    new_cond = shelf[cond_ref]['field'].get('condition')
-                    if new_cond is None:
-                        fld.pop('condition', None)
-                    else:
-                        fld['condition'] = new_cond
-                except Exception:
-                    pass
+                new_cond = shelf[cond_ref]['field'].get('condition')
+                if new_cond is None:
+                    fld.pop('condition', None)
+                else:
+                    fld['condition'] = new_cond
 
         if 'operators' in fld:
             # Walk the operators and replace field references

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -121,6 +121,11 @@ def _coerce_string_into_field(value, search_for_operators=True):
             if operators:
                 result['operators'] = operators
             return result
+    elif isinstance(value, dict):
+        # Removing these fields which are added in validation allows
+        # a schema to be validated more than once without harm
+        value.pop('_aggregation_fn', None)
+        return value
     else:
         return value
 
@@ -229,7 +234,6 @@ class ConditionPost(object):
             if not isinstance(_op_value, list):
                 _op_value = [_op_value]
         value['_op_value'] = _op_value
-        value.pop(self.operator)
         return value
 
 
@@ -264,6 +268,12 @@ def _condition_schema(operator, _op, scalar=True, aggr=False):
 def _coerce_string_into_condition_ref(cond):
     if isinstance(cond, basestring) and cond.startswith('@'):
         return {'ref': cond[1:]}
+    elif isinstance(cond, dict):
+        # Removing these fields which are added in validation allows
+        # a schema to be validated more than once without harm
+        cond.pop('_op', None)
+        cond.pop('_op_value', None)
+
     return cond
 
 
@@ -382,6 +392,7 @@ def _adjust_kinds(value):
 
 
 def _replace_refs_in_field(fld, shelf):
+    """ Replace refs in fields"""
     if 'ref' in fld:
         ref = fld['ref']
         if ref in shelf:

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -254,6 +254,12 @@ def _condition_schema(operator, _op, scalar=True, aggr=False):
     return _condition_schema
 
 
+def _coerce_string_into_condition_ref(cond):
+    if isinstance(cond, basestring) and cond.startswith('@'):
+        return {'ref': cond[1:]}
+    return cond
+
+
 def _full_condition_schema(aggr=False):
     """ Conditions can be a field with an operator, like this yaml example
 
@@ -274,25 +280,45 @@ def _full_condition_schema(aggr=False):
     """
 
     # Handle conditions where there's an operator
-    operator_condition = S.DictWhenKeyExists({
-        'gt': _condition_schema('gt', '__gt__', aggr=aggr),
-        'gte': _condition_schema('gte', '__ge__', aggr=aggr),
-        'ge': _condition_schema('ge', '__ge__', aggr=aggr),
-        'lt': _condition_schema('lt', '__lt__', aggr=aggr),
-        'lte': _condition_schema('lte', '__le__', aggr=aggr),
-        'le': _condition_schema('le', '__le__', aggr=aggr),
-        'eq': _condition_schema('eq', '__eq__', aggr=aggr),
-        'ne': _condition_schema('ne', '__ne__', aggr=aggr),
-        'in': _condition_schema('in', 'in_', scalar=False, aggr=aggr),
-        'notin': _condition_schema('notin', 'notin', scalar=False, aggr=aggr),
-        'or': S.Dict(schema={
-            'or': S.List(schema='condition')
-        }),
-        'and': S.Dict(schema={
-            'and': S.List(schema='condition')
-        }),
-    },
-                                             required=False)
+    operator_condition = S.DictWhenKeyExists(
+        {
+            'gt':
+                _condition_schema('gt', '__gt__', aggr=aggr),
+            'gte':
+                _condition_schema('gte', '__ge__', aggr=aggr),
+            'ge':
+                _condition_schema('ge', '__ge__', aggr=aggr),
+            'lt':
+                _condition_schema('lt', '__lt__', aggr=aggr),
+            'lte':
+                _condition_schema('lte', '__le__', aggr=aggr),
+            'le':
+                _condition_schema('le', '__le__', aggr=aggr),
+            'eq':
+                _condition_schema('eq', '__eq__', aggr=aggr),
+            'ne':
+                _condition_schema('ne', '__ne__', aggr=aggr),
+            'in':
+                _condition_schema('in', 'in_', scalar=False, aggr=aggr),
+            'notin':
+                _condition_schema('notin', 'notin', scalar=False, aggr=aggr),
+            'or':
+                S.Dict(schema={
+                    'or': S.List(schema='condition')
+                }),
+            'and':
+                S.Dict(schema={
+                    'and': S.List(schema='condition')
+                }),
+            # A reference to another condition
+            'ref':
+                S.Dict(schema={
+                    'ref': S.String()
+                })
+        },
+        required=False,
+        coerce=_coerce_string_into_condition_ref
+    )
 
     return {
         'registry': {

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -399,7 +399,7 @@ def _replace_refs_in_field(fld, shelf):
             # FIXME: what to do if you can't find the ref
             try:
                 fld = shelf[ref]['field']
-            except Exception as e:
+            except Exception:
                 pass
     else:
         # Replace conditions and operators within the field
@@ -415,7 +415,7 @@ def _replace_refs_in_field(fld, shelf):
                         fld.pop('condition', None)
                     else:
                         fld['condition'] = new_cond
-                except Exception as e:
+                except Exception:
                     pass
 
         if 'operators' in fld:

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -388,6 +388,19 @@ def _replace_refs_in_field(fld, shelf):
             # FIXME: what to do if you can't find the ref
             fld = shelf[ref]['field']
 
+    # Replace conditions
+    if 'condition' in fld and isinstance(fld['condition'], dict):
+        cond = fld['condition']
+        if 'ref' in cond:
+            cond_ref = cond['ref']
+            # FIXME: what to do if you can't find the ref
+            # What if the field doesn't have a condition
+            new_cond = shelf[cond_ref]['field'].get('condition')
+            if new_cond is None:
+                fld.pop('condition', None)
+            else:
+                fld['condition'] = new_cond
+
     if 'operators' in fld:
         # Walk the operators and replace field references
         new_operators = [{

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -349,6 +349,8 @@ def _adjust_kinds(value):
 
 
 def _process_ingredient(ingr, shelf):
+    # TODO: Support condition references (to filters, dimension/metric
+    #  quickfilters, and to field conditions)
     val = ingr.get('field', {}).get('value', '')
     if val.startswith('@'):
         ref = val[1:]
@@ -367,8 +369,6 @@ def _process_ingredient(ingr, shelf):
 def _replace_references(shelf):
     """ Iterate over the shelf and replace and field.value: @ references
     with the field in another ingredient """
-    from pprint import pprint
-    pprint(shelf)
     for ingr in shelf.values():
         _process_ingredient(ingr, shelf)
     return shelf

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -76,7 +76,7 @@ def find_operators(value):
 
     remaining_value = value[len(field):]
     if remaining_value:
-        for part in re.findall('[+-\/\*][\w\.]+', remaining_value):
+        for part in re.findall('[+-\/\*][\@\w\.]+', remaining_value):
             # TODO: Full validation on other fields
             other_field = _coerce_string_into_field(
                 part[1:], search_for_operators=False
@@ -90,7 +90,9 @@ def _coerce_string_into_field(value, search_for_operators=True):
     form into a value and aggregation """
     if isinstance(value, basestring):
         if value.startswith('@'):
-            return {'value': value[1:], 'ref': value[1:]}
+            result = _coerce_string_into_field(value[1:])
+            result['ref'] = result['value']
+            return result
 
         # Remove all whitespace
         value = re.sub(r'\s+', '', value, flags=re.UNICODE)

--- a/tests/ingredients/census_references.yaml
+++ b/tests/ingredients/census_references.yaml
@@ -14,6 +14,11 @@ pop2000:
 pop2008:
     kind: Metric
     field: pop2008
+pop2008oldsters:
+    kind: Metric
+    field:
+        value: pop2008
+        condition: '@pop2000'
 popdivide:
     kind: Metric
     field: '@pop2000'

--- a/tests/ingredients/census_references.yaml
+++ b/tests/ingredients/census_references.yaml
@@ -1,0 +1,20 @@
+state:
+    kind: Dimension
+    field: state
+    lookup:
+        Vermont: "The Green Mountain State"
+        Tennessee: "The Volunteer State"
+pop2000:
+    kind: Metric
+    field:
+        value: pop2000
+        condition:
+            field: age
+            gt: 40
+pop2008:
+    kind: Metric
+    field: pop2008
+popdivide:
+    kind: Metric
+    field: '@pop2000'
+    divide_by: '@pop2008'

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -182,24 +182,43 @@ Vermont,620602,The Green Mountain State,Vermont
         )
 
     def test_shelf_with_references(self):
-        """Build a recipe that uses metrics and dimensions defined using
-        references."""
+        """Build a recipe using a shelf that uses field references """
         shelf = self.validated_shelf('census_references.yaml', Census)
         recipe = Recipe(shelf=shelf, session=self.session).\
             dimensions('state').metrics('popdivide').order_by('state')
         assert recipe.to_sql() == '''SELECT census.state AS state_raw,
-CAST(sum(CASE
-WHEN (census.age > 40) THEN census.pop2000
-END) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS popdivide
+       CAST(sum(CASE
+                    WHEN (census.age > 40) THEN census.pop2000
+                END) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS popdivide
 FROM census
 GROUP BY census.state
 ORDER BY census.state'''  # noqa: E501
         self.assert_recipe_csv(
-           recipe, '''state_raw,popdivide,state,state_id
+            recipe, '''state_raw,popdivide,state,state_id
 Tennessee,0.3856763995010324,The Volunteer State,Tennessee
 Vermont,0.4374284968466095,The Green Mountain State,Vermont
 '''
-       )
+        )
+
+    def test_shelf_with_condition_references(self):
+        """Build a recipe using a shelf that uses condition references """
+        shelf = self.validated_shelf('census_references.yaml', Census)
+        recipe = Recipe(
+            shelf=shelf, session=self.session
+        ).dimensions('state').metrics('pop2008oldsters').order_by('state')
+        assert recipe.to_sql() == '''SELECT census.state AS state_raw,
+       sum(CASE
+               WHEN (census.age > 40) THEN census.pop2008
+           END) AS pop2008oldsters
+FROM census
+GROUP BY census.state
+ORDER BY census.state'''  # noqa: E501
+        self.assert_recipe_csv(
+            recipe, '''state_raw,pop2008oldsters,state,state_id
+Tennessee,2821955,The Volunteer State,Tennessee
+Vermont,311842,The Green Mountain State,Vermont
+'''
+        )
 
     def test_bad_census_from_validated_yaml(self):
         """ Test a bad yaml file """

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -193,7 +193,7 @@ WHEN (census.age > 40) THEN census.pop2000
 END) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS popdivide
 FROM census
 GROUP BY census.state
-ORDER BY census.state'''
+ORDER BY census.state'''  # noqa: E501
         self.assert_recipe_csv(
            recipe, '''state_raw,popdivide,state,state_id
 Tennessee,0.3856763995010324,The Volunteer State,Tennessee

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -133,7 +133,6 @@ def test_field_format():
 def test_field_ref():
     v = {'foo': {'kind': 'Metric', 'field': '@foo'}}
     x = normalize_schema(shelf_schema, v, allow_unknown=False)
-    print(x)
     assert x == {
         'foo': {
             'field': {
@@ -202,7 +201,6 @@ def test_find_operators():
 
         fld, operators = find_operators(v)
         operators = map(process_operator, operators)
-        print fld, operators
         assert fld == expected_fld
         assert operators == expected_operators
 
@@ -1094,7 +1092,6 @@ class TestValidateRecipe(object):
                 'gt': 3
             }]
         }
-        print(normalize_schema(recipe_schema, config))
         assert normalize_schema(recipe_schema, config) == {
             'metrics': ['foo'],
             'dimensions': ['bar'],

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -483,6 +483,9 @@ def test_condition_ref():
                 'value': 'a',
                 'condition': '@foo'
             }
+        },
+        'foo': {
+            'field': 'b'
         }
     }
     x = normalize_schema(shelf_schema, shelf, allow_unknown=False)
@@ -490,11 +493,16 @@ def test_condition_ref():
         'a': {
             'field': {
                 '_aggregation_fn': ANY,
-                'condition': {
-                    'ref': 'foo'
-                },
                 'aggregation': 'sum',
                 'value': 'a'
+            },
+            'kind': 'Metric'
+        },
+        'foo': {
+            'field': {
+                '_aggregation_fn': ANY,
+                'aggregation': 'sum',
+                'value': 'b'
             },
             'kind': 'Metric'
         }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -396,6 +396,32 @@ def test_and_condition():
     }
 
 
+def test_condition_ref():
+    shelf = {
+        'a': {
+            'kind': 'Metric',
+            'field': {
+                'value': 'a',
+                'condition': '@foo'
+            }
+        }
+    }
+    x = normalize_schema(shelf_schema, shelf, allow_unknown=False)
+    assert x == {
+        'a': {
+            'field': {
+                '_aggregation_fn': ANY,
+                'condition': {
+                    'ref': 'foo'
+                },
+                'aggregation': 'sum',
+                'value': 'a'
+            },
+            'kind': 'Metric'
+        }
+    }
+
+
 def test_valid_conditions():
     conditions = [
         {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -7,7 +7,9 @@ from mock import ANY
 from sureberus import errors as E
 from sureberus import normalize_schema
 
-from recipe.schemas import aggregations, recipe_schema, shelf_schema
+from recipe.schemas import (
+    aggregations, find_operators, recipe_schema, shelf_schema
+)
 
 
 def test_field_parsing():
@@ -126,6 +128,49 @@ def test_field_format():
             'format': ',.0f'
         }
     }
+
+
+def test_field_ref():
+    v = {'foo': {'kind': 'Metric', 'field': '@foo'}}
+    x = normalize_schema(shelf_schema, v, allow_unknown=False)
+    assert x == {
+        'foo': {
+            'field': {
+                '_aggregation_fn': ANY,
+                'ref': 'foo',
+                'aggregation': 'sum',
+                'value': 'foo'
+            },
+            'kind': 'Metric'
+        }
+    }
+
+    # v = {'foo': {'kind': 'Metric', 'field': '@foo + @moo'}}
+    # x = normalize_schema(shelf_schema, v, allow_unknown=False)
+    # print(x)
+    # assert x == {
+    #     'foo': {
+    #         'field': {
+    #             '_aggregation_fn': ANY,
+    #             'ref': 'foo',
+    #             'aggregation': 'sum',
+    #             'value': 'foo'
+    #         },
+    #         'kind': 'Metric'
+    #     }
+    # }
+
+
+#
+# def test_find_operators():
+#     examples = [
+#         ('a+b', ('a', [{'operator': '+', 'field': 'b'}]))
+#     ]
+#
+#     for v, expected in examples:
+#         result = find_operators(v)
+#         print result
+#         assert result == expected
 
 
 def test_field_operators():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -200,7 +200,7 @@ def test_find_operators():
         v = re.sub(r'\s+', '', v, flags=re.UNICODE)
 
         fld, operators = find_operators(v)
-        operators = map(process_operator, operators)
+        operators = list(map(process_operator, operators))
         assert fld == expected_fld
         assert operators == expected_operators
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -454,6 +454,7 @@ def test_and_condition():
                             'aggregation': 'none',
                             'value': 'foo'
                         },
+                        'in': [22, 44, 55],
                         '_op_value': [22, 44, 55],
                         '_op': 'in_'
                     }, {
@@ -462,6 +463,7 @@ def test_and_condition():
                             'aggregation': 'none',
                             'value': 'foo'
                         },
+                        'notin': [41],
                         '_op': 'notin',
                         '_op_value': [41]
                     }]
@@ -634,6 +636,7 @@ def test_ingredient():
                         'aggregation': 'none',
                         'value': 'moo'
                     },
+                    'gt': 'cow',
                     '_op': '__gt__',
                     '_op_value': 'cow'
                 },
@@ -748,6 +751,7 @@ def test_valid_ingredients():
                         'aggregation': 'none',
                         'value': 'moo2'
                     },
+                    'in': 'wo',
                     '_op_value': ['wo'],
                     '_op': 'in_'
                 },
@@ -764,6 +768,13 @@ def test_valid_ingredients():
         v = {'a': deepcopy(ingr)}
         x = normalize_schema(shelf_schema, v, allow_unknown=False)
         assert expected_output == x['a']
+
+    # Test that a schema can be validated more than once without harm
+    for ingr, expected_output in examples:
+        v = {'a': deepcopy(ingr)}
+        x = normalize_schema(shelf_schema, v, allow_unknown=False)
+        y = normalize_schema(shelf_schema, x, allow_unknown=False)
+        assert expected_output == y['a']
 
 
 def test_invalid_ingredients():
@@ -982,6 +993,7 @@ def test_valid_ingredients_field_condition():
                 'aggregation': 'none',
                 'value': 'cow'
             },
+            'in': ['1', '2'],
             '_op_value': ['1', '2'],
             '_op': 'in_'
         }),
@@ -994,6 +1006,7 @@ def test_valid_ingredients_field_condition():
                 'aggregation': 'none',
                 'value': 'foo'
             },
+            'in': ['1', '2'],
             '_op_value': ['1', '2'],
             '_op': 'in_'
         }),
@@ -1007,6 +1020,7 @@ def test_valid_ingredients_field_condition():
                 'aggregation': 'none',
                 'value': 'foo'
             },
+            'in': '1',
             '_op_value': ['1'],
             '_op': 'in_'
         })
@@ -1101,6 +1115,7 @@ class TestValidateRecipe(object):
                     'aggregation': 'none',
                     'value': 'xyzzy'
                 },
+                'gt': 3,
                 '_op': '__gt__',
                 '_op_value': 3
             }]


### PR DESCRIPTION
NOTE: Requires `unify-metrics` branch to be merged.

This adds a new syntax for fields. `field: @ingredient-name` will reference another ingredient's field property and copy it to this location.

Here's a sample ingredients.yaml file. `popdivide` references other metrics.

```
state:
    kind: Dimension
    field: state
    lookup:
        Vermont: "The Green Mountain State"
        Tennessee: "The Volunteer State"
pop2000:
    kind: Metric
    field:
        value: pop2000
        condition:
            field: age
            gt: 40
pop2008:
    kind: Metric
    field: pop2008
popdivide:
    kind: Metric
    field: '@pop2000'
    divide_by: '@pop2008'
```

This is equivalent to 

```
popdivide:
    kind: Metric
    field:
        value: pop2000
        condition:
            field: age
            gt: 40
    divide_by: pop2008
```

## How it works

Fields and conditions can have string values that are references. References look like '@{id}'. These references are stored in a `ref` property on the field or condition. The shelf `coerce_post` replaces these references with appropriate values. Fields and operators are searched recursively so references can be replaced anywhere.

#### Reference syntax

Currently very simple, reference syntax for fields and conditions looks like

```
field: @{id}
divide_by: @{id}
id_field: @{id}
condition @{id}
```

This will replace the field with the validated `field` of the shelf's ingredient with id `{id}`. 
For conditions, this replaces the condition with the condition in the validated `field` of the shelf's ingredient with id `{id}`. 

## Bonus: Idempotency!

This PR also makes shelves and ingredients idempotent.

Ingredients and shelves can be validated more than once, creating the same result.