### PR TITLE
Remove dirty flags, use decorators

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -1,7 +1,6 @@
 import logging
 import time
 import warnings
-from functools import wraps
 from uuid import uuid4
 
 import attr
@@ -17,35 +16,13 @@ from recipe.exceptions import BadRecipe
 from recipe.ingredients import Dimension, Filter, Having, Metric
 from recipe.schemas import recipe_schema
 from recipe.shelf import Shelf, parse_unvalidated_condition
-from recipe.utils import prettyprintable_sql
+from recipe.utils import prettyprintable_sql, recipe_arg
 
 ALLOW_QUERY_CACHING = True
 
 warnings.simplefilter('always', DeprecationWarning)
 
 logger = logging.getLogger(__name__)
-
-
-def recipe_arg(*args):
-    """Decorator for recipe builder arguments. Prevents these methods
-    from being called after the recipe has fetched data.
-
-    Promotes builder pattern by returning self.
-    """
-
-    def decorator(func):
-
-        @wraps(func)
-        def wrapper(self, *_args, **_kwargs):
-            if self._query is not None:
-                self.reset()
-
-            func(self, *_args, **_kwargs)
-            return self
-
-        return wrapper
-
-    return decorator
 
 
 @attr.s()

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -38,10 +38,7 @@ def recipe_arg(*args):
         @wraps(func)
         def wrapper(self, *_args, **_kwargs):
             if self._query is not None:
-                raise BadRecipe(
-                    'A Recipe can not be changed after it has '
-                    'fetched data'
-                )
+                self.reset()
 
             func(self, *_args, **_kwargs)
             return self

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from sqlalchemy import and_, func, text
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -10,18 +12,39 @@ from recipe.utils import FakerAnonymizer
 Base = declarative_base()
 
 
+def recipe_extension_arg(*args):
+    """Decorator for recipe builder arguments on extensions. Prevents these
+    methods from being called after the recipe has fetched data.
+
+    Promotes builder pattern by returning self.
+    """
+
+    def decorator(func):
+
+        @wraps(func)
+        def wrapper(self, *_args, **_kwargs):
+            if self.recipe._query is not None:
+                raise BadRecipe(
+                    'A Recipe can not be changed after it has '
+                    'fetched data'
+                )
+
+            func(self, *_args, **_kwargs)
+            return self.recipe
+
+        return wrapper
+
+    return decorator
+
+
 class RecipeExtension(object):
     """
     Recipe extensions plug into the recipe builder pattern and can modify the
     generated query.
 
-    The extension should mark itself as ``dirty`` if it has changes which
-    change the current recipe results.
-
     recipe generates a query in the following way
 
-        (RECIPE) recipe checks its dirty state and all extension dirty
-        states to determine if the cached query needs to be regenerated
+        (RECIPE) recipe checks if a query has been generated
 
         (EXTENSIONS) all extension ``add_ingredients`` run to inject
         ingredients directly on the recipe
@@ -50,9 +73,7 @@ class RecipeExtension(object):
 
         (RECIPE) recipe applies limits and offsets on the query
 
-        (RECIPE) recipe caches completed query and sets all dirty flags to
-        False.
-
+        (RECIPE) recipe caches completed query
 
     When the recipe fetches data the results will be ``enchanted`` to add
     fields to the result. ``RecipeExtensions`` can modify result rows with
@@ -66,7 +87,6 @@ class RecipeExtension(object):
     """
 
     def __init__(self, recipe):
-        self.dirty = True
         self.recipe = recipe
 
     def add_ingredients(self):
@@ -174,6 +194,7 @@ class AutomaticFilters(RecipeExtension):
         self.exclude_keys = None
         self.include_keys = None
 
+    @recipe_extension_arg()
     def from_config(self, obj):
         handle_directives(
             obj, {
@@ -187,7 +208,6 @@ class AutomaticFilters(RecipeExtension):
                     lambda v: self.exclude_automatic_filter_keys(*v),
             }
         )
-        return self.recipe
 
     def add_ingredients(self):
         if self.apply:
@@ -210,17 +230,16 @@ class AutomaticFilters(RecipeExtension):
                 # make a Filter and add it to filters
                 self.recipe.filters(dimension.build_filter(values, operator))
 
+    @recipe_extension_arg()
     def apply_automatic_filters(self, value):
         """Toggles whether automatic filters are applied to a recipe. The
         following will disable automatic filters for this recipe::
 
             recipe.apply_automatic_filters(False)
         """
-        if self.apply != value:
-            self.dirty = True
-            self.apply = value
-        return self.recipe
+        self.apply = value
 
+    @recipe_extension_arg()
     def automatic_filters(self, value):
         """Sets a dictionary of automatic filters to apply to this recipe.
         If your recipe uses a shelf that has dimensions 'state' and 'gender'
@@ -278,9 +297,8 @@ class AutomaticFilters(RecipeExtension):
         """
         assert isinstance(value, dict)
         self._automatic_filters = value
-        self.dirty = True
-        return self.recipe
 
+    @recipe_extension_arg()
     def exclude_automatic_filter_keys(self, *keys):
         """A "blacklist" of automatic filter keys to exclude. The following will
         cause ``'state'`` to be ignored if it is present in the
@@ -290,8 +308,8 @@ class AutomaticFilters(RecipeExtension):
         """
 
         self.exclude_keys = keys
-        return self.recipe
 
+    @recipe_extension_arg()
     def include_automatic_filter_keys(self, *keys):
         """A "whitelist" of automatic filter keys to use. The following will
         **only use** ``'state'`` for automatic filters regardless of what is
@@ -300,7 +318,6 @@ class AutomaticFilters(RecipeExtension):
             recipe.include_automatic_filter_keys('state')
         """
         self.include_keys = keys
-        return self.recipe
 
 
 class UserFilters(RecipeExtension):
@@ -322,14 +339,13 @@ class SummarizeOver(RecipeExtension):
         super(SummarizeOver, self).__init__(*args, **kwargs)
         self._summarize_over = None
 
+    @recipe_extension_arg()
     def from_config(self, obj):
         handle_directives(obj, {'summarize_over': self.summarize_over})
-        return self.recipe
 
+    @recipe_extension_arg()
     def summarize_over(self, dimension_key):
-        self.dirty = True
         self._summarize_over = dimension_key
-        return self.recipe
 
     def modify_postquery_parts(self, postquery_parts):
         """
@@ -423,20 +439,15 @@ class Anonymize(RecipeExtension):
         super(Anonymize, self).__init__(*args, **kwargs)
         self._anonymize = False
 
+    @recipe_extension_arg()
     def from_config(self, obj):
         handle_directives(obj, {'anonymize': self.anonymize})
-        return self.recipe
 
+    @recipe_extension_arg()
     def anonymize(self, value):
         """ Should this recipe be anonymized"""
         assert isinstance(value, bool)
-
-        if self._anonymize != value:
-            self.dirty = True
-            self._anonymize = value
-
-        # Builder pattern must return the recipe
-        return self.recipe
+        self._anonymize = value
 
     def add_ingredients(self):
         """ Put the anonymizers in the last position of formatters """
@@ -501,6 +512,7 @@ class BlendRecipe(RecipeExtension):
         self.blend_types = []
         self.blend_criteria = []
 
+    @recipe_extension_arg()
     def blend(self, blend_recipe, join_base, join_blend):
         """Blend a recipe into the base recipe.
         This performs an inner join of the blend_recipe to the
@@ -511,9 +523,8 @@ class BlendRecipe(RecipeExtension):
         self.blend_recipes.append(blend_recipe)
         self.blend_types.append('inner')
         self.blend_criteria.append((join_base, join_blend))
-        self.dirty = True
-        return self.recipe
 
+    @recipe_extension_arg()
     def full_blend(self, blend_recipe, join_base, join_blend):
         """Blend a recipe into the base recipe preserving
         values from both recipes.
@@ -525,8 +536,6 @@ class BlendRecipe(RecipeExtension):
         self.blend_recipes.append(blend_recipe)
         self.blend_types.append('outer')
         self.blend_criteria.append((join_base, join_blend))
-        self.dirty = True
-        return self.recipe
 
     def modify_postquery_parts(self, postquery_parts):
         """
@@ -627,14 +636,13 @@ class CompareRecipe(RecipeExtension):
         self.compare_recipe = []
         self.suffix = []
 
+    @recipe_extension_arg()
     def compare(self, compare_recipe, suffix='_compare'):
         """Adds a comparison recipe to a base recipe."""
         assert isinstance(compare_recipe, Recipe)
         assert isinstance(suffix, basestring)
         self.compare_recipe.append(compare_recipe)
         self.suffix.append(suffix)
-        self.dirty = True
-        return self.recipe
 
     def modify_postquery_parts(self, postquery_parts):
         """Make the comparison recipe a subquery that is left joined to the

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -24,10 +24,7 @@ def recipe_extension_arg(*args):
         @wraps(func)
         def wrapper(self, *_args, **_kwargs):
             if self.recipe._query is not None:
-                raise BadRecipe(
-                    'A Recipe can not be changed after it has '
-                    'fetched data'
-                )
+                self.recipe.reset()
 
             func(self, *_args, **_kwargs)
             return self.recipe

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -180,7 +180,6 @@ FROM foo
 WHERE foo.first IN ('foo')
 GROUP BY foo.first"""
 
-        recipe.reset()
         with pytest.raises(AssertionError):
             # Automatic filters must be a dict
             recipe.automatic_filters(2)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -129,7 +129,6 @@ class TestAutomaticFiltersExtension(object):
         recipe = recipe.apply_automatic_filters(False)
 
         assert recipe.recipe_extensions[0].apply is False
-        assert recipe.recipe_extensions[0].dirty is True
 
         recipe = self.recipe().metrics('age').dimensions('first')
         recipe = recipe.include_automatic_filter_keys('first')
@@ -181,6 +180,7 @@ FROM foo
 WHERE foo.first IN ('foo')
 GROUP BY foo.first"""
 
+        recipe.reset()
         with pytest.raises(AssertionError):
             # Automatic filters must be a dict
             recipe.automatic_filters(2)
@@ -190,7 +190,6 @@ GROUP BY foo.first"""
         recipe = recipe.automatic_filters({
             'first': ['foo']
         }).apply_automatic_filters(False)
-        assert recipe.recipe_extensions[0].dirty is True
         assert recipe.to_sql() == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -511,15 +511,9 @@ class TestStats(object):
 
     def test_stats(self):
         recipe = self.recipe().metrics('age').dimensions('last')
-
-        assert recipe.stats.ready is False
-        with pytest.raises(BadRecipe):
-            assert recipe.stats.rows == 5
-
         recipe.all()
 
         # Stats are ready after the recipe is run
-        assert recipe.stats.ready is True
         assert recipe.stats.rows == 2
         assert recipe.stats.dbtime < 1.0
         assert recipe.stats.enchanttime < 1.0

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -143,11 +143,10 @@ GROUP BY foo.first"""
         assert recipe.all()[0].first == 'hi'
         assert recipe.all()[0].age == 15
         assert recipe.stats.rows == 1
-        assert recipe.dirty is False
 
         sess = oven.Session()
+        recipe.reset()
         recipe.session(sess)
-        assert recipe.dirty is True
 
     def test_shelf(self):
         recipe = self.recipe().metrics('age').dimensions('first')


### PR DESCRIPTION
This PR simplifies how recipes track changes by replacing an explicit dirty flag with checking self._query. Methods that modify the recipe or recipe extensions are decorated with a decorator recipe.utils.recipe_arg

Replace recipe.stats with a simpler object.