### PR TITLE
Better handling for nones, add scalar ops like and ilike

### DIFF
--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -203,10 +203,9 @@ class Ingredient(object):
         if operator is None or operator == 'in':
             # Default operator is 'in' so if no operator is provided, handle
             # like an 'in'
-            value = sorted(value)
             if None in value:
                 # filter out the Nones
-                non_none_value = [v for v in value if v is not None]
+                non_none_value = sorted([v for v in value if v is not None])
                 if non_none_value:
                     return Filter(
                         or_(
@@ -217,12 +216,13 @@ class Ingredient(object):
                 else:
                     return Filter(filter_column.is_(None))
             else:
+                # Sort to generate deterministic query sql for caching
+                value = sorted(value)
                 return Filter(filter_column.in_(value))
         elif operator == 'notin':
-            value = sorted(value)
             if None in value:
                 # filter out the Nones
-                non_none_value = [v for v in value if v is not None]
+                non_none_value = sorted([v for v in value if v is not None])
                 if non_none_value:
                     return Filter(
                         and_(
@@ -233,6 +233,8 @@ class Ingredient(object):
                 else:
                     return Filter(filter_column.isnot(None))
             else:
+                # Sort to generate deterministic query sql for caching
+                value = sorted(value)
                 return Filter(filter_column.notin_(value))
         elif operator == 'between':
             if len(value) != 2:

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -313,6 +313,10 @@ def _full_condition_schema(aggr=False):
                 _condition_schema('eq', '__eq__', aggr=aggr),
             'ne':
                 _condition_schema('ne', '__ne__', aggr=aggr),
+            'like':
+                _condition_schema('like', 'like', aggr=aggr),
+            'ilike':
+                _condition_schema('ilike', 'ilike', aggr=aggr),
             'in':
                 _condition_schema('in', 'in_', scalar=False, aggr=aggr),
             'notin':

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -185,6 +185,16 @@ GROUP BY foo.first"""
             # Automatic filters must be a dict
             recipe.automatic_filters(2)
 
+        recipe = self.recipe().metrics('age').dimensions('first')
+        recipe = recipe.automatic_filters({'first': [None]})
+
+        assert recipe.recipe_extensions[0].apply is True
+        assert recipe.to_sql() == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.first IS NULL
+GROUP BY foo.first"""
+
     def test_apply_automatic_filters(self):
         recipe = self.recipe().metrics('age').dimensions('first')
         recipe = recipe.automatic_filters({

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -152,6 +152,13 @@ class TestIngredientBuildFilter(object):
         assert str(filt.filters[0]) == 'foo.first IS :first_1'
         filt = d.build_filter('moo', 'isnot')
         assert str(filt.filters[0]) == 'foo.first IS NOT :first_1'
+        filt = d.build_filter('moo', 'like')
+        assert str(filt.filters[0]) == 'foo.first LIKE :first_1'
+        filt = d.build_filter('moo', 'ilike')
+        assert str(filt.filters[0]) == 'lower(foo.first) LIKE lower(:first_1)'
+        # None values get converted to IS
+        filt = d.build_filter(None, 'eq')
+        assert str(filt.filters[0]) == 'foo.first IS NULL'
 
         # str filter values are acceptable
         filt = d.build_filter(u'Τη γλώσ')
@@ -163,18 +170,39 @@ class TestIngredientBuildFilter(object):
         with pytest.raises(ValueError):
             filt = d.build_filter(['moo'], 'lt')
 
+        # Unknown operator
+        with pytest.raises(ValueError):
+            filt = d.build_filter(['moo'], 'cows')
+
     def test_vector_filter(self):
         d = Dimension(MyTable.first)
 
         # Test building scalar filters
         filt = d.build_filter(['moo'])
         assert str(filt.filters[0]) == 'foo.first IN (:first_1)'
+        filt = d.build_filter(['moo', None])
+        assert str(filt.filters[0]
+                  ) == 'foo.first IS NULL OR foo.first IN (:first_1)'
+        filt = d.build_filter([None, 'moo', None, None])
+        assert str(filt.filters[0]
+                  ) == 'foo.first IS NULL OR foo.first IN (:first_1)'
+        filt = d.build_filter([None, None])
+        assert str(filt.filters[0]) == 'foo.first IS NULL'
+
         filt = d.build_filter(['moo', 'foo'])
         assert str(filt.filters[0]) == 'foo.first IN (:first_1, :first_2)'
         filt = d.build_filter(['moo'], operator='in')
         assert str(filt.filters[0]) == 'foo.first IN (:first_1)'
         filt = d.build_filter(['moo'], operator='notin')
         assert str(filt.filters[0]) == 'foo.first NOT IN (:first_1)'
+        filt = d.build_filter(['moo', None], operator='notin')
+        assert str(filt.filters[0]
+                  ) == 'foo.first IS NOT NULL AND foo.first NOT IN (:first_1)'
+        filt = d.build_filter([None, 'moo', None], operator='notin')
+        assert str(filt.filters[0]
+                  ) == 'foo.first IS NOT NULL AND foo.first NOT IN (:first_1)'
+        filt = d.build_filter([None, None], operator='notin')
+        assert str(filt.filters[0]) == 'foo.first IS NOT NULL'
         filt = d.build_filter(['moo', 'foo'], operator='between')
         assert str(filt.filters[0]) \
             == 'foo.first BETWEEN :first_1 AND :first_2'

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -511,11 +511,23 @@ def test_valid_conditions():
         },
         {
             'field': 'foo',
+            'like': 'moo%'
+        },
+        {
+            'field': 'foo',
+            'ilike': '%cows%'
+        },
+        {
+            'field': 'foo',
             'notin': [41]
         },
         {
             'field': 'foo',
             'in': [22, 44, 55]
+        },
+        {
+            'field': 'foo',
+            'in': [22, 44, 55, None]
         },
         {
             'and': [{


### PR DESCRIPTION
### Issue 1:

Don't generate bad sql when there is a None in a list. Convert these to `is_` or `notis` operators.


### Issue 2

Add `like` and `ilike` scalar operators to both ingredient.build_filter and to ingredients.yaml