### PR TITLE
[ISSUE-37] Add bucket support to Dimensions defined via config

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -366,16 +366,9 @@ class Recipe(object):
         order_bys = OrderedSet()
         if self._order_bys:
             for ingredient in self._order_bys:
-                if isinstance(ingredient, Dimension):
-                    # Reverse the ordering columns so that dimensions
-                    # order by their label rather than their id
-                    columns = reversed(ingredient.columns)
-                else:
-                    columns = ingredient.columns
-                for c in columns:
-                    order_by = c.desc() if ingredient.ordering == 'desc' else c
-                    if str(order_by) not in [str(o) for o in order_bys]:
-                        order_bys.add(order_by)
+                for c in ingredient.order_by_columns:
+                    if str(c) not in [str(o) for o in order_bys]:
+                        order_bys.add(c)
 
         return list(order_bys)
 

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -310,6 +310,10 @@ class Dimension(Ingredient):
     def __init__(self, expression, **kwargs):
         super(Dimension, self).__init__(**kwargs)
 
+        # An optional exprssion to use instead of the value expression
+        # when ordering
+        order_by_expression = kwargs.pop('order_by_expression', None)        
+
         # We must always have a value role
         self.roles = {'value': expression}
         for k, v in kwargs.items():
@@ -322,9 +326,6 @@ class Dimension(Ingredient):
                     raise BadIngredient('raw is a reserved role in dimensions')
                 self.roles[role] = v
 
-        # An optional exprssion to use instead of the value expression
-        # when ordering
-        self.order_by_expression = kwargs.pop('order_by_value', None)
 
         self.columns = []
         self.group_by = []
@@ -341,8 +342,8 @@ class Dimension(Ingredient):
             self.role_keys.append('value')
             # Order by columns are in order of value, id
             # Extra roles are ignored
-            if self.order_by_expression is not None:
-                self._order_by_columns.insert(0, self.order_by_expression)
+            if order_by_expression is not None:
+                self._order_by_columns.insert(0, order_by_expression)
             else:
                 self._order_by_columns.insert(0, self.roles['value'])
 

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -7,10 +7,6 @@ from recipe.compat import basestring, str
 from recipe.exceptions import BadIngredient
 from recipe.utils import AttrDict
 
-# TODO: How do we avoid attaching significance to particular
-# indices in columns
-# Should dimensions having ids be an extension to recipe?
-
 
 @total_ordering
 class Ingredient(object):
@@ -312,7 +308,7 @@ class Dimension(Ingredient):
 
         # An optional exprssion to use instead of the value expression
         # when ordering
-        order_by_expression = kwargs.pop('order_by_expression', None)        
+        order_by_expression = kwargs.pop('order_by_expression', None)
 
         # We must always have a value role
         self.roles = {'value': expression}
@@ -325,7 +321,6 @@ class Dimension(Ingredient):
                 if role == 'raw':
                     raise BadIngredient('raw is a reserved role in dimensions')
                 self.roles[role] = v
-
 
         self.columns = []
         self.group_by = []
@@ -363,8 +358,8 @@ class Dimension(Ingredient):
             if 'lookup_default' in kwargs:
                 self.lookup_default = kwargs.get('lookup_default')
                 self.formatters.insert(
-                    0,
-                    lambda value: self.lookup.get(value, self.lookup_default)
+                    0, lambda value: self.lookup.
+                    get(value, self.lookup_default)
                 )
             else:
                 self.formatters.insert(
@@ -481,10 +476,9 @@ class DivideMetric(Metric):
         else:
             # If the denominator is zero, return the ifzero value otherwise do
             # the division
-            expression = case(
-                ((cast(denominator, Float) == 0.0, ifzero),),
-                else_=cast(numerator, Float) / cast(denominator, Float)
-            )
+            expression = case(((cast(denominator, Float) == 0.0, ifzero),),
+                              else_=cast(numerator, Float) /
+                              cast(denominator, Float))
         super(DivideMetric, self).__init__(expression, **kwargs)
 
 

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -237,7 +237,7 @@ class ConditionPost(object):
 def _condition_schema(
     operator, _op, scalar=True, aggr=False, label_required=False
 ):
-    """Build a schema that expresses an (optionally labeled) booolean 
+    """Build a schema that expresses an (optionally labeled) boolean
     expression.
 
     For instance:
@@ -546,7 +546,7 @@ ingredient_schema = S.DictWhenKeyIs(
                         S.String(
                             coerce=lambda v: format_lookup.get(v, v),
                             required=False
-                        ),
+                        ),  # noqa: E123
                     'quickfilters':
                         quickfilter_schema
                 },

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -439,11 +439,12 @@ def _replace_refs_in_field(fld, shelf):
                     # FIXME: what to do if you can't find the ref
                     # What if the field doesn't have a condition
                     new_cond = shelf[cond_ref]['field'].get('condition')
-                    for k in cond.keys():
-                        cond.pop(k)
-                    cond.update(new_cond)
-                    if 'label' not in cond:
-                        cond['label'] = cond_ref
+                    if new_cond:
+                        for k in list(cond.keys()):
+                            cond.pop(k)
+                        cond.update(new_cond)
+                        if 'label' not in cond:
+                            cond['label'] = cond_ref
 
         if 'condition' in fld and isinstance(fld['condition'], dict):
             cond = fld['condition']

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -431,6 +431,20 @@ def _replace_refs_in_field(fld, shelf):
             fld = shelf[ref]['field']
     else:
         # Replace conditions and operators within the field
+        if 'buckets' in fld:
+            for cond in fld['buckets']:
+                if 'ref' in cond:
+                    # Update the condition in place
+                    cond_ref = cond.pop('ref')
+                    # FIXME: what to do if you can't find the ref
+                    # What if the field doesn't have a condition
+                    new_cond = shelf[cond_ref]['field'].get('condition')
+                    for k in cond.keys():
+                        cond.pop(k)
+                    cond.update(new_cond)
+                    if 'label' not in cond:
+                        cond['label'] = cond_ref
+
         if 'condition' in fld and isinstance(fld['condition'], dict):
             cond = fld['condition']
             if 'ref' in cond:

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import re
 
+from copy import copy
 from sqlalchemy import distinct, func
 from sureberus import schema as S
 
@@ -373,6 +374,11 @@ def _move_extra_fields(value):
                     'field': value.pop(k)
                 })
 
+        if 'buckets' in value:
+            for b in value['buckets']:
+                if 'field' not in b:
+                    b['field'] = copy(value.get('field'))
+
     return value
 
 
@@ -501,7 +507,8 @@ ingredient_schema = S.DictWhenKeyIs(
                                 }
                             )
                         ),
-                    'buckets': S.List(required=False, schema='labeled_condition'),
+                    'buckets':
+                        S.List(required=False, schema='labeled_condition'),
                     'buckets_default_label': {
                         'anyof': SCALAR_TYPES,
                         'required': False
@@ -526,12 +533,18 @@ ingredient_schema = S.DictWhenKeyIs(
     default_choice='Metric',
     coerce=_adjust_kinds,
     registry={
-        'aggregated_field': _field_schema(aggr=True, required=True),
-        'optional_aggregated_field': _field_schema(aggr=True, required=False),
-        'non_aggregated_field': _field_schema(aggr=False, required=True),
-        'condition': _full_condition_schema(aggr=False, label_required=False),
-        'labeled_condition': _full_condition_schema(aggr=False, label_required=True),
-        'having_condition': _full_condition_schema(aggr=True, label_required=False)
+        'aggregated_field':
+            _field_schema(aggr=True, required=True),
+        'optional_aggregated_field':
+            _field_schema(aggr=True, required=False),
+        'non_aggregated_field':
+            _field_schema(aggr=False, required=True),
+        'condition':
+            _full_condition_schema(aggr=False, label_required=False),
+        'labeled_condition':
+            _full_condition_schema(aggr=False, label_required=True),
+        'having_condition':
+            _full_condition_schema(aggr=True, label_required=False)
     }
 )
 
@@ -557,11 +570,17 @@ recipe_schema = S.Dict(
             S.List(schema=S.String(), required=False),
     },
     registry={
-        'aggregated_field': _field_schema(aggr=True, required=True),
-        'optional_aggregated_field': _field_schema(aggr=True, required=False),
-        'non_aggregated_field': _field_schema(aggr=False, required=True),
-        'condition': _full_condition_schema(aggr=False, label_required=False),
-        'labeled_condition': _full_condition_schema(aggr=False, label_required=True),
-        'having_condition': _full_condition_schema(aggr=True, label_required=False)
+        'aggregated_field':
+            _field_schema(aggr=True, required=True),
+        'optional_aggregated_field':
+            _field_schema(aggr=True, required=False),
+        'non_aggregated_field':
+            _field_schema(aggr=False, required=True),
+        'condition':
+            _full_condition_schema(aggr=False, label_required=False),
+        'labeled_condition':
+            _full_condition_schema(aggr=False, label_required=True),
+        'having_condition':
+            _full_condition_schema(aggr=True, label_required=False)
     }
 )

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -360,6 +360,19 @@ def _full_condition_schema(**kwargs):
     }
 
 
+def _move_buckets_to_field(value):
+    """ Move buckets from a dimension into the field """
+    # return value
+    buckets = value.pop('buckets', None)
+    buckets_default_label = value.pop('buckets_default_label', None)
+    if buckets:
+        if 'field' in value:
+            value['field']['buckets'] = buckets
+            if buckets_default_label is not None:
+                value['field']['buckets_default_label'] = buckets_default_label
+    return value
+
+
 def _move_extra_fields(value):
     """ Move any fields that look like "{role}_field" into the extra_fields
     list. These will be processed as fields. Rename them as {role}_expression.
@@ -494,6 +507,7 @@ ingredient_schema = S.DictWhenKeyIs(
             S.Dict(
                 allow_unknown=True,
                 coerce=_move_extra_fields,
+                coerce_post=_move_buckets_to_field,
                 schema={
                     'field':
                         'non_aggregated_field',

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -521,12 +521,12 @@ ingredient_schema = S.DictWhenKeyIs(
     default_choice='Metric',
     coerce=_adjust_kinds,
     registry={
-        'aggregated_field': _field_schema(aggr=True),
+        'aggregated_field': _field_schema(aggr=True, required=True),
         'optional_aggregated_field': _field_schema(aggr=True, required=False),
-        'non_aggregated_field': _field_schema(aggr=False),
+        'non_aggregated_field': _field_schema(aggr=False, required=True),
         'condition': _full_condition_schema(aggr=False, label_required=False),
         'condition_label_required': _full_condition_schema(aggr=False, label_required=True),
-        'having_condition': _full_condition_schema(aggr=True),
+        'having_condition': _full_condition_schema(aggr=True, label_required=False)
     }
 )
 
@@ -552,10 +552,11 @@ recipe_schema = S.Dict(
             S.List(schema=S.String(), required=False),
     },
     registry={
-        'aggregated_field': _field_schema(aggr=True),
+        'aggregated_field': _field_schema(aggr=True, required=True),
         'optional_aggregated_field': _field_schema(aggr=True, required=False),
-        'non_aggregated_field': _field_schema(aggr=False),
-        'condition': _full_condition_schema(aggr=False),
-        'having_condition': _full_condition_schema(aggr=True),
+        'non_aggregated_field': _field_schema(aggr=False, required=True),
+        'condition': _full_condition_schema(aggr=False, label_required=False),
+        'condition_label_required': _full_condition_schema(aggr=False, label_required=True),
+        'having_condition': _full_condition_schema(aggr=True, label_required=False)
     }
 )

--- a/recipe/schemas.py
+++ b/recipe/schemas.py
@@ -501,6 +501,11 @@ ingredient_schema = S.DictWhenKeyIs(
                                 }
                             )
                         ),
+                    'buckets': S.List(required=False, schema='labeled_condition'),
+                    'buckets_default_label': {
+                        'anyof': SCALAR_TYPES,
+                        'required': False
+                    },
                     'format':
                         S.String(
                             coerce=lambda v: format_lookup.get(v, v),
@@ -525,7 +530,7 @@ ingredient_schema = S.DictWhenKeyIs(
         'optional_aggregated_field': _field_schema(aggr=True, required=False),
         'non_aggregated_field': _field_schema(aggr=False, required=True),
         'condition': _full_condition_schema(aggr=False, label_required=False),
-        'condition_label_required': _full_condition_schema(aggr=False, label_required=True),
+        'labeled_condition': _full_condition_schema(aggr=False, label_required=True),
         'having_condition': _full_condition_schema(aggr=True, label_required=False)
     }
 )
@@ -556,7 +561,7 @@ recipe_schema = S.Dict(
         'optional_aggregated_field': _field_schema(aggr=True, required=False),
         'non_aggregated_field': _field_schema(aggr=False, required=True),
         'condition': _full_condition_schema(aggr=False, label_required=False),
-        'condition_label_required': _full_condition_schema(aggr=False, label_required=True),
+        'labeled_condition': _full_condition_schema(aggr=False, label_required=True),
         'having_condition': _full_condition_schema(aggr=True, label_required=False)
     }
 )

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -68,8 +68,8 @@ def find_column(selectable, name):
             return col
 
     # Selectable is a sqlalchemy subquery
-    elif hasattr(selectable, 'c'
-                ) and isinstance(selectable.c, ImmutableColumnCollection):
+    elif hasattr(selectable,
+                 'c') and isinstance(selectable.c, ImmutableColumnCollection):
         col = getattr(selectable.c, name, None)
         if col is not None:
             return col
@@ -138,7 +138,7 @@ def ingredient_from_unvalidated_dict(unvalidated_ingr, selectable):
 
 
 def parse_validated_field(fld, selectable, use_bucket_labels=True):
-    """ Converts a validated field to a sqlalchemy expression. 
+    """ Converts a validated field to a sqlalchemy expression.
     Field references are looked up in selectable """
     if fld is None:
         return
@@ -150,12 +150,13 @@ def parse_validated_field(fld, selectable, use_bucket_labels=True):
 
     if 'buckets' in fld:
         # Buckets only appear in dimensions
-        buckets_default_label = fld.get('buckets_default_label') if use_bucket_labels else 9999
-        conditions = [
-            (parse_validated_condition(cond, selectable), 
-             cond.get('label') if use_bucket_labels else idx)
-            for idx,cond in enumerate(fld.get('buckets', []))
-        ]
+        buckets_default_label = fld.get(
+            'buckets_default_label'
+        ) if use_bucket_labels else 9999
+        conditions = [(
+            parse_validated_condition(cond, selectable),
+            cond.get('label') if use_bucket_labels else idx
+        ) for idx, cond in enumerate(fld.get('buckets', []))]
         field = case(conditions, else_=buckets_default_label)
     else:
         field = find_column(selectable, fld['value'])
@@ -208,10 +209,14 @@ def ingredient_from_validated_dict(ingr_dict, selectable):
 
     field_defn = ingr_dict.pop('field', None)
     divide_by_defn = ingr_dict.pop('divide_by', None)
-    
-    field = parse_validated_field(field_defn, selectable, use_bucket_labels=True)
+
+    field = parse_validated_field(
+        field_defn, selectable, use_bucket_labels=True
+    )
     if isinstance(field_defn, dict) and 'buckets' in field_defn:
-        ingr_dict['order_by_expression'] = parse_validated_field(field_defn, selectable, use_bucket_labels=False)
+        ingr_dict['order_by_expression'] = parse_validated_field(
+            field_defn, selectable, use_bucket_labels=False
+        )
 
     if divide_by_defn is not None:
         # Perform a divide by zero safe division

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -146,7 +146,16 @@ def parse_validated_field(fld, selectable):
     if fld.pop('_use_raw_value', False):
         return float(fld['value'])
 
-    field = find_column(selectable, fld['value'])
+    if 'buckets' in fld:
+        # Buckets only appear in dimensions
+        buckets_default_label = fld.get('buckets_default_label')
+        conditions = [
+            (parse_validated_condition(cond, selectable), cond.get('label'))
+            for cond in fld.get('buckets', [])
+        ]
+        field = case(conditions, else_=buckets_default_label)
+    else:
+        field = find_column(selectable, fld['value'])
 
     operator_lookup = {
         '+': lambda fld: getattr(fld, '__add__'),

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -23,7 +23,6 @@ __all__ = [
     'prettyprintable_sql', 'clean_unicode', 'FakerAnonymizer', 'FakerFormatter'
 ]
 
-
 def recipe_arg(*args):
     """Decorator for recipe builder arguments.
 

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -23,6 +23,7 @@ __all__ = [
     'prettyprintable_sql', 'clean_unicode', 'FakerAnonymizer', 'FakerFormatter'
 ]
 
+
 def recipe_arg(*args):
     """Decorator for recipe builder arguments.
 

--- a/tests/ingredients/census.yaml
+++ b/tests/ingredients/census.yaml
@@ -13,6 +13,17 @@ pop2000:
 pop2008:
     kind: Metric
     field: pop2008
+age_buckets:
+    kind: Dimension
+    field: age
+    buckets:
+    - label: 'babies'
+      lt: 2
+    - label: 'children'
+      lt: 13
+    - label: 'teens'
+      lt: 20
+    buckets_default_label: 'oldsters'
 ttlpop:
     kind: Metric
     field: pop2000 + pop2008

--- a/tests/ingredients/census.yaml
+++ b/tests/ingredients/census.yaml
@@ -24,6 +24,20 @@ age_buckets:
     - label: 'teens'
       lt: 20
     buckets_default_label: 'oldsters'
+mixed_buckets:
+    kind: Dimension
+    field: age
+    buckets:
+    - label: 'northeast'
+      in: ['Vermont', 'New Hampshire']
+      field: state
+    - label: 'babies'
+      lt: 2
+    - label: 'children'
+      lt: 13
+    - label: 'teens'
+      lt: 20
+    buckets_default_label: 'oldsters'
 ttlpop:
     kind: Metric
     field: pop2000 + pop2008

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -283,6 +283,32 @@ class TestDimension(object):
         assert len(d.columns) == 2
         assert len(d.group_by) == 2
 
+    def test_dimension_order_by(self):
+        d = Dimension(MyTable.first)
+        assert len(list(d.order_by_columns)) == 1
+
+        # Dimension with different id and value expressions
+        d = Dimension(MyTable.first, id_expression=MyTable.last)
+        assert len(list(d.order_by_columns)) == 2
+        # Order by value expression then id expression
+        assert list(d.order_by_columns) == [
+            MyTable.first,
+            MyTable.last,
+        ]
+
+        # Extra roles do not participate in ordering
+        d = Dimension(
+            MyTable.first,
+            id_expression=MyTable.last,
+            age_expression=MyTable.age,
+            id='moo'
+        )
+        assert len(list(d.order_by_columns)) == 2
+        assert list(d.order_by_columns) == [
+            MyTable.first,
+            MyTable.last,
+        ]
+
     def test_dimension_cauldron_extras(self):
         d = Dimension(MyTable.first, id='moo')
         extras = list(d.cauldron_extras)

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -147,7 +147,8 @@ teens,614548,teens
         shelf = self.unvalidated_shelf('census.yaml', Census)
         recipe = Recipe(
             shelf=shelf, session=self.session
-        ).dimensions('mixed_buckets').metrics('pop2000').order_by('-mixed_buckets')
+        ).dimensions('mixed_buckets').metrics('pop2000').order_by(
+            '-mixed_buckets')
         assert recipe.to_sql() == """SELECT CASE
            WHEN (census.state IN ('Vermont',
                                   'New Hampshire')) THEN 'northeast'
@@ -245,7 +246,6 @@ teens,614548,teens
 children,948240,children
 babies,164043,babies
 ''')
-
 
     def test_complex_census_from_validated_yaml(self):
         """Build a recipe that uses complex definitions dimensions and

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -143,6 +143,70 @@ oldsters,4567879,oldsters
 teens,614548,teens
 ''')
 
+    def test_census_buckets_ordering(self):
+        shelf = self.unvalidated_shelf('census.yaml', Census)
+        recipe = Recipe(
+            shelf=shelf, session=self.session
+        ).dimensions('age_buckets').metrics('pop2000').order_by('age_buckets')
+        assert recipe.to_sql() == """SELECT CASE
+           WHEN (census.age < 2) THEN 'babies'
+           WHEN (census.age < 13) THEN 'children'
+           WHEN (census.age < 20) THEN 'teens'
+           ELSE 'oldsters'
+       END AS age_buckets,
+       sum(census.pop2000) AS pop2000
+FROM census
+GROUP BY CASE
+             WHEN (census.age < 2) THEN 'babies'
+             WHEN (census.age < 13) THEN 'children'
+             WHEN (census.age < 20) THEN 'teens'
+             ELSE 'oldsters'
+         END
+ORDER BY CASE
+             WHEN (census.age < 2) THEN 0
+             WHEN (census.age < 13) THEN 1
+             WHEN (census.age < 20) THEN 2
+             ELSE 9999
+         END"""
+        self.assert_recipe_csv(
+            recipe, '''age_buckets,pop2000,age_buckets_id
+babies,164043,babies
+children,948240,children
+teens,614548,teens
+oldsters,4567879,oldsters
+''')
+        recipe = Recipe(
+            shelf=shelf, session=self.session
+        ).dimensions('age_buckets').metrics('pop2000').order_by('-age_buckets')
+        assert recipe.to_sql() == """SELECT CASE
+           WHEN (census.age < 2) THEN 'babies'
+           WHEN (census.age < 13) THEN 'children'
+           WHEN (census.age < 20) THEN 'teens'
+           ELSE 'oldsters'
+       END AS age_buckets,
+       sum(census.pop2000) AS pop2000
+FROM census
+GROUP BY CASE
+             WHEN (census.age < 2) THEN 'babies'
+             WHEN (census.age < 13) THEN 'children'
+             WHEN (census.age < 20) THEN 'teens'
+             ELSE 'oldsters'
+         END
+ORDER BY CASE
+             WHEN (census.age < 2) THEN 0
+             WHEN (census.age < 13) THEN 1
+             WHEN (census.age < 20) THEN 2
+             ELSE 9999
+         END DESC"""
+        self.assert_recipe_csv(
+            recipe, '''age_buckets,pop2000,age_buckets_id
+oldsters,4567879,oldsters
+teens,614548,teens
+children,948240,children
+babies,164043,babies
+''')
+
+
     def test_complex_census_from_validated_yaml(self):
         """Build a recipe that uses complex definitions dimensions and
         metrics """

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -303,6 +303,7 @@ Vermont,609480,Taciturny,Vermont
             shelf=shelf, session=self.session
         ).dimensions('state_idval').metrics('pop2000').order_by('state_idval'
                                                                ).limit(5)
+        print(recipe.to_sql())
         assert recipe.to_sql() == '''SELECT census.pop2000 AS state_idval_id,
        census.state AS state_idval,
        sum(census.pop2000) AS pop2000

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -149,12 +149,9 @@ def test_field_ref():
                         'value': 'moo'
                     }
                 }],
-                'ref':
-                    'foo',
-                'aggregation':
-                    'sum',
-                'value':
-                    'foo'
+                'ref': 'foo',
+                'aggregation': 'sum',
+                'value': 'foo'
             },
             'kind': 'Metric'
         }
@@ -177,11 +174,10 @@ def test_field_buckets_ref():
         'moo': {
             'kind': 'Dimension',
             'field': 'moo',
-            'buckets': [
-                { 'ref': 'foo'}
-            ]
+            'buckets': [{
+                'ref': 'foo'
+            }]
         }
-
     }
     x = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert x == {
@@ -314,10 +310,8 @@ def test_field_operators():
                         'value': '1.02'
                     }
                 }],
-                'aggregation':
-                    'sum',
-                'value':
-                    'foo'
+                'aggregation': 'sum',
+                'value': 'foo'
             },
             'kind': 'Metric'
         }
@@ -347,10 +341,8 @@ def test_field_operators():
                         'value': '523.5'
                     }
                 }],
-                'aggregation':
-                    'sum',
-                'value':
-                    'foo'
+                'aggregation': 'sum',
+                'value': 'foo'
             },
             'kind': 'Metric'
         }
@@ -464,10 +456,17 @@ def test_dimension():
 
 
 def test_dimension_buckets():
-    v = {'a': {'kind': 'Dimension', 'field': 'foo', 'icon': 'squee', 'buckets': [
-     {   'gt': 20,
-        'label': 'over20'}
-    ]}}
+    v = {
+        'a': {
+            'kind': 'Dimension',
+            'field': 'foo',
+            'icon': 'squee',
+            'buckets': [{
+                'gt': 20,
+                'label': 'over20'
+            }]
+        }
+    }
 
     x = normalize_schema(shelf_schema, v, allow_unknown=False)
 
@@ -492,7 +491,6 @@ def test_dimension_buckets():
             'kind': 'Dimension'
         }
     }
-
 
 
 def test_and_condition():
@@ -788,10 +786,8 @@ def test_valid_ingredients():
                         'value': 'cow'
                     }
                 }],
-                'aggregation':
-                    'sum',
-                'value':
-                    'moo'
+                'aggregation': 'sum',
+                'value': 'moo'
             },
             'kind': 'Metric',
             'format': ',.0f'

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -402,6 +402,38 @@ def test_dimension():
     }
 
 
+def test_dimension_bucket():
+    v = {'a': {'kind': 'Dimension', 'field': 'foo', 'icon': 'squee', 'buckets': [
+     {   'gt': 20,
+        'label': 'over20'}
+    ]}}
+
+    x = normalize_schema(shelf_schema, v, allow_unknown=False)
+
+    # The dimension field gets inserted into the buckets
+    assert x == {
+        'a': {
+            'field': {
+                'aggregation': 'none',
+                'buckets': [{
+                    '_op': '__gt__',
+                    '_op_value': 20,
+                    'field': {
+                        'aggregation': 'none',
+                        'value': 'foo'
+                    },
+                    'gt': 20,
+                    'label': 'over20'
+                }],
+                'value': 'foo'
+            },
+            'icon': 'squee',
+            'kind': 'Dimension'
+        }
+    }
+
+
+
 def test_and_condition():
     shelf = {
         'a': {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -161,6 +161,67 @@ def test_field_ref():
     }
 
 
+def test_field_buckets_ref():
+    v = {
+        'foo': {
+            'kind': 'Dimension',
+            'field': {
+                'value': 'foo',
+                'condition': {
+                    'field': 'foo',
+                    'label': 'foo < 200',
+                    'lt': 200
+                }
+            }
+        },
+        'moo': {
+            'kind': 'Dimension',
+            'field': 'moo',
+            'buckets': [
+                { 'ref': 'foo'}
+            ]
+        }
+
+    }
+    x = normalize_schema(shelf_schema, v, allow_unknown=False)
+    assert x == {
+        'foo': {
+            'field': {
+                'aggregation': 'none',
+                'condition': {
+                    '_op': '__lt__',
+                    '_op_value': 200,
+                    'field': {
+                        'aggregation': 'none',
+                        'value': 'foo'
+                    },
+                    'label': 'foo < 200',
+                    'lt': 200
+                },
+                'value': 'foo'
+            },
+            'kind': 'Dimension'
+        },
+        'moo': {
+            'field': {
+                'aggregation': 'none',
+                'buckets': [{
+                    '_op': '__lt__',
+                    '_op_value': 200,
+                    'field': {
+                        'aggregation': 'none',
+                        'value': 'foo'
+                    },
+                    'label': 'foo < 200',
+                    'lt': 200
+                }],
+                'value': 'moo'
+            },
+            'kind': 'Dimension'
+        }
+    }
+
+
 def test_find_operators():
 
     def process_operator(op):
@@ -402,7 +463,7 @@ def test_dimension():
     }
 
 
-def test_dimension_bucket():
+def test_dimension_buckets():
     v = {'a': {'kind': 'Dimension', 'field': 'foo', 'icon': 'squee', 'buckets': [
      {   'gt': 20,
         'label': 'over20'}


### PR DESCRIPTION
## Defining buckets in Dimensions

Buckets are a list of labeled conditions. The conditions are checked in order. If no conditions match, the buckets_default_label value is used.

```
age_buckets:
    kind: Dimension
    field: age
    buckets:
    - label: 'babies'
      lt: 2
    - label: 'children'
      lt: 13
    - label: 'teens'
      lt: 20
    buckets_default_label: 'oldsters'
```

Buckets **"inherit"** field from the dimension. However, they can be defined with their own alternative fields. The following a bucket dimension that uses two different fields.

```
age_buckets:
    kind: Dimension
    field: age
    buckets:
    - label: 'West coast'
      in: ['California', 'Oregon', 'Washington']
      field: state
    - label: 'children'
      lt: 13
    - label: 'teens'
      field: 
      lt: 20
    buckets_default_label: 'oldsters'
```

### A necessary feature

Buckets sort by the order in which buckets are defined rather than by the order of their strings. This is a feature we need to support on Dimension https://www.wikiwand.com/en/Ordinal_data

## Support custom ordering on Dimension

Dimensions order by the value expression then by the id expression. This PR adds an optional order_by_expression that will be used for ordering. This is motivated by buckets. We want buckets to be displayed in the order they are defined.

## Labeled conditions

Buckets are defined as a list of labeled conditions. We should use this for quickfilters!