### PR TITLE
Caching improvements

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -85,6 +85,7 @@ class Recipe(object):
         # Cache options
         self.cache_context = None
         self._cache_region = 'default'
+        self._cache_prefix = 'default'
         self._use_cache = True
 
         self.stats = Stats()
@@ -225,6 +226,12 @@ class Recipe(object):
         """Set a cache region for recipe-caching to use """
         assert isinstance(value, basestring)
         self._cache_region = value
+
+    @recipe_arg()
+    def cache_prefix(self, value):
+        """Set a cache prefix for recipe-caching to use """
+        assert isinstance(value, basestring)
+        self._cache_prefix = value
 
     @recipe_arg()
     def use_cache(self, value):
@@ -445,6 +452,8 @@ class Recipe(object):
         for extension in self.recipe_extensions:
             recipe_parts = extension.modify_postquery_parts(recipe_parts)
 
+        if 'recipe' not in recipe_parts:
+            recipe_parts['recipe'] = self
         recipe_parts = run_hooks(
             recipe_parts, 'modify_query', self.dynamic_extensions
         )

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -224,13 +224,13 @@ class Recipe(object):
     @recipe_arg()
     def cache_region(self, value):
         """Set a cache region for recipe-caching to use """
-        assert isinstance(value, basestring)
+        assert isinstance(value, str)
         self._cache_region = value
 
     @recipe_arg()
     def cache_prefix(self, value):
         """Set a cache prefix for recipe-caching to use """
-        assert isinstance(value, basestring)
+        assert isinstance(value, str)
         self._cache_prefix = value
 
     @recipe_arg()

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -10,7 +10,7 @@ from sqlalchemy import alias, func
 from sqlalchemy.sql.elements import BinaryExpression
 from sureberus import normalize_dict, normalize_schema
 
-from recipe.compat import str
+from recipe.compat import basestring
 from recipe.dynamic_extensions import run_hooks
 from recipe.exceptions import BadRecipe
 from recipe.ingredients import Dimension, Filter, Having, Metric
@@ -224,13 +224,13 @@ class Recipe(object):
     @recipe_arg()
     def cache_region(self, value):
         """Set a cache region for recipe-caching to use """
-        assert isinstance(value, str)
+        assert isinstance(value, basestring)
         self._cache_region = value
 
     @recipe_arg()
     def cache_prefix(self, value):
         """Set a cache prefix for recipe-caching to use """
-        assert isinstance(value, str)
+        assert isinstance(value, basestring)
         self._cache_prefix = value
 
     @recipe_arg()

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -453,7 +453,8 @@ class Recipe(object):
             recipe_parts = extension.modify_postquery_parts(recipe_parts)
 
         if 'recipe' not in recipe_parts:
-            recipe_parts['recipe'] = self
+            recipe_parts['cache_region'] = self._cache_region
+            recipe_parts['cache_prefix'] = self._cache_prefix
         recipe_parts = run_hooks(
             recipe_parts, 'modify_query', self.dynamic_extensions
         )

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -222,11 +222,13 @@ class Recipe(object):
 
     @recipe_arg()
     def cache_region(self, value):
+        """Set a cache region for recipe-caching to use """
         assert isinstance(value, basestring)
         self._cache_region = value
 
     @recipe_arg()
     def use_cache(self, value):
+        """If False, invalidate the cache before fetching data."""
         assert isinstance(value, bool)
         self._use_cache = value
 

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -690,30 +690,3 @@ class CompareRecipe(RecipeExtension):
                 .outerjoin(comparison_subq, join_clause)
 
         return postquery_parts
-
-
-class CacheOptions(RecipeExtension):
-    """ Save a custom region which can be used by recipe_caching.
-    Also support query invalidation.
-    """
-
-    recipe_schema = {
-        'cache_region': {
-            'type': 'string'
-        },
-        'use_cache': {
-            'type': 'boolean'
-        },
-    }
-
-    def __init__(self, *args, **kwargs):
-        super(RecipeExtension, self).__init__(*args, **kwargs)
-        self.recipe._cache_region = 'default'
-        self.recipe.use_cache = True
-
-    def cache_region(self, value):
-        self.recipe._cache_region = value
-
-    def use_cache(self):
-        self.recipe.use_cache = False
-        return self.recipe

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -690,3 +690,30 @@ class CompareRecipe(RecipeExtension):
                 .outerjoin(comparison_subq, join_clause)
 
         return postquery_parts
+
+
+class CacheOptions(RecipeExtension):
+    """ Save a custom region which can be used by recipe_caching.
+    Also support query invalidation.
+    """
+
+    recipe_schema = {
+        'cache_region': {
+            'type': 'string'
+        },
+        'use_cache': {
+            'type': 'boolean'
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(RecipeExtension, self).__init__(*args, **kwargs)
+        self.recipe._cache_region = 'default'
+        self.recipe.use_cache = True
+
+    def cache_region(self, value):
+        self.recipe._cache_region = value
+
+    def use_cache(self):
+        self.recipe.use_cache = False
+        return self.recipe

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -139,7 +139,17 @@ OFFSET 1"""
         assert recipe._cache_region == 'foo'
 
         with pytest.raises(AssertionError):
-            self.recipe().metrics('age').use_cache(2)
+            self.recipe().metrics('age').cache_region(22)
+
+    def test_cache_prefix(self):
+        recipe = self.recipe().metrics('age')
+        assert recipe._cache_prefix == 'default'
+
+        recipe = self.recipe().metrics('age').cache_prefix('foo')
+        assert recipe._cache_prefix == 'foo'
+
+        with pytest.raises(AssertionError):
+            self.recipe().metrics('age').cache_prefix(22)
 
     def test_dataset(self):
         recipe = self.recipe().metrics('age').dimensions('first')

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -126,8 +126,8 @@ OFFSET 1"""
         assert recipe._use_cache is True
 
         recipe = self.recipe().metrics('age').use_cache(False)
-        assert recipe._use_cache == False
-        
+        assert recipe._use_cache is False
+
         with pytest.raises(AssertionError):
             self.recipe().metrics('age').use_cache('potatoe')
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -121,6 +121,26 @@ OFFSET 1"""
         recipe = self.recipe().metrics('age')
         assert recipe._is_postgres() is False
 
+    def test_use_cache(self):
+        recipe = self.recipe().metrics('age')
+        assert recipe._use_cache is True
+
+        recipe = self.recipe().metrics('age').use_cache(False)
+        assert recipe._use_cache == False
+        
+        with pytest.raises(AssertionError):
+            self.recipe().metrics('age').use_cache('potatoe')
+
+    def test_cache_region(self):
+        recipe = self.recipe().metrics('age')
+        assert recipe._cache_region == 'default'
+
+        recipe = self.recipe().metrics('age').cache_region('foo')
+        assert recipe._cache_region == 'foo'
+
+        with pytest.raises(AssertionError):
+            self.recipe().metrics('age').use_cache(2)
+
     def test_dataset(self):
         recipe = self.recipe().metrics('age').dimensions('first')
         assert recipe.dataset.json == '[{"first": "hi", "age": 15, ' \


### PR DESCRIPTION
Add options to control caching in a recipe.

## recipe.use_cache(False)

Recipes can now set a flag to disable caching on a recipe. This doesn't actually prevent the recipe results from being stored in a cache, but invalidates the cache before getting data. If you run the same recipe without the use_cache flag later you will get cached results.

## recipe.cache_region

Recipes can define a cache region which will be used by the recipe-caching package.

## recipe.cache_prefix

Recipes can define a cache prefix which will be used by the recipe-caching package to namespace cache keys.