### PR TITLE
Extend Paginate to validate the page

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -113,14 +113,15 @@ class Recipe(object):
         ]
         self.dynamic_extensions = dynamic_extensions
 
-    def total_count(self):
+    def total_count(self, query=None):
         """Return the number of rows that would be returned by this Recipe,
         ignoring any `limit` that has been applied.
         """
         # If there is an ordering we take it off to make this
         # count run faster, then set the recipe to dirty so the
         # query is generated again
-        query = self.query()
+        if query is None:
+            query = self.query()
         if self._limit:
             query = query.limit(None)
         if self._order_bys:

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -116,6 +116,14 @@ class Recipe(object):
     def total_count(self, query=None):
         """Return the number of rows that would be returned by this Recipe,
         ignoring any `limit` that has been applied.
+
+        Args:
+
+            query: An optional SQLAlchemy query to calculate total_count for.
+              If None, the recipe query will be used.
+
+        Returns:
+            A count of the number of rows that are returned by this query.
         """
         # If there is an ordering we take it off to make this
         # count run faster, then set the recipe to dirty so the

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -745,8 +745,9 @@ class Paginate(RecipeExtension):
         :raises BadRecipe:
         """
         if self._validated_pagination is None:
-            raise BadRecipe("validated_pagination can only be accessed after the "
-                            "recipe has run")
+            raise BadRecipe(
+                "validated_pagination can only be accessed after the " "recipe has run"
+            )
         else:
             return self._validated_pagination
 

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -546,6 +546,7 @@ class Paginate(RecipeExtension):
         self._pagination_order_by = []
         self._pagination_page_size = 0
         self._pagination_page = 1
+        self._validated_pagination = None
 
     @recipe_arg()
     def from_config(self, obj):
@@ -709,17 +710,45 @@ class Paginate(RecipeExtension):
         """Apply pagination limits and offset to a completed query. """
 
         limit = self._pagination_page_size
-        page = self._pagination_page
-        # page=1 is the first page
-        offset = limit * (page - 1)
+        if limit == 0 or not self._apply_pagination:
+            return postquery_parts
 
-        if limit and self._apply_pagination:
-            if limit:
-                postquery_parts["query"] = postquery_parts["query"].limit(limit)
-            if offset:
-                postquery_parts["query"] = postquery_parts["query"].offset(offset)
+        # Validate what page we are on by looking at the total
+        # number of items.
+        total_count = self.recipe.total_count(postquery_parts["query"])
+
+        d, m = divmod(total_count, limit)
+        total_pages = d + (1 if m > 0 else 0)
+        page = self._pagination_page
+        validated_page = min(max(1, page), total_pages)
+
+        self._validated_pagination = {
+            "requestedPage": page,
+            "page": validated_page,
+            "pageSize": limit,
+            "totalItems": total_count,
+        }
+
+        # page=1 is the first page
+        offset = limit * (validated_page - 1)
+
+        postquery_parts["query"] = postquery_parts["query"].limit(limit)
+        if offset:
+            postquery_parts["query"] = postquery_parts["query"].offset(offset)
 
         return postquery_parts
+
+    def validated_pagination(self):
+        """ Return pagination validated against the actual number of items in the
+        response.
+
+        :raises BadRecipe:
+        """
+        if self._validated_pagination is None:
+            raise BadRecipe("validated_pagination can only be accessed after the "
+                            "recipe has run")
+        else:
+            return self._validated_pagination
 
 
 class BlendRecipe(RecipeExtension):

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -707,7 +707,7 @@ class Paginate(RecipeExtension):
         self._apply_pagination_q()
 
     def modify_postquery_parts(self, postquery_parts):
-        """Apply pagination limits and offset to a completed query. """
+        """Apply validated pagination limits and offset to a completed query. """
 
         limit = self._pagination_page_size
         if limit == 0 or not self._apply_pagination:
@@ -746,7 +746,7 @@ class Paginate(RecipeExtension):
         """
         if self._validated_pagination is None:
             raise BadRecipe(
-                "validated_pagination can only be accessed after the " "recipe has run"
+                "validated_pagination can only be accessed after the recipe has run"
             )
         else:
             return self._validated_pagination

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -574,10 +574,7 @@ GROUP BY state"""
     def test_pagination(self):
         """ If pagination page size is configured, pagination is applied to results"""
         recipe = (
-            self.recipe()
-            .metrics("pop2000")
-            .dimensions("age")
-            .pagination_page_size(10)
+            self.recipe().metrics("pop2000").dimensions("age").pagination_page_size(10)
         )
         assert (
             recipe.to_sql()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -576,18 +576,24 @@ GROUP BY state"""
         recipe = (
             self.recipe()
             .metrics("pop2000")
-            .dimensions("state")
+            .dimensions("age")
             .pagination_page_size(10)
         )
         assert (
             recipe.to_sql()
-            == """SELECT census.state AS state,
+            == """SELECT census.age AS age,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY state
+GROUP BY age
 LIMIT 10
 OFFSET 0"""
         )
+        assert recipe.validated_pagination() == {
+            "page": 1,
+            "pageSize": 10,
+            "requestedPage": 1,
+            "totalItems": 86,
+        }
 
         recipe = self.recipe_from_config(
             {
@@ -605,6 +611,12 @@ GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
+        assert recipe.validated_pagination() == {
+            "page": 1,
+            "pageSize": 10,
+            "requestedPage": 1,
+            "totalItems": 2,
+        }
 
         recipe = recipe.pagination_page(2)
         assert (
@@ -616,7 +628,6 @@ GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
-        print(recipe.validated_pagination())
         assert recipe.validated_pagination() == {
             "page": 1,
             "pageSize": 10,
@@ -637,13 +648,13 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 1
 OFFSET 1"""
         )
         assert recipe.validated_pagination() == {
-            "page": 1,
-            "pageSize": 10,
+            "page": 2,
+            "pageSize": 1,
             "requestedPage": 2,
             "totalItems": 2,
         }

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -614,14 +614,21 @@ OFFSET 0"""
 FROM census
 GROUP BY census.state
 LIMIT 10
-OFFSET 10"""
+OFFSET 0"""
         )
+        print(recipe.validated_pagination())
+        assert recipe.validated_pagination() == {
+            "page": 1,
+            "pageSize": 10,
+            "requestedPage": 2,
+            "totalItems": 2
+        }
 
         recipe = self.recipe_from_config(
             {
                 "metrics": ["pop2000"],
                 "dimensions": ["state"],
-                "pagination_page_size": 10,
+                "pagination_page_size": 1,
                 "pagination_page": 2,
             }
         )
@@ -631,9 +638,15 @@ OFFSET 10"""
        sum(census.pop2000) AS pop2000
 FROM census
 GROUP BY census.state
-LIMIT 10
-OFFSET 10"""
+LIMIT 1
+OFFSET 1"""
         )
+        assert recipe.validated_pagination() == {
+            "page": 1,
+            "pageSize": 10,
+            "requestedPage": 2,
+            "totalItems": 2
+        }
 
     def test_apply_pagination(self):
         recipe = (

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -466,10 +466,10 @@ ORDER BY foo.first"""
 
         recipe = (
             self.recipe()
-                .metrics("age")
-                .dimensions("firstanon")
-                .order_by("firstanon")
-                .anonymize(True)
+            .metrics("age")
+            .dimensions("firstanon")
+            .order_by("firstanon")
+            .anonymize(True)
         )
         assert (
             recipe.to_sql()
@@ -478,7 +478,7 @@ ORDER BY foo.first"""
 FROM foo
 GROUP BY foo.first
 ORDER BY foo.first"""
-    )
+        )
         assert recipe.all()[0].firstanon == fake_value
         assert recipe.all()[0].firstanon_raw == "hi"
         assert recipe.all()[0].firstanon_id == "hi"
@@ -621,7 +621,7 @@ OFFSET 0"""
             "page": 1,
             "pageSize": 10,
             "requestedPage": 2,
-            "totalItems": 2
+            "totalItems": 2,
         }
 
         recipe = self.recipe_from_config(
@@ -645,7 +645,7 @@ OFFSET 1"""
             "page": 1,
             "pageSize": 10,
             "requestedPage": 2,
-            "totalItems": 2
+            "totalItems": 2,
         }
 
     def test_apply_pagination(self):


### PR DESCRIPTION
The Paginate extension does not validate the page that is requested. Hence it is possible to request a page that isn't available in the data.

This PR improves paginate to validate page. 

After validation, `validated_pagination()` is available on recipe which provides the validated page returned.

```
        assert recipe.validated_pagination() == {
            "page": 1,
            "pageSize": 10,
            "requestedPage": 2,
            "totalItems": 2
        }
```

Validated_pagination returns a dictionary with the following properties

* `page`: The page that was fetched
* `pageSize`: The page size that was set with pagination_page_size
* `requestedPage`: The original, unvalidated page provided with pagination_page
* `totalItems`: The total number of rows available in the unpaginated dataset.