### PR TITLE
Create a default strategy that lets recipe GROUP BY using column labels

### DIFF
--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -776,7 +776,7 @@ class BlendRecipe(RecipeExtension):
         if self.blend_recipes:
             for ingr in self.recipe._cauldron.ingredients():
                 if isinstance(ingr, Dimension):
-                    ingr.group_by_strategy = 'direct'
+                    ingr.group_by_strategy = "direct"
 
     def modify_postquery_parts(self, postquery_parts):
         """
@@ -897,7 +897,7 @@ class CompareRecipe(RecipeExtension):
         if self.compare_recipe:
             for ingr in self.recipe._cauldron.ingredients():
                 if isinstance(ingr, Dimension):
-                    ingr.group_by_strategy = 'direct'
+                    ingr.group_by_strategy = "direct"
 
     def modify_postquery_parts(self, postquery_parts):
         """Make the comparison recipe a subquery that is left joined to the

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -767,6 +767,17 @@ class BlendRecipe(RecipeExtension):
         self.blend_types.append("outer")
         self.blend_criteria.append((join_base, join_blend))
 
+    def add_ingredients(self):
+        """If we have a blend_recipe, modify all ingredients in the base recipe
+        to group_by using the direct strategy. This is because when we join
+        the base recipe to the blend recipe we will likely have more than one column
+        that has the same label. This will generate invalid sql if a more explicit
+        reference isn't used. """
+        if self.blend_recipes:
+            for ingr in self.recipe._cauldron.ingredients():
+                if isinstance(ingr, Dimension):
+                    ingr.group_by_strategy = 'direct'
+
     def modify_postquery_parts(self, postquery_parts):
         """
         Make the comparison recipe a subquery that is left joined to the
@@ -876,6 +887,17 @@ class CompareRecipe(RecipeExtension):
         assert isinstance(suffix, basestring)
         self.compare_recipe.append(compare_recipe)
         self.suffix.append(suffix)
+
+    def add_ingredients(self):
+        """If we have a compare_recipe, modify all ingredients in the base recipe
+        to group_by using the direct strategy. This is because when we join
+        the base recipe to the compare recipe we will likely have more than one column
+        that has the same label. This will generate invalid sql if a more explicit
+        reference isn't used. """
+        if self.compare_recipe:
+            for ingr in self.recipe._cauldron.ingredients():
+                if isinstance(ingr, Dimension):
+                    ingr.group_by_strategy = 'direct'
 
     def modify_postquery_parts(self, postquery_parts):
         """Make the comparison recipe a subquery that is left joined to the

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -515,7 +515,7 @@ class Dimension(Ingredient):
             else:
                 self.formatters.insert(0, lambda value: self.lookup.get(value, value))
 
-    @group_by.getter
+    @property
     def group_by(self):
         # Ensure the labels are generated
         if not self._labels:

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -520,7 +520,7 @@ class Dimension(Ingredient):
         if not self._labels:
             list(self.query_columns)
 
-        if self.group_by_strategy == 'labels':
+        if self.group_by_strategy == "labels":
             return [lbl for gb, lbl in zip(self._group_by, self._labels)]
         else:
             return self._group_by

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -77,6 +77,8 @@ class Ingredient(object):
         self.column_suffixes = kwargs.pop("column_suffixes", None)
         self.cache_context = kwargs.pop("cache_context", "")
         self.anonymize = False
+        self._labels = []
+
         # What order should this be in
         self.ordering = kwargs.pop("ordering", "asc")
 
@@ -139,7 +141,9 @@ class Ingredient(object):
     def query_columns(self):
         """Yield labeled columns to be used as a select in a query.
         """
+        self._labels = []
         for column, suffix in zip(self.columns, self.make_column_suffixes()):
+            self._labels.append(self.id + suffix)
             yield column.label(self.id + suffix)
 
     @property
@@ -434,6 +438,13 @@ class Dimension(Ingredient):
         lookup_default (:obj:`object`)
             A default to show if the value can't be found in the
             lookup dictionary.
+        group_by_strategy (:obj:`str`):
+            A strategy to use when preparing group_bys for the query
+            "labels" is the default strategy which will use the labels assigned to
+            each column.
+            "direct" will use the column expression directly. This alternative is
+            useful when there might be more than one column with the same label
+            being used in the query.
 
     Returns:
 
@@ -449,6 +460,7 @@ class Dimension(Ingredient):
         # An optional exprssion to use instead of the value expression
         # when ordering
         order_by_expression = kwargs.pop("order_by_expression", None)
+        self.group_by_strategy = kwargs.pop("group_by_strategy", "labels")
 
         # We must always have a value role
         self.roles = {"value": expression}
@@ -463,17 +475,17 @@ class Dimension(Ingredient):
                 self.roles[role] = v
 
         self.columns = []
-        self.group_by = []
+        self._group_by = []
         self._order_by_columns = []
         self.role_keys = []
         if "id" in self.roles:
             self.columns.append(self.roles["id"])
-            self.group_by.append(self.roles["id"])
+            self._group_by.append(self.roles["id"])
             self.role_keys.append("id")
             self._order_by_columns.append(self.roles["id"])
         if "value" in self.roles:
             self.columns.append(self.roles["value"])
-            self.group_by.append(self.roles["value"])
+            self._group_by.append(self.roles["value"])
             self.role_keys.append("value")
             # Order by columns are in order of value, id
             # Extra roles are ignored
@@ -487,7 +499,7 @@ class Dimension(Ingredient):
             if k in ("id", "value"):
                 continue
             self.columns.append(self.roles[k])
-            self.group_by.append(self.roles[k])
+            self._group_by.append(self.roles[k])
             self.role_keys.append(k)
 
         if "lookup" in kwargs:
@@ -502,6 +514,21 @@ class Dimension(Ingredient):
                 )
             else:
                 self.formatters.insert(0, lambda value: self.lookup.get(value, value))
+
+    def get_group_by(self):
+        # Ensure the labels are generated
+        if not self._labels:
+            list(self.query_columns)
+
+        if self.group_by_strategy == 'labels':
+            return [lbl for gb, lbl in zip(self._group_by, self._labels)]
+        else:
+            return self._group_by
+
+    def set_group_by(self, value):
+        self._group_by = value
+
+    group_by = property(get_group_by, set_group_by)
 
     @property
     def cauldron_extras(self):

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -515,7 +515,8 @@ class Dimension(Ingredient):
             else:
                 self.formatters.insert(0, lambda value: self.lookup.get(value, value))
 
-    def get_group_by(self):
+    @group_by.getter
+    def group_by(self):
         # Ensure the labels are generated
         if not self._labels:
             list(self.query_columns)
@@ -525,10 +526,9 @@ class Dimension(Ingredient):
         else:
             return self._group_by
 
-    def set_group_by(self, value):
+    @group_by.setter
+    def group_by(self, value):
         self._group_by = value
-
-    group_by = property(get_group_by, set_group_by)
 
     @property
     def cauldron_extras(self):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -466,10 +466,10 @@ ORDER BY foo.first"""
 
         recipe = (
             self.recipe()
-                .metrics("age")
-                .dimensions("firstanon")
-                .order_by("firstanon")
-                .anonymize(True)
+            .metrics("age")
+            .dimensions("firstanon")
+            .order_by("firstanon")
+            .anonymize(True)
         )
         assert (
             recipe.to_sql()
@@ -478,7 +478,7 @@ ORDER BY foo.first"""
 FROM foo
 GROUP BY firstanon_raw
 ORDER BY foo.first"""
-    )
+        )
         assert recipe.all()[0].firstanon == fake_value
         assert recipe.all()[0].firstanon_raw == "hi"
         assert recipe.all()[0].firstanon_id == "hi"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -97,7 +97,7 @@ class TestAddFilterExtension(object):
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first > 2
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
 
@@ -169,7 +169,7 @@ class TestAutomaticFiltersExtension(object):
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         recipe = self.recipe().metrics("age").dimensions("first")
@@ -182,7 +182,7 @@ GROUP BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
     def test_automatic_filters(self):
@@ -197,7 +197,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first IN ('foo')
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         with pytest.raises(AssertionError):
@@ -214,7 +214,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first IS NULL
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
     def test_apply_automatic_filters(self):
@@ -227,7 +227,7 @@ GROUP BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
     def test_include_exclude_keys(self):
@@ -240,7 +240,7 @@ GROUP BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         recipe = self.recipe().metrics("age").dimensions("first")
@@ -253,7 +253,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first IN ('foo')
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         recipe = self.recipe().metrics("age").dimensions("first")
@@ -266,7 +266,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first IN ('foo')
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         recipe = self.recipe().metrics("age").dimensions("first")
@@ -278,7 +278,7 @@ GROUP BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         recipe = self.recipe().metrics("age").dimensions("first")
@@ -290,7 +290,7 @@ GROUP BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
     def test_operators(self):
@@ -303,7 +303,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first NOT IN ('foo')
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         # between operator
@@ -315,7 +315,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first BETWEEN 'foo' AND 'moo'
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
         # scalar operator
@@ -327,7 +327,7 @@ GROUP BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.first < 'moo'
-GROUP BY foo.first"""
+GROUP BY first"""
         )
 
 
@@ -387,7 +387,7 @@ class TestAnonymizeRecipeExtension(object):
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "fred"
@@ -407,7 +407,7 @@ ORDER BY foo.last"""
             == """SELECT foo.last AS last_raw,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last_raw
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "derf"
@@ -430,7 +430,7 @@ ORDER BY foo.last"""
             == """SELECT foo.first AS firstanon,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY firstanon
 ORDER BY foo.first"""
         )
         assert recipe.all()[0].firstanon == "hi"
@@ -450,7 +450,7 @@ ORDER BY foo.first"""
             == """SELECT foo.first AS firstanon_raw,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY firstanon_raw
 ORDER BY foo.first"""
         )
 
@@ -476,7 +476,7 @@ ORDER BY foo.first"""
             == """SELECT foo.first AS firstanon_raw,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY firstanon_raw
 ORDER BY foo.first"""
     )
         assert recipe.all()[0].firstanon == fake_value
@@ -499,7 +499,7 @@ ORDER BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY first
 ORDER BY foo.first"""
         )
         assert recipe.all()[0].first == "hi"
@@ -519,7 +519,7 @@ ORDER BY foo.first"""
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY first
 ORDER BY foo.first"""
         )
         assert recipe.all()[0].first == "hi"
@@ -557,7 +557,7 @@ class TestPaginateExtension(object):
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
 
         recipe = self.recipe_from_config(
@@ -568,7 +568,7 @@ GROUP BY census.state"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
 
     def test_pagination(self):
@@ -584,7 +584,7 @@ GROUP BY census.state"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -601,7 +601,7 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -612,7 +612,7 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 10"""
         )
@@ -630,7 +630,7 @@ OFFSET 10"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 10"""
         )
@@ -648,7 +648,7 @@ OFFSET 10"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
 
         recipe = self.recipe_from_config(
@@ -659,7 +659,7 @@ GROUP BY census.state"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
 
     def test_pagination_order_by(self):
@@ -675,7 +675,7 @@ GROUP BY census.state"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 ORDER BY census.state DESC
 LIMIT 10
 OFFSET 0"""
@@ -694,7 +694,7 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 ORDER BY census.state DESC
 LIMIT 10
 OFFSET 0"""
@@ -714,7 +714,7 @@ OFFSET 0"""
            sum(census.pop2000) AS pop2000
     FROM census
     WHERE lower(census.state) LIKE lower('T%')
-    GROUP BY census.state
+    GROUP BY state
     LIMIT 10
     OFFSET 0"""
             )
@@ -739,7 +739,7 @@ OFFSET 0"""
            sum(census.pop2000) AS pop2000
     FROM census
     WHERE lower(census.state) LIKE lower('T%')
-    GROUP BY census.state
+    GROUP BY state
     LIMIT 10
     OFFSET 0"""
             )
@@ -759,7 +759,7 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -778,7 +778,7 @@ OFFSET 0"""
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -798,7 +798,7 @@ OFFSET 0"""
        sum(census.pop2000) AS pop2000
 FROM census
 WHERE lower(census.sex) LIKE lower('M')
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -819,7 +819,7 @@ OFFSET 0"""
 FROM census
 WHERE lower(census.sex) LIKE lower('M')
   OR lower(census.state) LIKE lower('M')
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -847,7 +847,7 @@ Vermont,298532,Vermont
 FROM census
 WHERE lower(census.sex) LIKE lower('M')
   OR lower(census.state) LIKE lower('M')
-GROUP BY census.state
+GROUP BY state
 LIMIT 10
 OFFSET 0"""
         )
@@ -873,9 +873,9 @@ OFFSET 0"""
 FROM census
 WHERE lower(census.state) LIKE lower('T%')
   OR lower(census.sex) LIKE lower('T%')
-GROUP BY census.age,
-         census.sex,
-         census.state
+GROUP BY age,
+         sex,
+         state
 LIMIT 10
 OFFSET 40"""
         )
@@ -924,9 +924,9 @@ OFFSET 40"""
 FROM census
 WHERE lower(census.state) LIKE lower('T%')
   OR lower(census.sex) LIKE lower('T%')
-GROUP BY census.age,
-         census.sex,
-         census.state
+GROUP BY age,
+         sex,
+         state
 LIMIT 10
 OFFSET 40"""
         )
@@ -973,8 +973,8 @@ FROM
           foo.last AS last,
           sum(foo.age) AS age
    FROM foo
-   GROUP BY foo.first,
-            foo.last) AS summarize
+   GROUP BY first,
+            last) AS summarize
 GROUP BY summarize.first"""
         )
 
@@ -996,8 +996,8 @@ FROM
           foo.last AS last,
           sum(foo.age) AS age
    FROM foo
-   GROUP BY foo.first,
-            foo.last) AS summarize
+   GROUP BY first,
+            last) AS summarize
 GROUP BY summarize.first"""
         )
         assert len(recipe.all()) == 1
@@ -1023,8 +1023,8 @@ FROM
           foo.last AS last_raw,
           sum(foo.age) AS age
    FROM foo
-   GROUP BY foo.first,
-            foo.last) AS summarize
+   GROUP BY first_raw,
+            last_raw) AS summarize
 GROUP BY summarize.first_raw"""
         )
         assert len(recipe.all()) == 1
@@ -1054,8 +1054,8 @@ FROM
           scores.username AS username,
           avg(scores.score) AS score
    FROM scores
-   GROUP BY scores.department,
-            scores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department"""
         )
         ops_row, sales_row = recipe.all()
@@ -1084,8 +1084,8 @@ FROM
           scores.username AS username,
           avg(scores.score) AS score
    FROM scores
-   GROUP BY scores.department,
-            scores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department LIMIT 2
 OFFSET 0""",
             """SELECT summarize.department,
@@ -1095,8 +1095,8 @@ FROM
           scores.username AS username,
           avg(scores.score) AS score
    FROM scores
-   GROUP BY scores.department,
-            scores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department
 LIMIT 2
 OFFSET 0""",
@@ -1162,8 +1162,8 @@ FROM
           scores.username AS username,
           avg(scores.score) AS score
    FROM scores
-   GROUP BY scores.department,
-            scores.username
+   GROUP BY department_raw,
+            username
    ORDER BY scores.department) AS summarize
 GROUP BY summarize.department_raw
 ORDER BY summarize.department_raw"""
@@ -1197,8 +1197,8 @@ FROM
           avg(scores.score) AS score
    FROM scores
    WHERE scores.department = 'ops'
-   GROUP BY scores.department,
-            scores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department"""
         )
         ops_row = recipe.one()
@@ -1230,8 +1230,8 @@ FROM
           tagscores.username AS username,
           avg(tagscores.score) AS score
    FROM tagscores
-   GROUP BY tagscores.department,
-            tagscores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department"""
         )
         ops_row, sales_row = recipe.all()
@@ -1261,8 +1261,8 @@ FROM
           avg(tagscores.score) AS score
    FROM tagscores
    WHERE tagscores.tag = 'musician'
-   GROUP BY tagscores.department,
-            tagscores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department"""
         )
         row = recipe.one()
@@ -1288,8 +1288,8 @@ FROM
           tagscores.username AS username,
           count(DISTINCT tagscores.testid) AS test_cnt
    FROM tagscores
-   GROUP BY tagscores.department,
-            tagscores.username) AS summarize
+   GROUP BY department,
+            username) AS summarize
 GROUP BY summarize.department"""
         )
         ops_row, sales_row = recipe.all()
@@ -1341,7 +1341,7 @@ LEFT OUTER JOIN
           sum(census.pop2000) AS pop2000
    FROM census
    WHERE census.state = 'Vermont'
-   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
 GROUP BY census.sex
 ORDER BY census.sex"""
         )
@@ -1380,7 +1380,7 @@ LEFT OUTER JOIN
           sum(census.pop2000) AS pop2000_sum
    FROM census
    WHERE census.state = 'Vermont'
-   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
 GROUP BY census.sex
 ORDER BY census.sex"""
         )
@@ -1418,7 +1418,7 @@ LEFT OUTER JOIN
           sum(census.pop2000) AS pop2000
    FROM census
    WHERE census.state = 'Vermont'
-   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
 GROUP BY census.sex
 ORDER BY census.sex"""
         )
@@ -1466,7 +1466,7 @@ LEFT OUTER JOIN
           sum(census.pop2000) AS pop2000
    FROM census
    WHERE census.state = 'Vermont'
-   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
 LEFT OUTER JOIN
   (SELECT sum(census.pop2000) AS pop2000
    FROM census) AS anon_2 ON 1=1
@@ -1548,7 +1548,7 @@ LEFT OUTER JOIN
           sum(census.pop2008) AS pop2008
    FROM census
    WHERE census.sex = 'F'
-   GROUP BY census.sex) AS anon_1 ON census.sex = anon_1.sex
+   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
 GROUP BY census.sex
 ORDER BY census.sex"""
         )
@@ -1585,8 +1585,8 @@ JOIN
   (SELECT state_fact.abbreviation AS abbreviation,
           state_fact.name AS state
    FROM state_fact
-   GROUP BY state_fact.abbreviation,
-            state_fact.name) AS anon_1 ON census.state = anon_1.state
+   GROUP BY abbreviation,
+            state) AS anon_1 ON census.state = anon_1.state
 GROUP BY census.state,
          anon_1.abbreviation
 ORDER BY census.state"""

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -30,7 +30,7 @@ class TestRecipeIngredients(object):
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].age == 15
@@ -44,8 +44,8 @@ GROUP BY foo.first"""
        foo.last AS firstlast,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last"""
+GROUP BY firstlast_id,
+         firstlast"""
         )
         assert recipe.all()[0].firstlast == "fred"
         assert recipe.all()[0].firstlast_id == "hi"
@@ -71,9 +71,9 @@ GROUP BY foo.first,
        foo.age AS d_age,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last,
-         foo.age"""
+GROUP BY d_id,
+         d,
+         d_age"""
         )
         assert recipe.all()[0].d == "fred"
         assert recipe.all()[0].d_id == "hi"
@@ -104,9 +104,9 @@ GROUP BY foo.first,
        foo.age AS d_age,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last,
-         foo.age"""
+GROUP BY d_id,
+         d_raw,
+         d_age"""
         )
 
         assert recipe.all()[0].d_raw == "fred"
@@ -128,7 +128,7 @@ GROUP BY foo.first,
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first
+GROUP BY first
 LIMIT ?
 OFFSET 1"""
         )
@@ -199,7 +199,7 @@ hi\t15\thi\r
             == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first"""
+GROUP BY first"""
         )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].age == 15
@@ -228,7 +228,7 @@ GROUP BY foo.first"""
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "fred"
@@ -243,7 +243,7 @@ ORDER BY foo.last"""
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "fred"
@@ -256,7 +256,7 @@ ORDER BY foo.last"""
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY sum(foo.age)"""
         )
         assert recipe.all()[0].last == "there"
@@ -269,7 +269,7 @@ ORDER BY sum(foo.age)"""
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY sum(foo.age) DESC"""
         )
         assert recipe.all()[0].last == "fred"
@@ -286,8 +286,8 @@ ORDER BY sum(foo.age) DESC"""
        foo.last AS firstlast,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last
+GROUP BY firstlast_id,
+         firstlast
 ORDER BY foo.last,
          foo.first"""
         )
@@ -300,8 +300,8 @@ ORDER BY foo.last,
        foo.last AS firstlast,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last
+GROUP BY firstlast_id,
+         firstlast
 ORDER BY foo.last DESC,
          foo.first DESC"""
         )
@@ -320,8 +320,8 @@ ORDER BY foo.last DESC,
        foo.last AS d,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.first,
-         foo.last
+GROUP BY d_id,
+         d
 ORDER BY upper(foo.last),
          foo.first"""
         )
@@ -334,7 +334,7 @@ ORDER BY upper(foo.last),
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "fred"
@@ -352,7 +352,7 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 4
-GROUP BY foo.first
+GROUP BY first
 ORDER BY foo.first"""
         )
         assert recipe.all()[0].first == "hi"
@@ -376,8 +376,8 @@ SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 4
-GROUP BY foo.first,
-         foo.last"""
+GROUP BY first,
+         last"""
         )
 
     def test_from_config_filter_object(self):
@@ -400,7 +400,7 @@ SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 13
-GROUP BY foo.last"""
+GROUP BY last"""
         )
 
     def test_from_config_extra_kwargs(self):
@@ -414,7 +414,7 @@ GROUP BY foo.last"""
 SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
 
@@ -455,7 +455,7 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 2
-GROUP BY foo.last
+GROUP BY last
 ORDER BY foo.last"""
         )
         assert recipe.all()[0].last == "fred"
@@ -479,7 +479,7 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 WHERE foo.age > 2
-GROUP BY foo.last
+GROUP BY last
 HAVING sum(foo.age) < 10
 ORDER BY foo.last"""
         )
@@ -680,8 +680,8 @@ FROM
   (SELECT foo.last AS last,
           sum(foo.age) AS age
    FROM foo
-   GROUP BY foo.last) AS anon
-GROUP BY anon.last"""
+   GROUP BY last) AS anon
+GROUP BY last"""
         )
         assert len(r.all()) == 2
 
@@ -719,7 +719,7 @@ class TestSelectFrom(object):
        sum(census.pop2000) AS pop
 FROM census
 JOIN state_fact ON census.state = state_fact.name
-GROUP BY state_fact.census_region_name"""
+GROUP BY region"""
         )
         assert (
             r.dataset.tsv
@@ -766,7 +766,7 @@ class TestShelfSelectFrom(object):
        sum(census.pop2000) AS pop
 FROM census
 JOIN state_fact ON census.state = state_fact.name
-GROUP BY state_fact.census_region_name"""
+GROUP BY region"""
         )
         assert (
             r.dataset.tsv
@@ -804,7 +804,7 @@ FROM
   (SELECT census.state AS state,
           sum(census.pop2000) AS pop2000
    FROM census
-   GROUP BY census.state) AS anon_1"""
+   GROUP BY state) AS anon_1"""
         )
         assert r.dataset.tsv == """pop\r\n3147355.0\r\n"""
 
@@ -835,7 +835,7 @@ FROM
   (SELECT census.state AS state,
           sum(census.pop2000) AS pop2000
    FROM census
-   GROUP BY census.state) AS anon_1"""
+   GROUP BY state) AS anon_1"""
         )
         assert r.dataset.tsv == """pop\r\n3147355.0\r\n"""
 
@@ -859,7 +859,7 @@ FROM
   (SELECT census.state AS state,
           sum(census.pop2000) AS pop2000
    FROM census
-   GROUP BY census.state) AS anon_1"""
+   GROUP BY state) AS anon_1"""
         )
         assert r2.dataset.tsv == """pop\r\n3147355.0\r\n"""
 

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -58,7 +58,7 @@ class TestFindColumn(object):
             == """SELECT census.state AS state,
        sum(census.pop2000) AS sum_pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
 
         col = find_column(recipe, "state")
@@ -615,7 +615,7 @@ ttlpop:
             == """SELECT census.state AS state,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY census.state"""
+GROUP BY state"""
         )
         assert (
             recipe.dataset.tsv


### PR DESCRIPTION
When running recipe with a bigquery backend, we were generating invalid SQL with queries like this one

```
SELECT CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END AS age_buckets,
       sum(census.pop2000) AS pop2000
FROM census
GROUP BY CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END
```

In this case, we are grouping by the column labeled age_buckets. However, the bigquery SQL engine was not able to parse that age_buckets was the same as the GROUP BY expression. 

This PR creates a new `group_by_strategy` parameter on Dimension that controls how group by is generated. The default case is now `group_by_strategy="labels"` which uses the labels on columns as the GROUP BYs. The SQL example above now is

```
SELECT CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END AS age_buckets,
       sum(census.pop2000) AS pop2000
FROM census
GROUP BY age_buckets
```

This generates slightly more compact code. 

However this does create one issue. In this example, invalid SQL is generated because the reference to `sex` in ambigous. It could refer to census.sex or anon_1.sex.

```
SELECT census.sex AS sex,
       sum(census.pop2000) AS pop2000,
       avg(anon_1.pop2000) AS pop2000_compare
FROM census
LEFT OUTER JOIN
  (SELECT census.sex AS sex,
          sum(census.pop2000) AS pop2000
   FROM census
   WHERE census.state = 'Vermont'
   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
GROUP BY sex                                           -- <=== This is the problem 
ORDER BY census.sex
```

Both the CompareRecipe extension and the BlendRecipe extension invoke the original `group_by_strategy="direct"` strategy for GROUP BYs if they are used.

This will generate the following valid SQL.

```
SELECT census.sex AS sex,
       sum(census.pop2000) AS pop2000,
       avg(anon_1.pop2000) AS pop2000_compare
FROM census
LEFT OUTER JOIN
  (SELECT census.sex AS sex,
          sum(census.pop2000) AS pop2000
   FROM census
   WHERE census.state = 'Vermont'
   GROUP BY sex) AS anon_1 ON census.sex = anon_1.sex
GROUP BY census.sex
ORDER BY census.sex
```

