### PR TITLE
Update recipe to use the more-accurate `fetched_from_cache` CachingQuery attribute

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -520,7 +520,7 @@ class Recipe(object):
                 self._query.all(), cache_context=self.cache_context
             )
             enchanttime = time.time()
-            fetched_from_cache = getattr(query, 'fetched_from_cache', False)
+            fetched_from_cache = getattr(self._query, 'fetched_from_cache', False)
         else:
             fetched_from_cache = True
 

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -520,7 +520,7 @@ class Recipe(object):
                 self._query.all(), cache_context=self.cache_context
             )
             enchanttime = time.time()
-            fetched_from_cache = getattr(self._query, 'fetched_from_cache', False)
+            fetched_from_cache = getattr(self._query, "fetched_from_cache", False)
         else:
             fetched_from_cache = True
 

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -508,29 +508,21 @@ class Recipe(object):
         starttime = fetchtime = enchanttime = time.time()
         self.query()
 
-        fetched_from_cache = True
         if self._all is None:
-            fetched_from_cache = False
-
-            # If we're using a caching query and that query did not
-            # save new values to cache, we got the cached results
-            # This is not 100% accurate; it only reports if the caching query
-            # attempts to save to cache not the internal state of the cache
-            # and whether the cache save actually occurred.
-            if not getattr(self._query, "saved_to_cache", True):
-                fetched_from_cache = True
             fetchtime = time.time()
             if not self._use_cache:
                 # Invalidate this query in the cache
                 # to ensure it gets fresh data from the database
                 if hasattr(self._query, "invalidate"):
-                    fetched_from_cache = False
                     self._query.invalidate()
 
             self._all = self._cauldron.enchant(
                 self._query.all(), cache_context=self.cache_context
             )
             enchanttime = time.time()
+            fetched_from_cache = getattr(query, 'fetched_from_cache', False)
+        else:
+            fetched_from_cache = True
 
         self.stats.rows = len(self._all)
         self.stats.dbtime = fetchtime - starttime

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -22,6 +22,7 @@ import sqlalchemy.orm
 import sqlparse
 from faker import Faker
 from faker.providers import BaseProvider
+from six import text_type, string_types
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.sql.sqltypes import Date, DateTime, NullType, String
@@ -153,8 +154,12 @@ def replace_whitespace_with_space(s):
 
 
 def clean_unicode(value):
+    """Convert a unicode value into ASCII bytes."""
     try:
-        cleaned_value = str(value)
+        if isinstance(value, string_types):
+            cleaned_value = value.encode("ascii")
+        else:
+            cleaned_value = text_type(value).encode("ascii")
     except UnicodeEncodeError:
         cleaned_value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore")
         if not cleaned_value:

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -154,17 +154,14 @@ def replace_whitespace_with_space(s):
 
 
 def clean_unicode(value):
-    """Convert a unicode value into ASCII bytes."""
+    """Convert value into ASCII bytes by brute force."""
+    if not isinstance(value, string_types):
+        value = text_type(value)
     try:
-        if isinstance(value, string_types):
-            cleaned_value = value.encode("ascii")
-        else:
-            cleaned_value = text_type(value).encode("ascii")
+        return value.encode("ascii")
     except UnicodeEncodeError:
-        cleaned_value = unicodedata.normalize("NFKD", value).encode("ascii", "ignore")
-        if not cleaned_value:
-            raise ValueError("Could not find useful chars in the string")
-    return cleaned_value
+        value = unicodedata.normalize("NFKD", value)
+        return value.encode("ascii", "ignore")
 
 
 class AttrDict(dict):

--- a/tests/test_clean_unicode.py
+++ b/tests/test_clean_unicode.py
@@ -5,46 +5,45 @@ from recipe.utils import clean_unicode
 
 
 class TestCleanUnicode(object):
-
     def test_string(self):
-        value = clean_unicode('cookies')
-        assert value, b'cookies'
+        value = clean_unicode("cookies")
+        assert value, b"cookies"
 
     def test_nonstring(self):
         value = clean_unicode(22.04)
-        assert value == b'22.04'
+        assert value == b"22.04"
 
         value = clean_unicode(None)
-        assert value == b'None'
+        assert value == b"None"
 
     def test_unicode_string(self):
-        test_string = u'Falsches Üben von Xylophonmusik quält jeden größeren' \
-            ' Zwerg'
-        expected_string = b'Falsches Uben von Xylophonmusik qualt jeden ' \
-                          b'groeren Zwerg'
+        test_string = u"Falsches Üben von Xylophonmusik quält jeden größeren" " Zwerg"
+        expected_string = (
+            b"Falsches Uben von Xylophonmusik qualt jeden " b"groeren Zwerg"
+        )
         value = clean_unicode(test_string)
         assert value == expected_string
 
     def test_unicode_string_single_upper(self):
-        test_string = u'«küßî»'
-        expected_string = b'kui'
+        test_string = u"«küßî»"
+        expected_string = b"kui"
         value = clean_unicode(test_string)
         assert value == expected_string
 
     def test_unicode_string_dashes(self):
-        test_string = u'― Like this? ― Right.'
-        expected_string = b' Like this?  Right.'
+        test_string = u"― Like this? ― Right."
+        expected_string = b" Like this?  Right."
         value = clean_unicode(test_string)
         assert value == expected_string
 
     def test_unicode_string_o_walk(self):
-        test_string = u'oòóôõöōŏǫȯőǒȍȏ'
-        expected_string = b'oooooooooooooo'
+        test_string = u"oòóôõöōŏǫȯőǒȍȏ"
+        expected_string = b"oooooooooooooo"
         value = clean_unicode(test_string)
         assert value == expected_string
 
     def test_unicode_string_two_byte_no_chars(self):
-        test_string = u'“ЌύБЇ”'
-        expected_string = b''
+        test_string = u"“ЌύБЇ”"
+        expected_string = b""
         value = clean_unicode(test_string)
         assert value == expected_string

--- a/tests/test_clean_unicode.py
+++ b/tests/test_clean_unicode.py
@@ -1,0 +1,50 @@
+# -*- coding: UTF-8 -*-
+from __future__ import print_function
+
+from recipe.utils import clean_unicode
+
+
+class TestCleanUnicode(object):
+
+    def test_string(self):
+        value = clean_unicode('cookies')
+        assert value, b'cookies'
+
+    def test_nonstring(self):
+        value = clean_unicode(22.04)
+        assert value == b'22.04'
+
+        value = clean_unicode(None)
+        assert value == b'None'
+
+    def test_unicode_string(self):
+        test_string = u'Falsches Üben von Xylophonmusik quält jeden größeren' \
+            ' Zwerg'
+        expected_string = b'Falsches Uben von Xylophonmusik qualt jeden ' \
+                          b'groeren Zwerg'
+        value = clean_unicode(test_string)
+        assert value == expected_string
+
+    def test_unicode_string_single_upper(self):
+        test_string = u'«küßî»'
+        expected_string = b'kui'
+        value = clean_unicode(test_string)
+        assert value == expected_string
+
+    def test_unicode_string_dashes(self):
+        test_string = u'― Like this? ― Right.'
+        expected_string = b' Like this?  Right.'
+        value = clean_unicode(test_string)
+        assert value == expected_string
+
+    def test_unicode_string_o_walk(self):
+        test_string = u'oòóôõöōŏǫȯőǒȍȏ'
+        expected_string = b'oooooooooooooo'
+        value = clean_unicode(test_string)
+        assert value == expected_string
+
+    def test_unicode_string_two_byte_no_chars(self):
+        test_string = u'“ЌύБЇ”'
+        expected_string = b''
+        value = clean_unicode(test_string)
+        assert value == expected_string


### PR DESCRIPTION
## Changes

- Delete code about how inaccurate `saved_to_cache` is, and change the code to use `fetched_from_cache` to determine whether the query was fetched from cache.
- update the `clean_unicode` implementation to match the one we have in fruition, which is safe on both py2 and py3. This function isn't used anywhere in recipe, but it is used in recipe_caching.