### PR TITLE
Remove pyhash as a requirement

### DIFF
--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -7,8 +7,6 @@ import unicodedata
 from .compat import str as compat_str
 from functools import wraps
 
-from pyhash import metro_64
-
 try:
     # getfullargspec is not available in python2
     # getargspec is deprecated
@@ -20,6 +18,8 @@ except ImportError:
 import attr
 import sqlalchemy.orm
 import sqlparse
+import hashlib
+
 from faker import Faker
 from faker.providers import BaseProvider
 from six import text_type, string_types
@@ -39,15 +39,14 @@ __all__ = [
 ]
 
 
-hash_fn = metro_64()
-
-
 def generate_faker_seed(value):
     """Generate a seed value for faker. """
     if not isinstance(value, compat_str):
         value = compat_str(value)
 
-    return hash_fn(value)
+    h = hashlib.new('md5')
+    h.update(value.encode('utf-8'))
+    return int(h.hexdigest()[:16], 16)
 
 
 def recipe_arg(*args):

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -44,8 +44,8 @@ def generate_faker_seed(value):
     if not isinstance(value, compat_str):
         value = compat_str(value)
 
-    h = hashlib.new('md5')
-    h.update(value.encode('utf-8'))
+    h = hashlib.new("md5")
+    h.update(value.encode("utf-8"))
     return int(h.hexdigest()[:16], 16)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ pyyaml>=4.2b1
 sureberus==0.14.0
 dateparser==0.7.1
 attrs==19.1.0
-pyhash==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ install = [
     'faker',
     'dateparser',
     'attrs',
-    'pyhash',
 ]
 # yapf: enable
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,13 +25,12 @@ class TestUtils(object):
 
     def test_generate_faker_seed(self):
         """ Test we get the same seed values in py2 and py3 """
-
         assert compat_str("2") == compat_str(u"2")
-        assert generate_faker_seed(None) == 15208487303490345319
-        assert generate_faker_seed(0) == 17387988563394623128
-        assert generate_faker_seed(u"hi") == 14742342832905345683
-        assert generate_faker_seed("hi") == 14742342832905345683
-        assert generate_faker_seed([]) == 2766641713143040348
+        assert generate_faker_seed(None) == 7701040980221191251
+        assert generate_faker_seed(0) == 14973660089898329583
+        assert generate_faker_seed(u"hi") == 5329599339005471788
+        assert generate_faker_seed("hi") == 5329599339005471788
+        assert generate_faker_seed([]) == 15515306683186839187
 
 
 class TestAttrDict(object):


### PR DESCRIPTION
The goal of our hashing is to generate a stable integer that we can use for seeding. Pyhash  requires memory intensive compilation during pip install which was breaking docs builds. Instead of using this
we can use a md5 hash and convert it to an integer.