### PR TITLE
Remove flapjack_stack dependency

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -4,14 +4,22 @@ Settings
 
 Recipe now has a ``SETTINGS`` object that can be use to store and modify any
 configuration options or setting needed for use within the recipe library.
-Any library wide settings should be made in the ``default_settings.py`` file.
-The settings object is based on the flapjack_stack library, which offers the
-ability to store settings in a stack and easily pop on and off settings. You
-can learn more about how to use flapjack_stack in its
-`documentation <http://flapjack-stack.readthedocs.io/en/latest/>`_.
 
 To access the ``SETTINGS`` object import it from recipe.
 
 .. code-block:: python
 
     from recipe import SETTINGS
+
+Recipe settings are
+
+**POOL_SIZE**
+    Used to set the ``pool_size`` kwarg property in a SQLAlchemy connection
+
+**POOL_RECYCLE**
+    Used to set the ``pool_recycle`` kwarg property in a SQLAlchemy connection
+
+The pluggable recipe_caching extension uses the following setting.
+
+**CACHE_REGIONS**
+    Used to set a dictionary of dogpile cache regions.

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -5,8 +5,6 @@ Recipe
 """
 import logging
 
-from flapjack_stack import FlapjackStack
-
 from recipe.core import Recipe
 from recipe.exceptions import BadIngredient, BadRecipe
 from recipe.extensions import (
@@ -40,8 +38,8 @@ class DefaultSettings(object):
         self.POOL_RECYCLE = 60 * 60
 
 
-SETTINGS = FlapjackStack()
-SETTINGS.add_layer(DefaultSettings())
+SETTINGS = DefaultSettings()
+
 
 try:  # Python 2.7+
     from logging import NullHandler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 faker==2.0.3
-flapjack_stack==1.0.0
 orderedset==2.0.1
 py==1.4.32
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ install = [
     'sqlparse',
     'tablib',
     'pyyaml',
-    'flapjack_stack',
     'stevedore',
     'sureberus',
     'faker',


### PR DESCRIPTION
Removes the flapjack_stack dependency. This adds some complexity that we don't need and pins a version of pyyaml that is insecure.