### PR TITLE
Release 0.12

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.3
+current_version = 0.12.0
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+0.12.0 (2019-11-25)
+-----------------------------------------
+
+* remove flapjack_stack and pyhash dependencies
+* Add percentile aggregations to metrics from config.
+* Use more accurate fetched_from_cache caching query attribute
+* Add grouping strategies so recipes can group by column labels
+
+
 0.11.0 (2019-11-07)
 -----------------------------------------
 * Add Paginate extension

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.11.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.12.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.11.3...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.12.0...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.11.3"
+version = release = "0.12.0"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -52,7 +52,7 @@ except ImportError:
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 
 __all__ = [
     "BadIngredient",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.11.3",
+    version="0.12.0",
     description="Lego consstruction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",


### PR DESCRIPTION

0.12.0 (2019-11-25)
-----------------------------------------

* remove flapjack_stack and pyhash dependencies
* Add percentile aggregations to metrics from config.
* Use more accurate fetched_from_cache caching query attribute
* Add grouping strategies so recipes can group by column labels