### PR TITLE
Update to an ordered-set that will work in python 3.8

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import attr
 import tablib
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 from sqlalchemy import alias, func
 from sqlalchemy.sql.elements import BinaryExpression
 from sureberus import normalize_dict, normalize_schema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 faker==2.0.4
-orderedset==2.0.1
+ordered-set==3.1.1
 six==1.13.0
 SQLAlchemy>=1.2.2
 sqlparse==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if sys.argv[-1] == "test":
 
 # yapf: disable
 install = [
-    'orderedset',
+    'ordered-set',
     'six',
     'sqlalchemy>=1.2.2',
     'sqlparse',


### PR DESCRIPTION
Orderedset has a deprecation warning

```
  /Users/chrisgemignani/.virtualenvs/recipe/lib/python3.7/site-packages/orderedset/__init__.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from ._orderedset import OrderedSet
```