### PR TITLE
Rework of orderings to use labels and other internal improvements

### DIFF
--- a/docs/concepts/ingredients.rst
+++ b/docs/concepts/ingredients.rst
@@ -122,6 +122,51 @@ them.
 The id is accessible as ``employee_id`` in each row and their full name is
 available as ``employee``.
 
+If you build a filter using this dimension, it will filter against the id.
+
+Adding an ordering
+~~~~~~~~~~~~~~~~~~
+
+If you want to order a dimension in a custom way, pass a keyword argument
+``order_by_expression``. This code adds an order_by_expression that causes the
+values to sort case insensitively.
+
+.. code-block:: python
+
+    from sqlalchemy import func
+
+    # Support an id and a label
+    self.shelf['employee']: Dimension(Employee.full_name,
+                                      order_by_expression=func.lower(
+                                        Employee.full_name
+                                      ))
+
+The order_by expression is accessible as ``employee_order_by`` in each row and
+the full name is available as ``employee``. If the `employee` dimension is used in a
+recipe, the recipe will **always** be ordered by ``func.lower(Employee.full_name)``.
+
+Adding additional groupings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both ``id_expression`` and ``order_by_expression`` are special cases of Dimension's
+ability to be passed additional columns can be used for grouping. Any keyword argument
+suffixed with ``_expression`` adds additional roles to this Dimension. The first
+*required* expression supplies the dimension's value role. For instance,
+you could create a dimension with an ``id``, a ``latitude`` and a ``longitude``.
+
+For instance, the following
+
+.. code-block:: python
+
+    Dimension(Hospitals.name,
+              latitude_expression=Hospitals.lat
+              longitude_expression=Hospitals.lng,
+              id='hospital')
+
+would add columns named "hospital", "hospital_latitude", and
+"hospital_longitude" to the recipes results. All three of these expressions
+would be used as group bys.
+
 Using lookups
 ~~~~~~~~~~~~~
 
@@ -138,7 +183,7 @@ If you use the gender dimension, there will be a ``gender_id`` in each row
 that will be "M" or "F" and a ``gender`` in each row that will be "Male" or
 "Female".
 
-.. code:: python
+.. code-block:: python
 
     shelf = Shelf({
         'state': Dimension(Census.state),
@@ -160,7 +205,7 @@ property. All dimensions also generate an ``{ingredient}_id`` property.
 
 Here is the query and the results.
 
-.. code:: python
+.. code-block::
 
     SELECT census.gender AS gender_desc_raw,
         sum(census.pop2000) AS population
@@ -171,13 +216,14 @@ Here is the query and the results.
     F,143534804,Female,F
     M,137392517,Male,M
 
+
 Metric
 ------
 
 Metrics are aggregations performed on your data. Here's an example
 of a few Metrics.
 
-.. code:: python
+.. code-block:: python
 
     shelf = Shelf({
         'total_population': Metric(func.sum(Census.pop2000)),

--- a/docs/concepts/ingredients.rst
+++ b/docs/concepts/ingredients.rst
@@ -2,7 +2,7 @@
 Ingredients
 ===========
 
-Ingredients are the building block of recipe. 
+Ingredients are the building block of recipe.
 
 Ingredients can contain columns that are part of the ``SELECT`` portion of a query,
 filters that are part of a ``WHERE`` clause of a query, group_bys that
@@ -16,18 +16,18 @@ Creating ingredients in python
 Ingredients can be created either in python or via configuration. To created
 Ingredients in python, use one of the four convenience classes.
 
-* **Metric**: Create an aggregated calculation using a column. This 
+* **Metric**: Create an aggregated calculation using a column. This
   value appears only in the SELECT part of the SQL statement.
-* **Dimension**: Create a non-aggregated value using a column. This 
+* **Dimension**: Create a non-aggregated value using a column. This
   value appears in the SELECT and GROUP BY parts of the SQL statement.
-* **Filter**: Create a boolean expression. This value appears in the 
-  WHERE part of the SQL statement. Filters can be created automatically 
+* **Filter**: Create a boolean expression. This value appears in the
+  WHERE part of the SQL statement. Filters can be created automatically
   using the AutomaticFilters extension or by using a Dimension or Metric'sales
   ``build_filter`` method.
-* **Having**: Create a boolean expression with an aggregated ColumnElement. 
-  This value appears in the HAVING part of the SQL statement. 
-  
-Metrics and Dimensions are commonly reused in working Recipe code, while filters are 
+* **Having**: Create a boolean expression with an aggregated ColumnElement.
+  This value appears in the HAVING part of the SQL statement.
+
+Metrics and Dimensions are commonly reused in working Recipe code, while filters are
 often created temporarily based on data.
 
 Features of ingredients
@@ -59,7 +59,7 @@ formatters, the original, unmodified value is available as ``{ingredient}_raw``.
     for row in recipe.all():
         print('{} has {} people'.format(row.gender, row.population))
         print('\tThe original value is: {}'.format(row.population_raw))
-        
+
 The results look like
 
 .. code::
@@ -79,7 +79,7 @@ Storing extra attributes in meta
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Extra keyword arguments that get passed to ingredient initialization
-get stored in the ``meta`` object. This can be used to extend the 
+get stored in the ``meta`` object. This can be used to extend the
 capabilities of ingredients and add extra features.
 
 .. code:: python
@@ -125,7 +125,7 @@ available as ``employee``.
 Using lookups
 ~~~~~~~~~~~~~
 
-Lookup maps values in your data to descriptive names. The ``_id``
+You can use a lookup table to map values in your data to descriptive names. The ``_id``
 property of your dimension contains the original value.
 
 .. code-block:: python
@@ -197,7 +197,7 @@ The results of this recipe are:
         min(census.pop2000) AS min_population,
         sum(census.pop2000) AS total_population
     FROM census
-    
+
     max_population,min_population,total_population
     294583,217,280927321
 
@@ -206,8 +206,8 @@ DivideMetric
 ------------
 
 Division in SQL introduces the possibility of division by zero. DivideMetric
-guards against division by zero while giving you a quick way to divide 
-one calculation by another. 
+guards against division by zero while giving you a quick way to divide
+one calculation by another.
 
 .. code:: python
 
@@ -223,7 +223,7 @@ This creates results like:
 .. code::
 
     SELECT census.state AS state,
-        CAST(sum(census.pop2008 - census.pop2000) AS FLOAT) / 
+        CAST(sum(census.pop2008 - census.pop2000) AS FLOAT) /
           (coalesce(CAST(sum(census.pop2000) AS FLOAT), 0.0) + 1e-09) AS popgrowth
     FROM census
     GROUP BY census.state
@@ -237,7 +237,7 @@ This creates results like:
     Colorado,0.14231283526592364,Colorado
     ...
 
-The denominator has a tiny value added to it to prevent division by zero.    
+The denominator has a tiny value added to it to prevent division by zero.
 
 WtdAvgMetric
 ------------
@@ -320,10 +320,10 @@ This results in output like:
 Different ways of generating Filters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Recipe has several ways of filtering recipes. 
+Recipe has several ways of filtering recipes.
 
 * **Filter objects can be added to the shelf**. They can be added to the
-  recipe by name from a shelf. This is best when 
+  recipe by name from a shelf. This is best when
   you have a filter that you want to use in many place.
 
   .. code:: python
@@ -345,17 +345,17 @@ Recipe has several ways of filtering recipes.
         recipe = recipe.filters(Filter(Census.age.between(13,19))
 
 * **Ingredient.build_filter**  can be used to build filters that refer
-  to the ingredient's column. 
+  to the ingredient's column.
 
   .. code:: python
 
     age_filter = shelf['age'].build_filter([13,19], 'between')
     recipe = recipe.filters(age_filter)
 
-  This is best when you want to reuse a column definition defined in 
+  This is best when you want to reuse a column definition defined in
   an ingredient.
-* **AutomaticFilters**: The AutomaticFilters extension adds filtering 
-  syntax directly to recipe. 
+* **AutomaticFilters**: The AutomaticFilters extension adds filtering
+  syntax directly to recipe.
 
   .. code:: python
 
@@ -363,15 +363,15 @@ Recipe has several ways of filtering recipes.
       'age__between': [13,19]
     })
 
-  This is best when you want to add many filters consistently. 
+  This is best when you want to add many filters consistently.
   AutomaticFilters uses ``Ingredient.build_filter`` behind the scenes.
 
 Having
 ------
 
-Having objects are binary expressions with an aggregated column value. 
-One easy way to generate ``Having`` objects is to ``build_filter`` using 
-a ``Metric``. 
+Having objects are binary expressions with an aggregated column value.
+One easy way to generate ``Having`` objects is to ``build_filter`` using
+a ``Metric``.
 
 .. code:: python
 
@@ -394,7 +394,7 @@ a ``Metric``.
 
 This generates the following results.
 
-.. code:: 
+.. code::
 
     SELECT census.state AS state,
         sum(census.pop2000) AS population

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -343,10 +343,7 @@ class Recipe(object):
         """
 
         # Order bys shouldn't be added to the _cauldron
-        self._order_bys = []
-        for ingr in order_bys:
-            order_by = self._shelf.find(ingr, (Dimension, Metric))
-            self._order_bys.append(order_by)
+        self._order_bys = order_bys
 
     @recipe_arg()
     def select_from(self, selectable):
@@ -393,17 +390,6 @@ class Recipe(object):
             self._is_postgres_engine = is_postgres_engine
         return self._is_postgres_engine
 
-    def _prepare_order_bys(self):
-        """ Build a set of order by columns """
-        order_bys = OrderedSet()
-        if self._order_bys:
-            for ingredient in self._order_bys:
-                for c in ingredient.order_by_columns:
-                    if str(c) not in [str(o) for o in order_bys]:
-                        order_bys.add(c)
-
-        return list(order_bys)
-
     def query(self):
         """
         Generates a query using the ingredients supplied by the recipe.
@@ -428,7 +414,8 @@ class Recipe(object):
         # Get the parts of the query from the cauldron
         # We don't need to regather order_bys
         recipe_parts = self._cauldron.brew_query_parts()
-        recipe_parts["order_bys"] = self._prepare_order_bys()
+
+        recipe_parts["order_bys"] = self._cauldron._prepare_order_bys(self._order_bys)
 
         for extension in self.recipe_extensions:
             recipe_parts = extension.modify_recipe_parts(recipe_parts)

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import attr
 import tablib
-from ordered_set import OrderedSet
 from sqlalchemy import alias, func
 from sqlalchemy.sql.elements import BinaryExpression
 from sureberus import normalize_dict, normalize_schema
@@ -328,21 +327,13 @@ class Recipe(object):
 
     @recipe_arg()
     def order_by(self, *order_bys):
-        """ Add a list of ingredients to order by to the query. These can
-        either be Dimension or Metric objects or strings representing
-        order_bys on the shelf.
+        """Apply an ordering to the recipe results.
 
-        The Order_by expression will be added to the query's order_by statement
-
-        :param order_bys: Order_bys to add to the recipe. Order_bys can
-                         either be keys on the ``shelf`` or
-                         Dimension or Metric objects. If the
-                         key is prefixed by "-" the ordering will be
-                         descending.
-        :type order_bys: list
+        :param order_bys: Order_bys to add to the recipe. Order_bys must
+                         be keys of ingredients already added to the recipe. If the
+                         key is prefixed by "-" the ordering will be descending.
+        :type order_bys: list(str)
         """
-
-        # Order bys shouldn't be added to the _cauldron
         self._order_bys = order_bys
 
     @recipe_arg()
@@ -412,10 +403,14 @@ class Recipe(object):
         # and apply any blend recipes
 
         # Get the parts of the query from the cauldron
-        # We don't need to regather order_bys
-        recipe_parts = self._cauldron.brew_query_parts()
-
-        recipe_parts["order_bys"] = self._cauldron._prepare_order_bys(self._order_bys)
+        # {
+        #             "columns": columns,
+        #             "group_bys": group_bys,
+        #             "filters": filters,
+        #             "havings": havings,
+        #             "order_bys": list(order_bys)
+        #         }
+        recipe_parts = self._cauldron.brew_query_parts(self._order_bys)
 
         for extension in self.recipe_extensions:
             recipe_parts = extension.modify_recipe_parts(recipe_parts)

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -12,7 +12,7 @@ from sureberus import normalize_dict, normalize_schema
 from recipe.compat import basestring
 from recipe.dynamic_extensions import run_hooks
 from recipe.exceptions import BadRecipe
-from recipe.ingredients import Dimension, Filter, Having, Metric
+from recipe.ingredients import Dimension, Filter, Having, Metric, Ingredient
 from recipe.schemas import recipe_schema
 from recipe.shelf import Shelf, parse_unvalidated_condition
 from recipe.utils import prettyprintable_sql, recipe_arg
@@ -334,6 +334,10 @@ class Recipe(object):
                          key is prefixed by "-" the ordering will be descending.
         :type order_bys: list(str)
         """
+        # Convert dimensions to use their id
+        order_bys = [
+            d.id if isinstance(d, Ingredient) else d for d in order_bys
+        ]
         self._order_bys = order_bys
 
     @recipe_arg()

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -367,7 +367,7 @@ class SummarizeOver(RecipeExtension):
         order_by_columns = []
         for col in postquery_parts["query"]._order_by:
             subq_col = getattr(
-                subq.c, col.name, getattr(subq.c, col.name + "_raw", None)
+                subq.c, str(col).split(' ')[0]
             )
             if subq_col is not None:
                 order_by_columns.append(subq_col)
@@ -412,6 +412,7 @@ class Anonymize(RecipeExtension):
     def add_ingredients(self):
         """ Put the anonymizers in the last position of formatters """
         for ingredient in self.recipe._cauldron.values():
+            ingredient.anonymize = self._anonymize
             if hasattr(ingredient.meta, "anonymizer"):
                 anonymizer = ingredient.meta.anonymizer
 

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -412,7 +412,6 @@ class Anonymize(RecipeExtension):
     def add_ingredients(self):
         """ Put the anonymizers in the last position of formatters """
         for ingredient in self.recipe._cauldron.values():
-            ingredient.anonymize = self._anonymize
             if hasattr(ingredient.meta, "anonymizer"):
                 anonymizer = ingredient.meta.anonymizer
 

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -433,7 +433,7 @@ class Dimension(Ingredient):
     """A Dimension is an Ingredient that adds columns and groups by those
     columns. Columns should be non-aggregate SQLAlchemy expressions.
 
-    The required expression supplies the dimension's value role. Additional
+    The required expression supplies the dimension's "value" role. Additional
     expressions can be provided in keyword arguments with keys
     that look like "{role}_expression". The role is suffixed to the
     end of the SQL column name.
@@ -450,6 +450,14 @@ class Dimension(Ingredient):
     would add columns named "hospital", "hospital_latitude", and
     "hospital_longitude" to the recipes results. All three of these expressions
     would be used as group bys.
+
+    Two special roles that can be added are "id" and "order_by". If a keyword argument
+    "id_expression" is passed, this expression will appear first in the list of
+    columns and group_bys. This "id" will be used if you call `build_filter` on the
+    dimension.
+
+    If the keyword argument "order_by_expression" is passed, this expression will
+    appear last in the list of columns and group_bys.
 
     The following additional keyword parameters are also supported:
 

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -120,6 +120,10 @@ class Ingredient(object):
     def make_column_suffixes(self):
         """ Make sure we have the right column suffixes. These will be appended
         to `id` when generating the query.
+
+        Developers note: These are generated when the query runs because the
+        recipe may be run with anonymization on or off, which will inject
+        a formatter.
         """
         if self.column_suffixes:
             return self.column_suffixes
@@ -545,6 +549,21 @@ class Dimension(Ingredient):
     def order_by_columns(self):
         """ Yield columns to be used in an order by using this ingredient
         """
+        # Ensure the labels are generated
+        if not self._labels:
+            list(self.query_columns)
+
+        if self.group_by_strategy == "labels":
+            if self.ordering == "desc":
+                suffix = ' desc'
+            else:
+                suffix = ''
+            return [lbl + suffix for gb, lbl in zip(self._group_by, self._labels)]
+        else:
+            for c in self._order_by_columns:
+                pass
+            return self._group_by
+
         for c in self._order_by_columns:
             if self.ordering == "desc":
                 yield c.desc()

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -1,7 +1,7 @@
 from functools import total_ordering
 from uuid import uuid4
 
-from sqlalchemy import Float, and_, between, case, cast, func, or_
+from sqlalchemy import Float, and_, between, case, cast, func, or_, text
 
 from recipe.compat import str
 from recipe.exceptions import BadIngredient
@@ -555,20 +555,16 @@ class Dimension(Ingredient):
 
         if self.group_by_strategy == "labels":
             if self.ordering == "desc":
-                suffix = ' desc'
+                suffix = ' DESC'
             else:
                 suffix = ''
-            return [lbl + suffix for gb, lbl in zip(self._group_by, self._labels)]
+
+            return [text(lbl + suffix) for gb, lbl in zip(self._group_by, self._labels)]
         else:
             for c in self._order_by_columns:
                 pass
             return self._group_by
 
-        for c in self._order_by_columns:
-            if self.ordering == "desc":
-                yield c.desc()
-            else:
-                yield c
 
     def make_column_suffixes(self):
         """ Make sure we have the right column suffixes. These will be appended

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -84,6 +84,7 @@ class Ingredient(object):
         self.column_suffixes = kwargs.pop("column_suffixes", None)
         self.cache_context = kwargs.pop("cache_context", "")
         self.anonymize = False
+        self.roles = {}
         self._labels = []
 
         # What order should this be in
@@ -464,6 +465,7 @@ class Dimension(Ingredient):
 
         # We must always have a value role
         self.roles = {"value": expression}
+
         for k, v in kwargs.items():
             role = None
             if k.endswith("_expression"):
@@ -576,7 +578,7 @@ class Dimension(Ingredient):
 
             return [
                 text(lbl + suffix)
-                for col, lbl in reversed(zip(self.columns, self._labels))
+                for col, lbl in reversed(list(zip(self.columns, self._labels)))
             ]
         else:
             return reversed(self.columns)
@@ -655,6 +657,9 @@ class Metric(Ingredient):
     def __init__(self, expression, **kwargs):
         super(Metric, self).__init__(**kwargs)
         self.columns = [expression]
+
+        # We must always have a value role
+        self.roles = {"value": expression}
 
     def build_filter(self, value, operator=None):
         """Building filters with Metric returns Having objects. """

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -2,6 +2,8 @@ import dateparser
 from copy import copy, deepcopy
 
 from datetime import date, datetime
+
+from ordered_set import OrderedSet
 from six import iteritems
 from sqlalchemy import (
     Float,
@@ -623,6 +625,18 @@ class Shelf(object):
             "filters": filters,
             "havings": havings,
         }
+
+    def _prepare_order_bys(self, order_by_keys):
+        """ Build a list of order by columns """
+        order_bys = OrderedSet()
+        for key in order_by_keys:
+            ingr = self.find(key, (Dimension, Metric))
+            for c in ingr.order_by_columns:
+                # Avoid duplicate order by columns
+                if str(c) not in [str(o) for o in order_bys]:
+                    order_bys.add(c)
+
+        return list(order_bys)
 
     def enchant(self, list, cache_context=None):
         """ Add any calculated values to each row of a resultset generating a

--- a/recipe/utils.py
+++ b/recipe/utils.py
@@ -36,6 +36,7 @@ __all__ = [
     "clean_unicode",
     "FakerAnonymizer",
     "FakerFormatter",
+    "recipe_arg",
 ]
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ TABLEDEF = """
 
 oven.engine.execute(TABLEDEF)
 oven.engine.execute(
-    "insert into foo values ('hi', 'there', 5, '2005-01-01', '2005-01-01 12:15:00'), ('hi', 'fred', 10, '2015-05-15', '2013-10-15 05:20:10')"  # noqa: E501
+    "insert into foo values ('hi', 'there', 5, '2005-01-01', '2005-01-01 12:15:00'), ('hi', 'fred', 10, '2015-05-15', '2013-10-15 05:20:10')"
 )
 
 # Create a table for testing summarization

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ TABLEDEF = """
 
 oven.engine.execute(TABLEDEF)
 oven.engine.execute(
-    "insert into foo values ('hi', 'there', 5, '2000-01-01', '2000-01-01 12:15:00'), ('hi', 'fred', 10, '2015-05-15', '2013-10-15 05:20:10')"  # noqa: E501
+    "insert into foo values ('hi', 'there', 5, '2005-01-01', '2005-01-01 12:15:00'), ('hi', 'fred', 10, '2015-05-15', '2013-10-15 05:20:10')"  # noqa: E501
 )
 
 # Create a table for testing summarization

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -382,13 +382,14 @@ class TestAnonymizeRecipeExtension(object):
             .order_by("last")
             .anonymize(False)
         )
+        print(recipe.to_sql())
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].last_id == "fred"
@@ -399,16 +400,17 @@ ORDER BY foo.last"""
             self.recipe()
             .metrics("age")
             .dimensions("last")
-            .order_by("last")
             .anonymize(True)
+            .order_by("last")
         )
+        print("anon is",recipe._anonymize)
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last_raw,
        sum(foo.age) AS age
 FROM foo
 GROUP BY last_raw
-ORDER BY foo.last"""
+ORDER BY last_raw"""
         )
         assert recipe.all()[0].last == "derf"
         assert recipe.all()[0].last_raw == "fred"
@@ -431,7 +433,7 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY firstanon
-ORDER BY foo.first"""
+ORDER BY firstanon"""
         )
         assert recipe.all()[0].firstanon == "hi"
         assert recipe.all()[0].firstanon_id == "hi"
@@ -451,7 +453,7 @@ ORDER BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY firstanon_raw
-ORDER BY foo.first"""
+ORDER BY firstanon_raw"""
         )
 
         fake = Faker(locale="en_US")
@@ -477,7 +479,7 @@ ORDER BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY firstanon_raw
-ORDER BY foo.first"""
+ORDER BY firstanon_raw"""
         )
         assert recipe.all()[0].firstanon == fake_value
         assert recipe.all()[0].firstanon_raw == "hi"
@@ -500,7 +502,7 @@ ORDER BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY first
-ORDER BY foo.first"""
+ORDER BY first"""
         )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].first_id == "hi"
@@ -520,7 +522,7 @@ ORDER BY foo.first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY first
-ORDER BY foo.first"""
+ORDER BY first"""
         )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].first_id == "hi"
@@ -697,7 +699,7 @@ GROUP BY state"""
        sum(census.pop2000) AS pop2000
 FROM census
 GROUP BY state
-ORDER BY census.state DESC
+ORDER BY state DESC
 LIMIT 10
 OFFSET 0"""
         )
@@ -716,7 +718,7 @@ OFFSET 0"""
        sum(census.pop2000) AS pop2000
 FROM census
 GROUP BY state
-ORDER BY census.state DESC
+ORDER BY state DESC
 LIMIT 10
 OFFSET 0"""
         )
@@ -1185,7 +1187,7 @@ FROM
    FROM scores
    GROUP BY department_raw,
             username
-   ORDER BY scores.department) AS summarize
+   ORDER BY department_raw) AS summarize
 GROUP BY summarize.department_raw
 ORDER BY summarize.department_raw"""
         )

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -382,7 +382,6 @@ class TestAnonymizeRecipeExtension(object):
             .order_by("last")
             .anonymize(False)
         )
-        print(recipe.to_sql())
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last,
@@ -403,7 +402,6 @@ ORDER BY last"""
             .anonymize(True)
             .order_by("last")
         )
-        print("anon is",recipe._anonymize)
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last_raw,

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -337,7 +337,8 @@ class TestDimension(object):
         d = Dimension(MyTable.first, id_expression=MyTable.last)
         assert len(list(d.order_by_columns)) == 2
         # Order by value expression then id expression
-        assert list(d.order_by_columns) == [MyTable.first, MyTable.last]
+        # FIXME: This is wrong
+        assert list(map(str,d.order_by_columns)) == [d.id + '_id', d.id]
 
         # Extra roles do not participate in ordering
         d = Dimension(

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -337,18 +337,65 @@ class TestDimension(object):
         d = Dimension(MyTable.first, id_expression=MyTable.last)
         assert len(list(d.order_by_columns)) == 2
         # Order by value expression then id expression
-        # FIXME: This is wrong
-        assert list(map(str,d.order_by_columns)) == [d.id + '_id', d.id]
+        assert list(map(str, d.order_by_columns)) == [d.id, d.id + "_id"]
 
-        # Extra roles do not participate in ordering
+        # Extra roles DO participate in ordering
         d = Dimension(
             MyTable.first,
             id_expression=MyTable.last,
             age_expression=MyTable.age,
             id="moo",
         )
-        assert len(list(d.order_by_columns)) == 2
-        assert list(d.order_by_columns) == [MyTable.first, MyTable.last]
+        assert len(list(d.order_by_columns)) == 3
+        assert list(map(str, d.order_by_columns)) == ["moo_age", "moo", "moo_id"]
+
+        # Extra roles DO participate in ordering, order_by_expression is always first
+        d = Dimension(
+            MyTable.first,
+            id_expression=MyTable.last,
+            age_expression=MyTable.age,
+            order_by_expression=MyTable.age,
+            id="moo",
+        )
+        assert len(list(d.order_by_columns)) == 4
+        assert list(map(str, d.order_by_columns)) == [
+            "moo_order_by",
+            "moo_age",
+            "moo",
+            "moo_id",
+        ]
+
+        d = Dimension(
+            MyTable.first,
+            id_expression=MyTable.last,
+            zed_expression=MyTable.age,
+            order_by_expression=MyTable.age,
+            id="moo",
+        )
+        assert len(list(d.order_by_columns)) == 4
+        assert list(map(str, d.order_by_columns)) == [
+            "moo_order_by",
+            "moo_zed",
+            "moo",
+            "moo_id",
+        ]
+
+        # Default ordering can be set to descending
+        d = Dimension(
+            MyTable.first,
+            id_expression=MyTable.last,
+            zed_expression=MyTable.age,
+            order_by_expression=MyTable.age,
+            ordering="desc",
+            id="moo",
+        )
+        assert len(list(d.order_by_columns)) == 4
+        assert list(map(str, d.order_by_columns)) == [
+            "moo_order_by DESC",
+            "moo_zed DESC",
+            "moo DESC",
+            "moo_id DESC",
+        ]
 
     def test_dimension_cauldron_extras(self):
         d = Dimension(MyTable.first, id="moo")

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -424,7 +424,7 @@ Vermont,271469,The Green Mountain State,Vermont
        sum((((census.pop2000 + census.pop2008) - census.pop2000) * census.pop2008) / (coalesce(CAST(census.pop2000 AS FLOAT), 0.0) + 1e-09)) AS allthemath
 FROM census
 GROUP BY state_raw"""
-        )  # noqa: E501
+        )
 
     def test_complex_census_quickselect_from_validated_yaml(self):
         """Build a recipe that uses complex definitions dimensions and
@@ -498,7 +498,7 @@ Vermont,620602,The Green Mountain State,Vermont
 FROM census
 GROUP BY state_raw
 ORDER BY state_raw"""
-        )  # noqa: E501
+        )
         self.assert_recipe_csv(
             recipe,
             """state_raw,popdivide,state,state_id
@@ -525,7 +525,7 @@ Vermont,0.4374284968466095,The Green Mountain State,Vermont
 FROM census
 GROUP BY state_raw
 ORDER BY state_raw"""
-        )  # noqa: E501
+        )
         self.assert_recipe_csv(
             recipe,
             """state_raw,pop2008oldsters,state,state_id
@@ -572,7 +572,7 @@ Vermont,311842,The Green Mountain State,Vermont
 FROM census
 GROUP BY state
 ORDER BY state"""
-        )  # noqa: E501
+        )
         self.assert_recipe_csv(
             recipe,
             """state,popchg,state_id
@@ -599,7 +599,7 @@ Vermont,0.9820786913351858,Vermont
 FROM census
 GROUP BY state_characteristic_raw
 ORDER BY state_characteristic_raw"""
-        )  # noqa: E501
+        )
         self.assert_recipe_csv(
             recipe,
             """state_characteristic_raw,pop2000,state_characteristic,state_characteristic_id
@@ -632,7 +632,7 @@ ORDER BY state_idval,
          state_idval_id
 LIMIT 5
 OFFSET 0"""
-        )  # noqa: E501
+        )
         self.assert_recipe_csv(
             recipe,
             """state_idval_id,state_idval,pop2000,state_idval_id
@@ -720,7 +720,7 @@ class TestNullHandling(TestRecipeIngredientsYaml):
 FROM scores_with_nulls
 GROUP BY department
 ORDER BY department"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -794,7 +794,7 @@ sales,,Sales,sales
 FROM scores_with_nulls
 GROUP BY department_lookup_with_null_raw
 ORDER BY department_lookup_with_null_raw"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -828,7 +828,7 @@ sales,,Sales,sales
 FROM scores_with_nulls
 GROUP BY department_default
 ORDER BY department_default"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -873,7 +873,7 @@ GROUP BY department_buckets,
          department_buckets_order_by
 ORDER BY department_buckets_order_by,
          department_buckets"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -913,7 +913,7 @@ Other,9999,80.0,Other
 FROM scores_with_nulls
 GROUP BY department_lookup_with_everything_raw
 ORDER BY department_lookup_with_everything_raw DESC"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -947,7 +947,7 @@ N/A,80.0,Unknown,N/A
 FROM scores_with_nulls
 GROUP BY department
 ORDER BY department"""
-        )  # noqa: E501
+        )
 
         self.assert_recipe_csv(
             recipe,

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -10,7 +10,7 @@ import pytest
 from six import text_type
 from tests.test_base import Census, MyTable, oven, ScoresWithNulls
 
-from recipe import AutomaticFilters, BadIngredient, Recipe, Shelf
+from recipe import AutomaticFilters, BadIngredient, Recipe, Shelf, BadRecipe
 
 
 class TestRecipeIngredientsYaml(object):
@@ -160,7 +160,7 @@ FROM
           sum(census.pop2000 + census.pop2008) AS ttlpop
    FROM census
    GROUP BY state
-   ORDER BY census.state) AS anon_1"""
+   ORDER BY state) AS anon_1"""
         )
         self.assert_recipe_csv(
             nested_recipe,
@@ -189,6 +189,7 @@ FROM
         )
 
     def test_census_buckets(self):
+        """Ordering is applied automatically if a dimension has an order_by"""
         shelf = self.unvalidated_shelf("census.yaml", Census)
         recipe = (
             Recipe(shelf=shelf, session=self.session)
@@ -203,17 +204,26 @@ FROM
            WHEN (census.age < 20) THEN 'teens'
            ELSE 'oldsters'
        END AS age_buckets,
+       CASE
+           WHEN (census.age < 2) THEN 0
+           WHEN (census.age < 13) THEN 1
+           WHEN (census.age < 20) THEN 2
+           ELSE 9999
+       END AS age_buckets_order_by,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY age_buckets"""
+GROUP BY age_buckets,
+         age_buckets_order_by
+ORDER BY age_buckets_order_by,
+         age_buckets"""
         )
         self.assert_recipe_csv(
             recipe,
-            """age_buckets,pop2000,age_buckets_id
-babies,164043,babies
-children,948240,children
-oldsters,4567879,oldsters
-teens,614548,teens
+            """age_buckets,age_buckets_order_by,pop2000,age_buckets_id
+babies,0,164043,babies
+children,1,948240,children
+teens,2,614548,teens
+oldsters,9999,4567879,oldsters
 """,
         )
 
@@ -269,26 +279,30 @@ FROM census"""
            WHEN (census.age < 20) THEN 'teens'
            ELSE 'oldsters'
        END AS mixed_buckets,
+       CASE
+           WHEN (census.state IN ('Vermont',
+                                  'New Hampshire')) THEN 0
+           WHEN (census.age < 2) THEN 1
+           WHEN (census.age < 13) THEN 2
+           WHEN (census.age < 20) THEN 3
+           ELSE 9999
+       END AS mixed_buckets_order_by,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY mixed_buckets
-ORDER BY CASE
-             WHEN (census.state IN ('Vermont',
-                                    'New Hampshire')) THEN 0
-             WHEN (census.age < 2) THEN 1
-             WHEN (census.age < 13) THEN 2
-             WHEN (census.age < 20) THEN 3
-             ELSE 9999
-         END DESC"""
+GROUP BY mixed_buckets,
+         mixed_buckets_order_by
+ORDER BY mixed_buckets_order_by DESC,
+         mixed_buckets DESC"""
         )
+
         self.assert_recipe_csv(
             recipe,
-            """mixed_buckets,pop2000,mixed_buckets_id
-oldsters,4124620,oldsters
-teens,550515,teens
-children,859206,children
-babies,150889,babies
-northeast,609480,northeast
+            """mixed_buckets,mixed_buckets_order_by,pop2000,mixed_buckets_id
+oldsters,9999,4124620,oldsters
+teens,3,550515,teens
+children,2,859206,children
+babies,1,150889,babies
+northeast,0,609480,northeast
 """,
         )
 
@@ -308,23 +322,26 @@ northeast,609480,northeast
            WHEN (census.age < 20) THEN 'teens'
            ELSE 'oldsters'
        END AS age_buckets,
+       CASE
+           WHEN (census.age < 2) THEN 0
+           WHEN (census.age < 13) THEN 1
+           WHEN (census.age < 20) THEN 2
+           ELSE 9999
+       END AS age_buckets_order_by,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY age_buckets
-ORDER BY CASE
-             WHEN (census.age < 2) THEN 0
-             WHEN (census.age < 13) THEN 1
-             WHEN (census.age < 20) THEN 2
-             ELSE 9999
-         END"""
+GROUP BY age_buckets,
+         age_buckets_order_by
+ORDER BY age_buckets_order_by,
+         age_buckets"""
         )
         self.assert_recipe_csv(
             recipe,
-            """age_buckets,pop2000,age_buckets_id
-babies,164043,babies
-children,948240,children
-teens,614548,teens
-oldsters,4567879,oldsters
+            """age_buckets,age_buckets_order_by,pop2000,age_buckets_id
+babies,0,164043,babies
+children,1,948240,children
+teens,2,614548,teens
+oldsters,9999,4567879,oldsters
 """,
         )
         recipe = (
@@ -333,6 +350,7 @@ oldsters,4567879,oldsters
             .metrics("pop2000")
             .order_by("-age_buckets")
         )
+        print(recipe.to_sql())
         assert (
             recipe.to_sql()
             == """SELECT CASE
@@ -341,23 +359,26 @@ oldsters,4567879,oldsters
            WHEN (census.age < 20) THEN 'teens'
            ELSE 'oldsters'
        END AS age_buckets,
+       CASE
+           WHEN (census.age < 2) THEN 0
+           WHEN (census.age < 13) THEN 1
+           WHEN (census.age < 20) THEN 2
+           ELSE 9999
+       END AS age_buckets_order_by,
        sum(census.pop2000) AS pop2000
 FROM census
-GROUP BY age_buckets
-ORDER BY CASE
-             WHEN (census.age < 2) THEN 0
-             WHEN (census.age < 13) THEN 1
-             WHEN (census.age < 20) THEN 2
-             ELSE 9999
-         END DESC"""
+GROUP BY age_buckets,
+         age_buckets_order_by
+ORDER BY age_buckets_order_by DESC,
+         age_buckets DESC"""
         )
         self.assert_recipe_csv(
             recipe,
-            """age_buckets,pop2000,age_buckets_id
-oldsters,4567879,oldsters
-teens,614548,teens
-children,948240,children
-babies,164043,babies
+            """age_buckets,age_buckets_order_by,pop2000,age_buckets_id
+oldsters,9999,4567879,oldsters
+teens,2,614548,teens
+children,1,948240,children
+babies,0,164043,babies
 """,
         )
 
@@ -379,7 +400,7 @@ babies,164043,babies
            END) AS pop2000
 FROM census
 GROUP BY state_raw
-ORDER BY census.state"""
+ORDER BY state_raw"""
         )
         self.assert_recipe_csv(
             recipe,
@@ -426,7 +447,7 @@ GROUP BY state_raw"""
 FROM census
 WHERE census.age < 40
 GROUP BY state_raw
-ORDER BY census.state"""
+ORDER BY state_raw"""
         )
         self.assert_recipe_csv(
             recipe,
@@ -451,7 +472,7 @@ Vermont,300605,The Green Mountain State,Vermont
 FROM census
 WHERE census.state = 'Vermont'
 GROUP BY state_raw
-ORDER BY census.state"""
+ORDER BY state_raw"""
         )
         self.assert_recipe_csv(
             recipe,
@@ -477,7 +498,7 @@ Vermont,620602,The Green Mountain State,Vermont
                 END) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS popdivide
 FROM census
 GROUP BY state_raw
-ORDER BY census.state"""
+ORDER BY state_raw"""
         )  # noqa: E501
         self.assert_recipe_csv(
             recipe,
@@ -504,7 +525,7 @@ Vermont,0.4374284968466095,The Green Mountain State,Vermont
            END) AS pop2008oldsters
 FROM census
 GROUP BY state_raw
-ORDER BY census.state"""
+ORDER BY state_raw"""
         )  # noqa: E501
         self.assert_recipe_csv(
             recipe,
@@ -551,7 +572,7 @@ Vermont,311842,The Green Mountain State,Vermont
        CAST(sum(census.pop2000) AS FLOAT) / (coalesce(CAST(sum(census.pop2008) AS FLOAT), 0.0) + 1e-09) AS popchg
 FROM census
 GROUP BY state
-ORDER BY census.state"""
+ORDER BY state"""
         )  # noqa: E501
         self.assert_recipe_csv(
             recipe,
@@ -578,7 +599,7 @@ Vermont,0.9820786913351858,Vermont
        sum(census.pop2000) AS pop2000
 FROM census
 GROUP BY state_characteristic_raw
-ORDER BY census.state"""
+ORDER BY state_characteristic_raw"""
         )  # noqa: E501
         self.assert_recipe_csv(
             recipe,
@@ -608,8 +629,8 @@ Vermont,609480,Taciturny,Vermont
 FROM census
 GROUP BY state_idval_id,
          state_idval
-ORDER BY census.state,
-         census.pop2000
+ORDER BY state_idval,
+         state_idval_id
 LIMIT 5
 OFFSET 0"""
         )  # noqa: E501
@@ -624,7 +645,7 @@ OFFSET 0"""
 """,
         )
 
-    def test_deprecated_ingredients_wtdavgmetric(self):
+    def test_deprecated_ingredients_idvaluedim(self):
         """ Test deprecated ingredient kinds in a yaml file """
         shelf = self.validated_shelf("census_deprecated.yaml", Census)
 
@@ -635,21 +656,49 @@ OFFSET 0"""
             .metrics("avgage")
             .order_by("state_idval")
         )
+        # Can't order_by something that isn't used as a dimension or metric
+        with pytest.raises(BadRecipe):
+            recipe.to_sql()
+
+    def test_deprecated_ingredients_idvaluedim(self):
+        """ Test deprecated ingredient kinds in a yaml file """
+        shelf = self.validated_shelf("census_deprecated.yaml", Census)
+
+        # We can IdValueDimension
+        recipe = (
+            Recipe(shelf=shelf, session=self.session)
+            .dimensions("state_idval")
+            .metrics("avgage")
+            .order_by("state_idval")
+            .limit(10)
+        )
         assert (
             recipe.to_sql()
-            == """SELECT census.state AS state,
+            == """SELECT census.pop2000 AS state_idval_id,
+       census.state AS state_idval,
        CAST(sum(census.age * census.pop2000) AS FLOAT) / (coalesce(CAST(sum(census.pop2000) AS FLOAT), 0.0) + 1e-09) AS avgage
 FROM census
-GROUP BY state
-ORDER BY census.state,
-         census.pop2000"""
-        )  # noqa: E501
+GROUP BY state_idval_id,
+         state_idval
+ORDER BY state_idval,
+         state_idval_id
+LIMIT 10
+OFFSET 0"""
+        )
 
         self.assert_recipe_csv(
             recipe,
-            """state,avgage,state_id
-Tennessee,36.24667550829078,Tennessee
-Vermont,37.0597968760254,Vermont
+            """state_idval_id,state_idval,avgage,state_idval_id
+5033,Tennessee,83.9999999999833,5033
+5562,Tennessee,82.99999999998506,5562
+6452,Tennessee,81.99999999998728,6452
+7322,Tennessee,80.99999999998893,7322
+8598,Tennessee,79.99999999999069,8598
+9583,Tennessee,78.99999999999176,9583
+10501,Tennessee,83.999999999992,10501
+10672,Tennessee,77.99999999999268,10672
+11141,Tennessee,82.99999999999255,11141
+11168,Tennessee,76.99999999999311,11168
 """,
         )
 
@@ -671,7 +720,7 @@ class TestNullHandling(TestRecipeIngredientsYaml):
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
 GROUP BY department
-ORDER BY scores_with_nulls.department"""
+ORDER BY department"""
         )  # noqa: E501
 
         self.assert_recipe_csv(
@@ -708,8 +757,8 @@ sales,,sales
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
 GROUP BY department_lookup_raw
-ORDER BY scores_with_nulls.department"""
-        )  # noqa: E501
+ORDER BY department_lookup_raw"""
+        )
 
         self.assert_recipe_csv(
             recipe,
@@ -745,7 +794,7 @@ sales,,Sales,sales
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
 GROUP BY department_lookup_with_null_raw
-ORDER BY scores_with_nulls.department"""
+ORDER BY department_lookup_with_null_raw"""
         )  # noqa: E501
 
         self.assert_recipe_csv(
@@ -779,7 +828,7 @@ sales,,Sales,sales
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
 GROUP BY department_default
-ORDER BY coalesce(scores_with_nulls.department, 'N/A')"""
+ORDER BY department_default"""
         )  # noqa: E501
 
         self.assert_recipe_csv(
@@ -814,22 +863,25 @@ sales,,sales
            WHEN (scores_with_nulls.department = 'ops') THEN 'Operations'
            ELSE 'Other'
        END AS department_buckets,
+       CASE
+           WHEN (scores_with_nulls.department = 'sales') THEN 0
+           WHEN (scores_with_nulls.department = 'ops') THEN 1
+           ELSE 9999
+       END AS department_buckets_order_by,
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
-GROUP BY department_buckets
-ORDER BY CASE
-             WHEN (scores_with_nulls.department = 'sales') THEN 0
-             WHEN (scores_with_nulls.department = 'ops') THEN 1
-             ELSE 9999
-         END"""
+GROUP BY department_buckets,
+         department_buckets_order_by
+ORDER BY department_buckets_order_by,
+         department_buckets"""
         )  # noqa: E501
 
         self.assert_recipe_csv(
             recipe,
-            """department_buckets,score,department_buckets_id
-Sales,,Sales
-Operations,90.0,Operations
-Other,80.0,Other
+            """department_buckets,department_buckets_order_by,score,department_buckets_id
+Sales,0,,Sales
+Operations,1,90.0,Operations
+Other,9999,80.0,Other
 """,
         )
 
@@ -853,7 +905,7 @@ Other,80.0,Other
             Recipe(shelf=shelf, session=self.session)
             .dimensions("department_lookup_with_everything")
             .metrics("score")
-            .order_by("department_lookup_with_everything")
+            .order_by("-department_lookup_with_everything")
         )
         assert (
             recipe.to_sql()
@@ -861,15 +913,15 @@ Other,80.0,Other
        avg(scores_with_nulls.score) AS score
 FROM scores_with_nulls
 GROUP BY department_lookup_with_everything_raw
-ORDER BY coalesce(scores_with_nulls.department, 'N/A')"""
+ORDER BY department_lookup_with_everything_raw DESC"""
         )  # noqa: E501
 
         self.assert_recipe_csv(
             recipe,
             """department_lookup_with_everything_raw,score,department_lookup_with_everything,department_lookup_with_everything_id
-N/A,80.0,Unknown,N/A
-ops,90.0,Operations,ops
 sales,,Sales,sales
+ops,90.0,Operations,ops
+N/A,80.0,Unknown,N/A
 """,
         )
 
@@ -895,7 +947,7 @@ sales,,Sales,sales
        coalesce(avg(scores_with_nulls.score), -1.0) AS score_with_default
 FROM scores_with_nulls
 GROUP BY department
-ORDER BY scores_with_nulls.department"""
+ORDER BY department"""
         )  # noqa: E501
 
         self.assert_recipe_csv(

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -350,7 +350,6 @@ oldsters,9999,4567879,oldsters
             .metrics("pop2000")
             .order_by("-age_buckets")
         )
-        print(recipe.to_sql())
         assert (
             recipe.to_sql()
             == """SELECT CASE

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -251,7 +251,6 @@ ORDER BY last"""
         assert recipe.stats.rows == 2
 
         recipe = self.recipe().metrics("age").dimensions("last").order_by("age")
-        # FIXME: Why is this using the calculation
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last,

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -258,7 +258,7 @@ ORDER BY last"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY sum(foo.age)"""
+ORDER BY age"""
         )
         assert recipe.all()[0].last == "there"
         assert recipe.all()[0].age == 5
@@ -319,12 +319,15 @@ ORDER BY firstlast DESC,
             recipe.to_sql()
             == """SELECT foo.first AS d_id,
        foo.last AS d,
+       upper(foo.last) AS d_order_by,
        sum(foo.age) AS age
 FROM foo
 GROUP BY d_id,
-         d
-ORDER BY upper(foo.last),
-         foo.first"""
+         d,
+         d_order_by
+ORDER BY d_order_by,
+         d,
+         d_id"""
         )
 
     def test_recipe_init(self):
@@ -336,7 +339,7 @@ ORDER BY upper(foo.last),
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10
@@ -354,7 +357,7 @@ ORDER BY foo.last"""
 FROM foo
 WHERE foo.age > 4
 GROUP BY first
-ORDER BY foo.first"""
+ORDER BY first"""
         )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].age == 15
@@ -416,7 +419,7 @@ SELECT foo.last AS last,
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
 
     def test_recipe_empty(self):
@@ -457,7 +460,7 @@ ORDER BY foo.last"""
 FROM foo
 WHERE foo.age > 2
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10
@@ -482,7 +485,7 @@ FROM foo
 WHERE foo.age > 2
 GROUP BY last
 HAVING sum(foo.age) < 10
-ORDER BY foo.last"""
+ORDER BY last"""
         )
 
         assert (

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -229,7 +229,7 @@ GROUP BY first"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].last_id == "fred"
@@ -244,13 +244,14 @@ ORDER BY foo.last"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY foo.last"""
+ORDER BY last"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10
         assert recipe.stats.rows == 2
 
         recipe = self.recipe().metrics("age").dimensions("last").order_by("age")
+        # FIXME: Why is this using the calculation
         assert (
             recipe.to_sql()
             == """SELECT foo.last AS last,
@@ -270,7 +271,7 @@ ORDER BY sum(foo.age)"""
        sum(foo.age) AS age
 FROM foo
 GROUP BY last
-ORDER BY sum(foo.age) DESC"""
+ORDER BY age DESC"""
         )
         assert recipe.all()[0].last == "fred"
         assert recipe.all()[0].age == 10
@@ -288,8 +289,8 @@ ORDER BY sum(foo.age) DESC"""
 FROM foo
 GROUP BY firstlast_id,
          firstlast
-ORDER BY foo.last,
-         foo.first"""
+ORDER BY firstlast,
+         firstlast_id"""
         )
         recipe = (
             self.recipe().metrics("age").dimensions("firstlast").order_by("-firstlast")
@@ -302,8 +303,8 @@ ORDER BY foo.last,
 FROM foo
 GROUP BY firstlast_id,
          firstlast
-ORDER BY foo.last DESC,
-         foo.first DESC"""
+ORDER BY firstlast DESC,
+         firstlast_id DESC"""
         )
 
         # Dimensions can define their own ordering

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -49,6 +49,50 @@ def test_field_as():
         normalize_schema(shelf_schema, v, allow_unknown=False)
 
 
+"""
+
+state:
+  singular: State
+  plural: States
+  kind: Dimension
+  field:
+    value: state
+    aggregation: none
+  role: 'dimension:place'
+  latitude_field: state_lat
+  longitude_field: state_long
+"""
+
+
+def test_dimension_extra_fields():
+    """ Extra fields get added to extra_fields list"""
+    value = {
+        "state": {
+            "field": "state",
+            "kind": "Dimension",
+            "latitude_field": "state_lat",
+            "longitude_field": "state_lng",
+        }
+    }
+    x = normalize_schema(shelf_schema, value)
+    assert x == {
+        "state": {
+            "kind": "Dimension",
+            "field": {"value": "state", "aggregation": "none"},
+            "extra_fields": [
+                {
+                    "field": {"value": "state_lat", "aggregation": "none"},
+                    "name": "latitude_expression",
+                },
+                {
+                    "field": {"value": "state_lng", "aggregation": "none"},
+                    "name": "longitude_expression",
+                },
+            ],
+        }
+    }
+
+
 def test_field_default():
     defaults = [24, True, 11.21243, "heythere"]
 


### PR DESCRIPTION
## Background

The 0.12 release added a new Dimension.group_by_strategy of "labels"  (https://github.com/juiceinc/recipe/pull/85). This used the labels applied to dimension columns in the GROUP BY. This generated more compact SQL code and fixed an error that was occurring in Bigquery.

This PR applies this logic to ORDER BY 

This

```
SELECT CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END AS age_buckets,
       sum(census.pop2000) AS pop2000
FROM census
GROUP BY CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END
ORDER BY CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END
```

Becomes this

```
SELECT CASE
           WHEN (census.age < 2) THEN 'babies'
           WHEN (census.age < 13) THEN 'children'
           WHEN (census.age < 20) THEN 'teens'
           ELSE 'oldsters'
       END AS age_buckets,
       sum(census.pop2000) AS pop2000
FROM census
GROUP BY age_buckets
ORDER BY age_buckets
```

## What has changed

This change reworked several internal aspects of order by.

* `recipe.order_by('a','b')` must now use dimensions and metrics **that are already in the recipe**. Previously it was possible to order by a field that was not otherwise in the recipe. I don't know of any cases where this was used.
* If a dimension has many extra roles (like a place might have a name, id, latitude, longitude, and order_by) all those roles participate in the ordering. Previously only the name, id, and order_by participated.
* Order bys are now created during recipe._cauldron.brew_query_parts() rather than in a separate step. 
* Order bys just use ingredient.columns directly rather than storing the orderings as a separate set of columns in a separate structure.
* A *magic* order_by_expression is now treated *mostly* like any other expression
* Minor fix: recipe.enchant passed a parameter called list. This is a bad and I feel bad. It has been changed to data.

### More about ingredient.columns

The order that expressions are added to the list of columns matters.

The first column is used for build_filter. For dimensions that contain both an id and a value, the id will be the first column (and used for filtering) while the value is the second column.

When the ingredient is used for ordering, columns are reversed, so later columns will take priority for ordering. For dimensions that contain both an id and a value, the id will be the first column (and used for filtering) while the value is the second column (and used for ordering).

If the ingredient has an order_by_expression, this will be placed last in the list of columns. Thus, it takes priority in ordering.

### More about order_by_expression

Order_by_expression is designed to allow data to have an innate ordering that is applied whenever it is used. See https://www.wikiwand.com/en/Ordinal_data

If a dimension has an order_by_expression, it will **always** order on that expression when the dimension is used. We are starting to use this on buckets.
