### PR TITLE
RECIPE-101 ignore ordering if not matching ingredients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ output/*/index.html
 docs/_build
 
 .DS_Store
+.direnv
 *~
 .*.sw[po]
 .build

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -385,8 +385,8 @@ class Shelf(object):
                     if str(c) not in [str(o) for o in order_bys]:
                         order_bys.add(c)
             except BadRecipe as e:
-                # Ignore order_by if the dimension/metric is not 
-                # used. 
+                # Ignore order_by if the dimension/metric is not
+                # used.
                 # TODO: Add structlog warning
                 pass
 

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -380,16 +380,15 @@ class Shelf(object):
         for key in order_by_keys:
             try:
                 ingr = self.find(key, (Dimension, Metric))
+                for c in ingr.order_by_columns:
+                    # Avoid duplicate order by columns
+                    if str(c) not in [str(o) for o in order_bys]:
+                        order_bys.add(c)
             except BadRecipe as e:
-                if "doesn't exist on the shelf" in str(e):
-                    raise BadRecipe(
-                        "{} can't be used for order_by unless it has "
-                        "already been added as a dimension or metric".format(key)
-                    )
-            for c in ingr.order_by_columns:
-                # Avoid duplicate order by columns
-                if str(c) not in [str(o) for o in order_bys]:
-                    order_bys.add(c)
+                # Ignore order_by if the dimension/metric is not 
+                # used. 
+                # TODO: Add structlog warning
+                pass
 
         return {
             "columns": columns,

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -329,8 +329,6 @@ ORDER BY d_order_by,
          d_id"""
         )
 
-
-
     def test_recipe_init(self):
         """Test that all options can be passed in the init"""
         recipe = self.recipe(metrics=("age",), dimensions=("last",)).order_by("last")

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -386,10 +386,13 @@ GROUP BY first,
     def test_order_bys_not_matching_ingredients(self):
         """If an order_by is not found in dimensions+metrics, we ignore it"""
         recipe = self.recipe().metrics("age").dimensions("first").order_by("last")
-        assert recipe.to_sql() == """SELECT foo.first AS first,
+        assert (
+            recipe.to_sql()
+            == """SELECT foo.first AS first,
        sum(foo.age) AS age
 FROM foo
 GROUP BY first"""
+        )
         assert recipe.all()[0].first == "hi"
         assert recipe.all()[0].age == 15
         assert recipe.stats.rows == 1

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -329,6 +329,8 @@ ORDER BY d_order_by,
          d_id"""
         )
 
+
+
     def test_recipe_init(self):
         """Test that all options can be passed in the init"""
         recipe = self.recipe(metrics=("age",), dimensions=("last",)).order_by("last")
@@ -382,6 +384,13 @@ WHERE foo.age > 4
 GROUP BY first,
          last"""
         )
+
+    def test_order_bys_not_matching_ingredients(self):
+        """When ordering by an ingredient that doesn't exist in dimensions
+        or metrics, we get a BadRecipe"""
+        recipe = self.recipe().metrics("age").dimensions("first").order_by("last")
+        with pytest.raises(BadRecipe):
+            recipe.to_sql()
 
     def test_from_config_filter_object(self):
         config = {

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -386,11 +386,15 @@ GROUP BY first,
         )
 
     def test_order_bys_not_matching_ingredients(self):
-        """When ordering by an ingredient that doesn't exist in dimensions
-        or metrics, we get a BadRecipe"""
+        """If an order_by is not found in dimensions+metrics, we ignore it"""
         recipe = self.recipe().metrics("age").dimensions("first").order_by("last")
-        with pytest.raises(BadRecipe):
-            recipe.to_sql()
+        assert recipe.to_sql() == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+GROUP BY first"""
+        assert recipe.all()[0].first == "hi"
+        assert recipe.all()[0].age == 15
+        assert recipe.stats.rows == 1
 
     def test_from_config_filter_object(self):
         config = {


### PR DESCRIPTION
Make recipe more lenient in its inputs by ignoring order_by if the ingredient has not been added to dimensions and metrics. This has been creating a exception in code where recipe is used. 