### PR TITLE
Count distinct not matching in parsed fields

### DIFF
--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -2,9 +2,11 @@ from lark import Lark, Transformer, v_args
 from .utils import aggregations
 from ..compat import basestring
 
-allowed_aggr_keys = "|".join(
-    k for k in aggregations.keys() if isinstance(k, basestring)
-)
+aggr_keys = [k for k in aggregations.keys() if isinstance(k, basestring)]
+# Sort the keys in descending order of length
+aggr_keys.sort(key=lambda item: (len(item), item), reverse=True)
+allowed_aggr_keys = "|".join(aggr_keys)
+
 
 # Grammar for boolean expressions
 boolean_expr_grammar = """

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -34,6 +34,7 @@ def test_parsers():
     max(war_total) - min(war_total)                 # 1,0,0,0,0,0
     min(war_total)-max(war_total-war_total)         # 1,0,0,0,0,0
     avg(war_total + 2.0)                            # 1,0,0,0,0,0
+    count_distinct(war_total + 2.0)                 # 1,0,0,0,0,0
     avg(war_total) + 2.0                            # 1,0,0,0,0,0
     min(a+b)/max(b*c)                               # 1,0,0,0,0,0
     min(2+\"a\")/max(b*c)                           # 1,0,0,0,0,0
@@ -63,7 +64,7 @@ def test_parsers():
                     tree = parser.parse(row)
                     # print(f"{parser_name:30s} succeeded ({expected_result})")
                     assert expected_result == "1"
-                    print(tree.pretty())
+                    # print(tree.pretty())
                 except:
                     # print(f"{parser_name:30s} failed ({expected_result})")
                     assert expected_result == "0"


### PR DESCRIPTION
Fields like `count_distinct(foo)` were not matching because the regex for an aggregation function looked like `sum|min|max|count|count_distinct...` and this was matching on count first. So we would match count and then try to parse `_distinct(foo)` and fail.

 