### PR TITLE
Build partial conditions into full conditions safely

### DIFF
--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -127,19 +127,29 @@ def _lowercase_kind(value):
     return value
 
 
+def _build_full_condition(field, itm):
+    """
+    Test if the itm["condition"] is a partial relation expression
+
+    If so, convert it in place into a full relation expression by including the field.
+    """
+    tree = noag_any_condition_parser.parse(itm["condition"])
+    if tree.data == "partial_relation_expr":
+        itm["condition"] = "(" + field + ")" + itm["condition"]
+
+
 def _convert_partial_conditions(value):
     """Convert all partial conditions to full conditions in buckets and quickselects."""
     field = value.get("field")
+
     # Convert all bucket conditions to full conditions
     for itm in value.get("buckets", []):
-        tree = noag_any_condition_parser.parse(itm["condition"])
-        if tree.data == "partial_relation_expr":
-            itm["condition"] = field + itm["condition"]
+        _build_full_condition(field, itm)
+
     # Convert all quickselects conditions to full conditions
     for itm in value.get("quickselects", []):
-        tree = noag_any_condition_parser.parse(itm["condition"])
-        if tree.data == "partial_relation_expr":
-            itm["condition"] = "(" + field + ")" + itm["condition"]
+        _build_full_condition(field, itm)
+
     return value
 
 

--- a/tests/ingredients/census.yaml
+++ b/tests/ingredients/census.yaml
@@ -34,7 +34,18 @@ mixed_buckets:
     - label: 'babies'
       lt: 2
     - label: 'children'
-      lt: 13
+      in:
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
     - label: 'teens'
       lt: 20
     buckets_default_label: 'oldsters'

--- a/tests/parsed_ingredients/census.yaml
+++ b/tests/parsed_ingredients/census.yaml
@@ -34,7 +34,7 @@ mixed_buckets:
     - label: 'babies'
       condition: '<2'
     - label: 'children'
-      condition: '<13'
+      condition: 'in (2,3,4,5,6,7,8,9,10,11,12)'
     - label: 'teens'
       condition: '<20'
     buckets_default_label: 'oldsters'

--- a/tests/schemas/test_parsed_schemas.py
+++ b/tests/schemas/test_parsed_schemas.py
@@ -148,7 +148,10 @@ test:
 """
     v = yaml.safe_load(content)
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
-    assert result["test"]["field"] == 'if((moo)>2,"foo",state in (1,2),"cow",(moo)in (3,4),"horse",NULL)'
+    assert (
+        result["test"]["field"]
+        == 'if((moo)>2,"foo",state in (1,2),"cow",(moo)in (3,4),"horse",NULL)'
+    )
     assert (
         result["test"]["extra_fields"][0]["field"]
         == "if((moo)>2,0,state in (1,2),1,(moo)in (3,4),2,9999)"

--- a/tests/schemas/test_parsed_schemas.py
+++ b/tests/schemas/test_parsed_schemas.py
@@ -143,13 +143,15 @@ test:
       condition: ">2"
     - label: cow
       condition: "state in (1,2)"
+    - label: horse
+      condition: "in (3,4)"
 """
     v = yaml.safe_load(content)
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
-    assert result["test"]["field"] == 'if(moo>2,"foo",state in (1,2),"cow",NULL)'
+    assert result["test"]["field"] == 'if((moo)>2,"foo",state in (1,2),"cow",(moo)in (3,4),"horse",NULL)'
     assert (
         result["test"]["extra_fields"][0]["field"]
-        == "if(moo>2,0,state in (1,2),1,9999)"
+        == "if((moo)>2,0,state in (1,2),1,(moo)in (3,4),2,9999)"
     )
 
     content = """
@@ -169,11 +171,11 @@ test:
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert (
         result["test"]["field"]
-        == 'if(moo<2,"undertwo",moo>"2","foo",state in ("1", "2"),"cow",NULL)'
+        == 'if((moo)<2,"undertwo",(moo)>"2","foo",state in ("1", "2"),"cow",NULL)'
     )
     assert (
         result["test"]["extra_fields"][0]["field"]
-        == 'if(moo<2,0,moo>"2",1,state in ("1", "2"),2,9999)'
+        == 'if((moo)<2,0,(moo)>"2",1,state in ("1", "2"),2,9999)'
     )
 
     content = """
@@ -194,11 +196,11 @@ age_buckets:
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert (
         result["age_buckets"]["field"]
-        == 'if(age<2,"babies",age<13,"children",age<20,"teens","oldsters")'
+        == 'if((age)<2,"babies",(age)<13,"children",(age)<20,"teens","oldsters")'
     )
     assert (
         result["age_buckets"]["extra_fields"][0]["field"]
-        == "if(age<2,0,age<13,1,age<20,2,9999)"
+        == "if((age)<2,0,(age)<13,1,(age)<20,2,9999)"
     )
 
 

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -274,7 +274,17 @@ FROM census"""
            WHEN (census.state IN ('Vermont',
                                   'New Hampshire')) THEN 'northeast'
            WHEN (census.age < 2) THEN 'babies'
-           WHEN (census.age < 13) THEN 'children'
+           WHEN (census.age IN (2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12)) THEN 'children'
            WHEN (census.age < 20) THEN 'teens'
            ELSE 'oldsters'
        END AS mixed_buckets,
@@ -282,7 +292,17 @@ FROM census"""
            WHEN (census.state IN ('Vermont',
                                   'New Hampshire')) THEN 0
            WHEN (census.age < 2) THEN 1
-           WHEN (census.age < 13) THEN 2
+           WHEN (census.age IN (2,
+                                3,
+                                4,
+                                5,
+                                6,
+                                7,
+                                8,
+                                9,
+                                10,
+                                11,
+                                12)) THEN 2
            WHEN (census.age < 20) THEN 3
            ELSE 9999
        END AS mixed_buckets_order_by,


### PR DESCRIPTION
Partial conditions with "IN" were being appended to the field name to create something like `ageIN (1,2,3)` this PR adds parenthesis and more consistency to how partial conditions are built. The prior example will now be `(age)IN (1,2,3)`

Adds tests and adds more diverse conditions when testing buckets