### PR TITLE
Backport a fix to count_distinct in parsed fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,20 @@
 Changelog
 =========
 
+0.14.1 (2020-06-11)
+-----------------------------------------
+
+* Fix count_distinct in parsed ingredients
+
+
+0.14.0 (2020-03-06)
+-----------------------------------------
+
+* Support graceful ingredient failures when ingredients can not be constructed from config.
+
 0.13.1 (2020-02-11)
 -----------------------------------------
+
 * Fix a pg8000 issue
 
 0.13.0 (2020-01-28)

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -2,9 +2,11 @@ from lark import Lark, Transformer, v_args
 from .utils import aggregations
 from ..compat import basestring
 
-allowed_aggr_keys = "|".join(
-    k for k in aggregations.keys() if isinstance(k, basestring)
-)
+aggr_keys = [k for k in aggregations.keys() if isinstance(k, basestring)]
+# Sort the keys in descending order of length
+aggr_keys.sort(key=lambda item: (len(item), item), reverse=True)
+allowed_aggr_keys = "|".join(aggr_keys)
+
 
 # Grammar for boolean expressions
 boolean_expr_grammar = """

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -33,6 +33,7 @@ def test_parsers():
     sum(war_total)                                  # 1,0,0,0,0,0
     max(war_total) - min(war_total)                 # 1,0,0,0,0,0
     min(war_total)-max(war_total-war_total)         # 1,0,0,0,0,0
+    count_distinct(war_total + 2.0)                 # 1,0,0,0,0,0
     avg(war_total + 2.0)                            # 1,0,0,0,0,0
     avg(war_total) + 2.0                            # 1,0,0,0,0,0
     min(a+b)/max(b*c)                               # 1,0,0,0,0,0
@@ -188,5 +189,5 @@ expr
     ]
     for v, pretty_tree in values:
         tree = field_parser.parse(v)
-        print(tree.pretty())
+        # print(tree.pretty())
         assert tree.pretty().strip() == pretty_tree.strip()


### PR DESCRIPTION
Fields like count_distinct(foo) were not matching because the regex for an aggregation function looked like sum|min|max|count|count_distinct... and this was matching on count first. So we would match count and then try to parse _distinct(foo) and fail.

This PR merges this into a bugfix release for 0.14