### PR TITLE
Improve SQL generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+0.16.0 (2020-06-19)
+-----------------------------------------
+* Ignore order_by on a recipe if the ingredient has not been added to the dimensions or metrics.
+* Allows case insensitivity in "kind:" and support "kind: Measure" as an alternative to "kind: Metric"
+* Fix like/ilike and pagination_q filtering against dimensions that have a non-string ID.
+* Fix parsed sql generation for AND and OR
+* Fix parsed sql generation for division when one of the terms is a constant (like sum(people) / 100.0)
+* Adds IS NULL as a boolean expression 
+* Adds "Intelligent date" calculations to allow more useful date calculations relative to current date
+
 0.15.0 (2020-05-08)
 -----------------------------------------
 * Ignore order_by if ingredients have not been added

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -41,12 +41,16 @@ base_grammar = """
     ?partial_relation_expr.0: comparator atom
                 | vector_comparator array
                 | BETWEEN atom AND atom
+                | is_comparator NULL
     ?relation_expr.1:        atom comparator atom
+                           | atom is_comparator NULL   -> relation_expr_using_is
     ?vector_relation_expr.1: atom vector_comparator array
     ?between_relation_expr.1: atom BETWEEN atom AND atom
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
+    ?is_comparator.1: IS | ISNOT
+    ?is_comparison.1: NULL
     OR: /OR/i
     AND: /AND/i
     NOT: /NOT/i
@@ -57,14 +61,19 @@ base_grammar = """
     GT: ">"
     GTE: ">="
     IN: /IN/i
+    IS: /IS/i
+    ISNOT: IS NOT
     NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
+    NULL: /NULL/i
+    DYNAMIC_DATE_RELATIVE: /(prior|this|next)/i
+    DYNAMIC_DATE_PERIOD: /(ytd|year|quarter|month|week|day)/i
 
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal
             | /true/i                          -> true
             | /false/i                         -> false
-            | /null/i                          -> null
+            | NULL
     STAR: "*"
     COMMENT: /#.*/
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -41,16 +41,16 @@ base_grammar = """
     ?partial_relation_expr.0: comparator atom
                 | vector_comparator array
                 | BETWEEN atom AND atom
-                | is_comparator NULL
+                | is_comparator null
     ?relation_expr.1:        atom comparator atom
-                           | atom is_comparator NULL   -> relation_expr_using_is
+                           | atom is_comparator null   -> relation_expr_using_is
     ?vector_relation_expr.1: atom vector_comparator array
     ?between_relation_expr.1: atom BETWEEN atom AND atom
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
     ?is_comparator.1: IS | ISNOT
-    ?is_comparison.1: NULL
+    //?is_comparison.1: NULL | ESCAPED_STRING
     OR: /OR/i
     AND: /AND/i
     NOT: /NOT/i
@@ -65,15 +65,12 @@ base_grammar = """
     ISNOT: IS NOT
     NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
-    NULL: /NULL/i
-    DYNAMIC_DATE_RELATIVE: /(prior|this|next)/i
-    DYNAMIC_DATE_PERIOD: /(ytd|year|quarter|month|week|day)/i
+    null: /NULL/i
 
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal
             | /true/i                          -> true
             | /false/i                         -> false
-            | NULL
     STAR: "*"
     COMMENT: /#.*/
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -8,8 +8,21 @@ aggr_keys.sort(key=lambda item: (len(item), item), reverse=True)
 allowed_aggr_keys = "|".join(aggr_keys)
 
 
-# Grammar for boolean expressions
-boolean_expr_grammar = """
+boolean_column_defn = "/NOMATCHBOOL/"
+string_column_defn = "/NOMATCHSTRING/"
+column_defn = "NAME"
+base_field_grammar_args = {
+    "allowed_aggr_keys": allowed_aggr_keys,
+    "boolean_column_defn": boolean_column_defn,
+    "string_column_defn": string_column_defn,
+    "column_defn": column_defn,
+}
+
+
+# Base grammar for boolean expressions
+# This grammar depends on a definition of atom which will be
+# added in the field grammars
+base_grammar = """
     ?start: bool_expr | partial_relation_expr
 
     // Pairs of boolean expressions and expressions
@@ -31,7 +44,6 @@ boolean_expr_grammar = """
     ?relation_expr.1:        atom comparator atom
     ?vector_relation_expr.1: atom vector_comparator array
     ?between_relation_expr.1: atom BETWEEN atom AND atom
-    ?pair_array:           "(" const "," const ")"            -> array
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
@@ -47,22 +59,7 @@ boolean_expr_grammar = """
     IN: /IN/i
     NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
-"""
 
-noag_field_grammar = (
-    """
-    ?expr: sum                                 -> expr
-    ?sum: product
-        | sum "+" product                      -> add
-        | sum "-" product                      -> sub
-    ?product: atom
-           | product "*" atom                  -> mul
-           | product "/" atom                  -> div
-    ?atom: const
-           | column
-           | case
-           | "(" sum ")"
-    ?column.0:  NAME                           -> column
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal
             | /true/i                          -> true
@@ -78,53 +75,44 @@ noag_field_grammar = (
     %ignore COMMENT
     %ignore WS_INLINE
 """
-    + boolean_expr_grammar
-)
+base_field_grammar = """
+    ?sum: product
+        | sum "+" product                      -> add
+        | sum "-" product                      -> sub
+    ?product: atom
+           | product "*" atom                  -> mul
+           | product "/" atom                  -> div
+    ?column.0: {boolean_column_defn}           -> boolean_column
+        | {string_column_defn}                 -> string_column
+        | {column_defn}                        -> column
+""".format(**base_field_grammar_args) + base_grammar
+
+
+# A grammar that does not include aggregate expressions
+noag_field_grammar = """
+    ?expr: sum                                 -> expr
+    ?atom: const
+           | column
+           | case
+           | "(" sum ")"
+""" + base_field_grammar
 
 
 # Grammar for expressions that allow aggregations
 # for instance:
 # "sum(sales)" or "max(yards) - min(yards)"
 # Aggregations are keys defined in
-agex_field_grammar = (
-    """
+agex_field_grammar = """
     ?expr: agex | sum                          -> expr
     ?agex: aggr "(" sum ")"
         | /count/i "(" STAR ")"                -> agex
-    ?sum: product
-        | sum "+" product                      -> add
-        | sum "-" product                      -> sub
-    ?product: atom
-           | product "*" atom                  -> mul
-           | product "/" atom                  -> div
-
     ?aggr:  /({allowed_aggr_keys})/i           -> aggregate
     ?atom: agex
            | const
            | column
            | case
            | "(" sum ")"
-    ?column.0:  NAME                           -> column
-    ?const.1: NUMBER                           -> number
-            | ESCAPED_STRING                   -> string_literal
-            | /true/i                          -> true
-            | /false/i                         -> false
-            | /null/i                          -> null
-
-    STAR: "*"
-    COMMENT: /#.*/
-
-    %import common.CNAME                       -> NAME
-    %import common.SIGNED_NUMBER               -> NUMBER
-    %import common.ESCAPED_STRING
-    %import common.WS_INLINE
-    %ignore COMMENT
-    %ignore WS_INLINE
-""".format(
-        allowed_aggr_keys=allowed_aggr_keys
-    )
-    + boolean_expr_grammar
-)
+""".format(**base_field_grammar_args) + base_field_grammar
 
 
 ambig = "resolve"

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -66,7 +66,7 @@ base_grammar = """
     NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
     null: /NULL/i
-    INTELLIGENT_DATE_OFFSET: /prior/i | /last/i | /previous/i | /current/i | /next/i
+    INTELLIGENT_DATE_OFFSET: /prior/i | /last/i | /previous/i | /current/i | /this/i | /next/i
     INTELLIGENT_DATE_UNITS: /ytd/i | /year/i | /qtr/i | /month/i | /mtd/i | /day/i
 
     ?const.1: NUMBER                           -> number

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -82,7 +82,8 @@ base_grammar = """
     %ignore COMMENT
     %ignore WS_INLINE
 """
-base_field_grammar = """
+base_field_grammar = (
+    """
     ?sum: product
         | sum "+" product                      -> add
         | sum "-" product                      -> sub
@@ -92,24 +93,32 @@ base_field_grammar = """
     ?column.0: {boolean_column_defn}           -> boolean_column
         | {string_column_defn}                 -> string_column
         | {column_defn}                        -> column
-""".format(**base_field_grammar_args) + base_grammar
+""".format(
+        **base_field_grammar_args
+    )
+    + base_grammar
+)
 
 
 # A grammar that does not include aggregate expressions
-noag_field_grammar = """
+noag_field_grammar = (
+    """
     ?expr: sum                                 -> expr
     ?atom: const
            | column
            | case
            | "(" sum ")"
-""" + base_field_grammar
+"""
+    + base_field_grammar
+)
 
 
 # Grammar for expressions that allow aggregations
 # for instance:
 # "sum(sales)" or "max(yards) - min(yards)"
 # Aggregations are keys defined in
-agex_field_grammar = """
+agex_field_grammar = (
+    """
     ?expr: agex | sum                          -> expr
     ?agex: aggr "(" sum ")"
         | /count/i "(" STAR ")"                -> agex
@@ -119,7 +128,11 @@ agex_field_grammar = """
            | column
            | case
            | "(" sum ")"
-""".format(**base_field_grammar_args) + base_field_grammar
+""".format(
+        **base_field_grammar_args
+    )
+    + base_field_grammar
+)
 
 
 ambig = "resolve"

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -8,13 +8,11 @@ aggr_keys.sort(key=lambda item: (len(item), item), reverse=True)
 allowed_aggr_keys = "|".join(aggr_keys)
 
 
-boolean_column_defn = "/NOMATCHBOOL/"
-string_column_defn = "/NOMATCHSTRING/"
+# TODO: We may want to match columns based on fields that exist in 
+# a source table. Allowing column definition to be changed is a start.
 column_defn = "NAME"
 base_field_grammar_args = {
     "allowed_aggr_keys": allowed_aggr_keys,
-    "boolean_column_defn": boolean_column_defn,
-    "string_column_defn": string_column_defn,
     "column_defn": column_defn,
 }
 
@@ -90,9 +88,7 @@ base_field_grammar = (
     ?product: atom
            | product "*" atom                  -> mul
            | product "/" atom                  -> div
-    ?column.0: {boolean_column_defn}           -> boolean_column
-        | {string_column_defn}                 -> string_column
-        | {column_defn}                        -> column
+    ?column.0: {column_defn}                   -> column
 """.format(
         **base_field_grammar_args
     )
@@ -133,7 +129,6 @@ agex_field_grammar = (
     )
     + base_field_grammar
 )
-
 
 ambig = "resolve"
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -8,7 +8,7 @@ aggr_keys.sort(key=lambda item: (len(item), item), reverse=True)
 allowed_aggr_keys = "|".join(aggr_keys)
 
 
-# TODO: We may want to match columns based on fields that exist in 
+# TODO: We may want to match columns based on fields that exist in
 # a source table. Allowing column definition to be changed is a start.
 column_defn = "NAME"
 base_field_grammar_args = {

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -41,16 +41,17 @@ base_grammar = """
     ?partial_relation_expr.0: comparator atom
                 | vector_comparator array
                 | BETWEEN atom AND atom
-                | is_comparator is_comparison
+                | IS is_comparison
     ?relation_expr.1:        atom comparator atom
-                           | atom is_comparator is_comparison   -> relation_expr_using_is
+                           | atom IS is_comparison   -> relation_expr_using_is
     ?vector_relation_expr.1: atom vector_comparator array
     ?between_relation_expr.1: atom BETWEEN atom AND atom
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
-    ?is_comparator.1: IS | ISNOT
-    ?is_comparison.1: null | INTELLIGENT_DATE_OFFSET INTELLIGENT_DATE_UNITS
+    ?is_comparator.1: IS
+    ?is_comparison.1: NULL | INTELLIGENT_DATE_OFFSET INTELLIGENT_DATE_UNITS
+    NOTIN: NOT IN
     OR: /OR/i
     AND: /AND/i
     NOT: /NOT/i
@@ -62,10 +63,8 @@ base_grammar = """
     GTE: ">="
     IN: /IN/i
     IS: /IS/i
-    ISNOT: IS NOT
-    NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
-    null: /NULL/i
+    NULL: /NULL/i
     INTELLIGENT_DATE_OFFSET: /prior/i | /last/i | /previous/i | /current/i | /this/i | /next/i
     INTELLIGENT_DATE_UNITS: /ytd/i | /year/i | /qtr/i | /month/i | /mtd/i | /day/i
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -41,16 +41,16 @@ base_grammar = """
     ?partial_relation_expr.0: comparator atom
                 | vector_comparator array
                 | BETWEEN atom AND atom
-                | is_comparator null
+                | is_comparator is_comparison
     ?relation_expr.1:        atom comparator atom
-                           | atom is_comparator null   -> relation_expr_using_is
+                           | atom is_comparator is_comparison   -> relation_expr_using_is
     ?vector_relation_expr.1: atom vector_comparator array
     ?between_relation_expr.1: atom BETWEEN atom AND atom
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
     ?is_comparator.1: IS | ISNOT
-    //?is_comparison.1: NULL | ESCAPED_STRING
+    ?is_comparison.1: null | INTELLIGENT_DATE_OFFSET INTELLIGENT_DATE_UNITS
     OR: /OR/i
     AND: /AND/i
     NOT: /NOT/i
@@ -66,6 +66,8 @@ base_grammar = """
     NOTIN: NOT IN
     BETWEEN: /BETWEEN/i
     null: /NULL/i
+    INTELLIGENT_DATE_OFFSET: /prior/i | /last/i | /previous/i | /current/i | /next/i
+    INTELLIGENT_DATE_UNITS: /ytd/i | /year/i | /qtr/i | /month/i | /mtd/i | /day/i
 
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -47,7 +47,6 @@ base_grammar = """
     ?array:                "(" [const ("," const)*] ")"
     ?comparator: EQ | NE | LT | LTE | GT | GTE
     ?vector_comparator.1: IN | NOTIN
-    ?is_comparator.1: IS
     ?is_comparison.1: NULL | INTELLIGENT_DATE_OFFSET INTELLIGENT_DATE_UNITS
     NOTIN: NOT IN
     OR: /OR/i

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -40,7 +40,17 @@ class TransformToSQLAlchemyExpression(Transformer):
     def NOTIN(self, value):
         return "NOTIN"
 
+    def IS(self, value):
+        print("found is")
+        return "IS"
+
+    def ISNOT(self, value):
+        return "ISNOT"
+
     def NULL(self, value):
+        return None
+
+    def null(self, value):
         return None
 
     def BETWEEN(self, value):
@@ -98,12 +108,12 @@ class TransformToSQLAlchemyExpression(Transformer):
 
     def relation_expr_using_is(self, left, rel, *args):
         """A relation expression like age is null """
-        print("here we go", left, rel, *args)
+        rel = rel.lower()
         if len(args) == 1:
-            rel = args[0].upper()
+            arg = args[0]
         comparators = {
-            "ISNOT": "isnot",
-            "IS": "is_",
+            "isnot": "isnot",
+            "is": "is_",
         }
         return getattr(left, comparators[rel])(None)
 

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -10,7 +10,13 @@ from .field_grammar import (
     noag_full_condition_parser,
     full_condition_parser,
 )
-from .utils import aggregations, find_column, ingredient_class_for_name, convert_value, calc_date_range
+from .utils import (
+    aggregations,
+    find_column,
+    ingredient_class_for_name,
+    convert_value,
+    calc_date_range,
+)
 from recipe.exceptions import BadIngredient
 
 
@@ -56,7 +62,7 @@ class TransformToSQLAlchemyExpression(Transformer):
 
     def div(self, num, denom):
         """SQL safe division"""
-        if isinstance(denom, (int, float)):            
+        if isinstance(denom, (int, float)):
             if denom == 0:
                 raise ValueError("Denominator can not be zero")
             elif isinstance(num, (int, float)):
@@ -67,7 +73,9 @@ class TransformToSQLAlchemyExpression(Transformer):
             if isinstance(num, (int, float)):
                 return case([(denom == 0, None)], else_=num / cast(denom, Float))
             else:
-                return case([(denom == 0, None)], else_=cast(num, Float) / cast(denom, Float))
+                return case(
+                    [(denom == 0, None)], else_=cast(num, Float) / cast(denom, Float)
+                )
 
     def column(self, name):
         return find_column(self.selectable, name)
@@ -132,7 +140,7 @@ class TransformToSQLAlchemyExpression(Transformer):
         """A relation expression like age is null or
         birth_date is last month"""
         # TODO: Why is this not handled by the tokenization
-        if str(right).upper() == 'NULL':
+        if str(right).upper() == "NULL":
             return left.is_(None)
         else:
             return left.between(*right)

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -34,14 +34,14 @@ class TransformToSQLAlchemyExpression(Transformer):
     def false(self, value):
         return False
 
-    def null(self, value):
-        return None
-
     def IN(self, value):
         return "IN"
 
     def NOTIN(self, value):
         return "NOTIN"
+
+    def NULL(self, value):
+        return None
 
     def BETWEEN(self, value):
         return "BETWEEN"
@@ -79,7 +79,9 @@ class TransformToSQLAlchemyExpression(Transformer):
         pairs = zip(args[::2], args[1::2])
         return case(pairs, else_=else_expr)
 
+
     def relation_expr(self, left, rel, right):
+        rel = rel.lower()
         comparators = {
             "=": "__eq__",
             ">": "__gt__",
@@ -93,6 +95,17 @@ class TransformToSQLAlchemyExpression(Transformer):
         # Convert the right into a type compatible with the left
         right = convert_value(left, right)
         return getattr(left, comparators[rel])(right)
+
+    def relation_expr_using_is(self, left, rel, *args):
+        """A relation expression like age is null """
+        print("here we go", left, rel, *args)
+        if len(args) == 1:
+            rel = args[0].upper()
+        comparators = {
+            "ISNOT": "isnot",
+            "IS": "is_",
+        }
+        return getattr(left, comparators[rel])(None)
 
     def array(self, *args):
         # TODO  check these are all the same type

--- a/recipe/schemas/utils.py
+++ b/recipe/schemas/utils.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from dateutil.relativedelta import relativedelta
 import dateparser
 import inspect
 from sqlalchemy import distinct, func
@@ -192,3 +193,62 @@ def ingredient_class_for_name(class_name):
     from recipe import ingredients
 
     return getattr(ingredients, class_name, None)
+
+
+def date_offset(dt, offset, **offset_params):
+    if offset in ('prior', 'previous', 'last'):
+        dt -= relativedelta(**offset_params)
+        return dt
+    elif offset == 'next':
+        dt += relativedelta(**offset_params)
+        return dt
+    elif offset in ('current', 'this'):
+        return dt
+    else:
+        raise ValueError("Unknown intelligent date offset")
+
+
+def calc_date_range(offset, units, dt):
+    """Create an intelligent date range using offsets, units and a starting date
+    
+    Args:
+
+        offset: An offset
+            current|this mean the current period
+            prior|previous|last mean the previous period
+            next means the next period
+        units: The kind of date range to create
+            year: A full year
+            ytd: The year up to the provided date
+            qtr: The full quarter the date belongs to
+            month: The full month of the provided date
+            mtd: The month up to the provided date
+            day: The provided date
+        today
+            
+    Returns:
+
+        A tuple of dates constructed using the 
+    """
+    if units == 'year':
+        dt = date_offset(dt, offset, years=1)
+        return date(dt.year, 1, 1), date(dt.year, 12, 31)
+    elif units == 'ytd':
+        dt = date_offset(dt, offset, years=1)
+        return date(dt.year, 1, 1), dt
+    elif units == 'qtr':
+        dt = date_offset(dt, offset, months=3)
+        qtr = (dt.month-1) // 3     # Calculate quarter as 0,1,2,3
+        return date(dt.year, qtr*3+1, 1), date(dt.year, qtr*3+3, 1) + relativedelta(months=1, days=-1)
+    elif units == 'month':
+        dt = date_offset(dt, offset, months=1)
+        start_dt = date(dt.year, dt.month, 1)
+        return start_dt, start_dt + relativedelta(months=1, days=-1)
+    elif units == 'mtd':
+        dt = date_offset(dt, offset, months=1)
+        return date(dt.year, dt.month, 1), dt
+    elif units == 'day':
+        dt = date_offset(dt, offset, days=1)
+        return dt, dt
+    else:
+        raise ValueError("Unknown intelligent date units")

--- a/recipe/schemas/utils.py
+++ b/recipe/schemas/utils.py
@@ -196,13 +196,13 @@ def ingredient_class_for_name(class_name):
 
 
 def date_offset(dt, offset, **offset_params):
-    if offset in ('prior', 'previous', 'last'):
+    if offset in ("prior", "previous", "last"):
         dt -= relativedelta(**offset_params)
         return dt
-    elif offset == 'next':
+    elif offset == "next":
         dt += relativedelta(**offset_params)
         return dt
-    elif offset in ('current', 'this'):
+    elif offset in ("current", "this"):
         return dt
     else:
         raise ValueError("Unknown intelligent date offset")
@@ -232,24 +232,27 @@ def calc_date_range(offset, units, dt):
         A tuple of dates constructed using the offsets and units
     """
     # TODO: Add a week unit
-    if units == 'year':
+    if units == "year":
         dt = date_offset(dt, offset, years=1)
         return date(dt.year, 1, 1), date(dt.year, 12, 31)
-    elif units == 'ytd':
+    elif units == "ytd":
         dt = date_offset(dt, offset, years=1)
         return date(dt.year, 1, 1), dt
-    elif units == 'qtr':
+    elif units == "qtr":
         dt = date_offset(dt, offset, months=3)
-        qtr = (dt.month-1) // 3     # Calculate quarter as 0,1,2,3
-        return date(dt.year, qtr*3+1, 1), date(dt.year, qtr*3+3, 1) + relativedelta(months=1, days=-1)
-    elif units == 'month':
+        qtr = (dt.month - 1) // 3  # Calculate quarter as 0,1,2,3
+        return (
+            date(dt.year, qtr * 3 + 1, 1),
+            date(dt.year, qtr * 3 + 3, 1) + relativedelta(months=1, days=-1),
+        )
+    elif units == "month":
         dt = date_offset(dt, offset, months=1)
         start_dt = date(dt.year, dt.month, 1)
         return start_dt, start_dt + relativedelta(months=1, days=-1)
-    elif units == 'mtd':
+    elif units == "mtd":
         dt = date_offset(dt, offset, months=1)
         return date(dt.year, dt.month, 1), dt
-    elif units == 'day':
+    elif units == "day":
         dt = date_offset(dt, offset, days=1)
         return dt, dt
     else:

--- a/recipe/schemas/utils.py
+++ b/recipe/schemas/utils.py
@@ -214,9 +214,9 @@ def calc_date_range(offset, units, dt):
     Args:
 
         offset: An offset
-            current|this mean the current period
-            prior|previous|last mean the previous period
-            next means the next period
+            current|this options for the current period
+            prior|previous|last options for the previous period
+            next options the next period
         units: The kind of date range to create
             year: A full year
             ytd: The year up to the provided date
@@ -224,12 +224,14 @@ def calc_date_range(offset, units, dt):
             month: The full month of the provided date
             mtd: The month up to the provided date
             day: The provided date
-        today
+        dt
+            The date that will be used for calculations
             
     Returns:
 
-        A tuple of dates constructed using the 
+        A tuple of dates constructed using the offsets and units
     """
+    # TODO: Add a week unit
     if units == 'year':
         dt = date_offset(dt, offset, years=1)
         return date(dt.year, 1, 1), date(dt.year, 12, 31)

--- a/tests/parsed_ingredients/ingredients1.yaml
+++ b/tests/parsed_ingredients/ingredients1.yaml
@@ -17,3 +17,6 @@ dt_between:
 dt_test:
     kind: Metric
     field: 'if(birth_date is NULL, age, 1)'
+intelligent_date_test:
+    kind: Metric
+    field: 'if(birth_date is prior year, age, 2)'

--- a/tests/parsed_ingredients/ingredients1.yaml
+++ b/tests/parsed_ingredients/ingredients1.yaml
@@ -14,3 +14,6 @@ date_between:
 dt_between:
     kind: Metric
     field: 'if(birth_date between "20 years ago" and "now", age)'
+dt_test:
+    kind: Metric
+    field: 'if(birth_date is NULL, age, 1)'

--- a/tests/schemas/test_intelligent_date_range.py
+++ b/tests/schemas/test_intelligent_date_range.py
@@ -1,0 +1,95 @@
+""" Test how intelligent date ranges are constructed """
+
+import pytest
+from datetime import date
+from recipe.schemas.utils import calc_date_range
+
+class TestIntelligentDateRanges(object):
+    def test_calc_date_range(self):
+        data = [
+            # Year + all offset dates
+            [ ("this", "year", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("current", "year", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("prior", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
+            [ ("previous", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
+            [ ("last", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
+            [ ("next", "year", date(2020,12,31)), (date(2021,1,1), date(2021,12,31)) ],
+            [ ("this", "year", date(2020,6,8)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("current", "year", date(2020,6,8)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("prior", "year", date(2020,6,8)), (date(2019,1,1), date(2019,12,31)) ],
+            [ ("next", "year", date(2020,6,8)), (date(2021,1,1), date(2021,12,31)) ],
+
+            # Ytd
+            [ ("this", "ytd", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("current", "ytd", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
+            [ ("prior", "ytd", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
+            [ ("next", "ytd", date(2020,12,31)), (date(2021,1,1), date(2021,12,31)) ],
+            [ ("this", "ytd", date(2020,6,8)), (date(2020,1,1), date(2020,6,8)) ],
+            [ ("current", "ytd", date(2020,6,8)), (date(2020,1,1), date(2020,6,8)) ],
+            [ ("prior", "ytd", date(2020,6,8)), (date(2019,1,1), date(2019,6,8)) ],
+            [ ("next", "ytd", date(2020,6,8)), (date(2021,1,1), date(2021,6,8)) ],
+            [ ("this", "ytd", date(2020,1,1)), (date(2020,1,1), date(2020,1,1)) ],
+
+            # qtr
+            [ ("this", "qtr", date(2020,12,31)), (date(2020,10,1), date(2020,12,31)) ],
+            [ ("this", "qtr", date(2020,10,1)), (date(2020,10,1), date(2020,12,31)) ],
+            [ ("this", "qtr", date(2020,9,30)), (date(2020,7,1), date(2020,9,30)) ],
+            [ ("this", "qtr", date(2020,6,8)), (date(2020,4,1), date(2020,6,30)) ],
+            [ ("this", "qtr", date(2020,6,30)), (date(2020,4,1), date(2020,6,30)) ],
+            [ ("this", "qtr", date(2020,5,30)), (date(2020,4,1), date(2020,6,30)) ],
+            [ ("this", "qtr", date(2020,4,1)), (date(2020,4,1), date(2020,6,30)) ],
+            [ ("this", "qtr", date(2020,3,31)), (date(2020,1,1), date(2020,3,31)) ],
+            [ ("this", "qtr", date(2020,1,31)), (date(2020,1,1), date(2020,3,31)) ],
+            [ ("this", "qtr", date(2020,1,1)), (date(2020,1,1), date(2020,3,31)) ],
+            [ ("next", "qtr", date(2020,1,1)), (date(2020,4,1), date(2020,6,30)) ],
+            [ ("previous", "qtr", date(2020,1,1)), (date(2019,10,1), date(2019,12,31)) ],
+            [ ("prior", "qtr", date(2020,3,31)), (date(2019,10,1), date(2019,12,31)) ],
+            [ ("next", "qtr", date(2020,3,31)), (date(2020,4,1), date(2020,6,30)) ],
+            # A leap day
+            [ ("next", "qtr", date(2020,2,29)), (date(2020,4,1), date(2020,6,30)) ],
+
+            # month
+            [ ("this", "month", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
+            [ ("this", "month", date(2020,10,31)), (date(2020,10,1), date(2020,10,31)) ],
+            # Leap and non leap days
+            [ ("this", "month", date(2020,2,2)), (date(2020,2,1), date(2020,2,29)) ],
+            [ ("this", "month", date(2019,2,2)), (date(2019,2,1), date(2019,2,28)) ],
+            [ ("next", "month", date(2019,2,2)), (date(2019,3,1), date(2019,3,31)) ],
+            [ ("prior", "month", date(2019,2,2)), (date(2019,1,1), date(2019,1,31)) ],
+
+            # mtd
+            [ ("this", "mtd", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
+            [ ("current", "mtd", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
+            [ ("prior", "mtd", date(2020,12,31)), (date(2020,11,1), date(2020,11,30)) ],
+            [ ("next", "mtd", date(2020,12,31)), (date(2021,1,1), date(2021,1,31)) ],
+            [ ("this", "mtd", date(2020,6,8)), (date(2020,6,1), date(2020,6,8)) ],
+            [ ("current", "mtd", date(2020,6,8)), (date(2020,6,1), date(2020,6,8)) ],
+            [ ("prior", "mtd", date(2020,6,8)), (date(2020,5,1), date(2020,5,8)) ],
+            [ ("next", "mtd", date(2020,6,8)), (date(2020,7,1), date(2020,7,8)) ],
+            [ ("this", "mtd", date(2020,1,1)), (date(2020,1,1), date(2020,1,1)) ],
+            # Long to short months
+            [ ("prior", "mtd", date(2020,3,30)), (date(2020,2,1), date(2020,2,29)) ],
+            # Short to long months count the number of days that have occurred
+            [ ("next", "mtd", date(2020,6,30)), (date(2020,7,1), date(2020,7,30)) ],
+
+            # day
+            [ ("this", "day", date(2020,12,31)), (date(2020,12,31), date(2020,12,31)) ],
+            [ ("next", "day", date(2020,12,31)), (date(2021,1,1), date(2021,1,1)) ],
+            [ ("prior", "day", date(2020,12,31)), (date(2020,12,30), date(2020,12,30)) ],
+
+        ]
+
+        for date_range_args, expected in data:
+            actual = calc_date_range(*date_range_args)
+            assert actual == expected
+
+
+    def test_bad_inputs(self):
+        with pytest.raises(ValueError):
+            calc_date_range("THIS", "day", date(2020,12,31))
+
+        with pytest.raises(ValueError):
+            calc_date_range("flugelhorn", "day", date(2020,12,31))
+
+        with pytest.raises(ValueError):
+            calc_date_range("current", "domino", date(2020,12,31))

--- a/tests/schemas/test_intelligent_date_range.py
+++ b/tests/schemas/test_intelligent_date_range.py
@@ -4,92 +4,185 @@ import pytest
 from datetime import date
 from recipe.schemas.utils import calc_date_range
 
+
 class TestIntelligentDateRanges(object):
     def test_calc_date_range(self):
         data = [
             # Year + all offset dates
-            [ ("this", "year", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("current", "year", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("prior", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
-            [ ("previous", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
-            [ ("last", "year", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
-            [ ("next", "year", date(2020,12,31)), (date(2021,1,1), date(2021,12,31)) ],
-            [ ("this", "year", date(2020,6,8)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("current", "year", date(2020,6,8)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("prior", "year", date(2020,6,8)), (date(2019,1,1), date(2019,12,31)) ],
-            [ ("next", "year", date(2020,6,8)), (date(2021,1,1), date(2021,12,31)) ],
-
+            [
+                ("this", "year", date(2020, 12, 31)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("current", "year", date(2020, 12, 31)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("prior", "year", date(2020, 12, 31)),
+                (date(2019, 1, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("previous", "year", date(2020, 12, 31)),
+                (date(2019, 1, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("last", "year", date(2020, 12, 31)),
+                (date(2019, 1, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("next", "year", date(2020, 12, 31)),
+                (date(2021, 1, 1), date(2021, 12, 31)),
+            ],
+            [
+                ("this", "year", date(2020, 6, 8)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("current", "year", date(2020, 6, 8)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("prior", "year", date(2020, 6, 8)),
+                (date(2019, 1, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("next", "year", date(2020, 6, 8)),
+                (date(2021, 1, 1), date(2021, 12, 31)),
+            ],
             # Ytd
-            [ ("this", "ytd", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("current", "ytd", date(2020,12,31)), (date(2020,1,1), date(2020,12,31)) ],
-            [ ("prior", "ytd", date(2020,12,31)), (date(2019,1,1), date(2019,12,31)) ],
-            [ ("next", "ytd", date(2020,12,31)), (date(2021,1,1), date(2021,12,31)) ],
-            [ ("this", "ytd", date(2020,6,8)), (date(2020,1,1), date(2020,6,8)) ],
-            [ ("current", "ytd", date(2020,6,8)), (date(2020,1,1), date(2020,6,8)) ],
-            [ ("prior", "ytd", date(2020,6,8)), (date(2019,1,1), date(2019,6,8)) ],
-            [ ("next", "ytd", date(2020,6,8)), (date(2021,1,1), date(2021,6,8)) ],
-            [ ("this", "ytd", date(2020,1,1)), (date(2020,1,1), date(2020,1,1)) ],
-
+            [
+                ("this", "ytd", date(2020, 12, 31)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("current", "ytd", date(2020, 12, 31)),
+                (date(2020, 1, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("prior", "ytd", date(2020, 12, 31)),
+                (date(2019, 1, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("next", "ytd", date(2020, 12, 31)),
+                (date(2021, 1, 1), date(2021, 12, 31)),
+            ],
+            [("this", "ytd", date(2020, 6, 8)), (date(2020, 1, 1), date(2020, 6, 8))],
+            [
+                ("current", "ytd", date(2020, 6, 8)),
+                (date(2020, 1, 1), date(2020, 6, 8)),
+            ],
+            [("prior", "ytd", date(2020, 6, 8)), (date(2019, 1, 1), date(2019, 6, 8))],
+            [("next", "ytd", date(2020, 6, 8)), (date(2021, 1, 1), date(2021, 6, 8))],
+            [("this", "ytd", date(2020, 1, 1)), (date(2020, 1, 1), date(2020, 1, 1))],
             # qtr
-            [ ("this", "qtr", date(2020,12,31)), (date(2020,10,1), date(2020,12,31)) ],
-            [ ("this", "qtr", date(2020,10,1)), (date(2020,10,1), date(2020,12,31)) ],
-            [ ("this", "qtr", date(2020,9,30)), (date(2020,7,1), date(2020,9,30)) ],
-            [ ("this", "qtr", date(2020,6,8)), (date(2020,4,1), date(2020,6,30)) ],
-            [ ("this", "qtr", date(2020,6,30)), (date(2020,4,1), date(2020,6,30)) ],
-            [ ("this", "qtr", date(2020,5,30)), (date(2020,4,1), date(2020,6,30)) ],
-            [ ("this", "qtr", date(2020,4,1)), (date(2020,4,1), date(2020,6,30)) ],
-            [ ("this", "qtr", date(2020,3,31)), (date(2020,1,1), date(2020,3,31)) ],
-            [ ("this", "qtr", date(2020,1,31)), (date(2020,1,1), date(2020,3,31)) ],
-            [ ("this", "qtr", date(2020,1,1)), (date(2020,1,1), date(2020,3,31)) ],
-            [ ("next", "qtr", date(2020,1,1)), (date(2020,4,1), date(2020,6,30)) ],
-            [ ("previous", "qtr", date(2020,1,1)), (date(2019,10,1), date(2019,12,31)) ],
-            [ ("prior", "qtr", date(2020,3,31)), (date(2019,10,1), date(2019,12,31)) ],
-            [ ("next", "qtr", date(2020,3,31)), (date(2020,4,1), date(2020,6,30)) ],
+            [
+                ("this", "qtr", date(2020, 12, 31)),
+                (date(2020, 10, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("this", "qtr", date(2020, 10, 1)),
+                (date(2020, 10, 1), date(2020, 12, 31)),
+            ],
+            [("this", "qtr", date(2020, 9, 30)), (date(2020, 7, 1), date(2020, 9, 30))],
+            [("this", "qtr", date(2020, 6, 8)), (date(2020, 4, 1), date(2020, 6, 30))],
+            [("this", "qtr", date(2020, 6, 30)), (date(2020, 4, 1), date(2020, 6, 30))],
+            [("this", "qtr", date(2020, 5, 30)), (date(2020, 4, 1), date(2020, 6, 30))],
+            [("this", "qtr", date(2020, 4, 1)), (date(2020, 4, 1), date(2020, 6, 30))],
+            [("this", "qtr", date(2020, 3, 31)), (date(2020, 1, 1), date(2020, 3, 31))],
+            [("this", "qtr", date(2020, 1, 31)), (date(2020, 1, 1), date(2020, 3, 31))],
+            [("this", "qtr", date(2020, 1, 1)), (date(2020, 1, 1), date(2020, 3, 31))],
+            [("next", "qtr", date(2020, 1, 1)), (date(2020, 4, 1), date(2020, 6, 30))],
+            [
+                ("previous", "qtr", date(2020, 1, 1)),
+                (date(2019, 10, 1), date(2019, 12, 31)),
+            ],
+            [
+                ("prior", "qtr", date(2020, 3, 31)),
+                (date(2019, 10, 1), date(2019, 12, 31)),
+            ],
+            [("next", "qtr", date(2020, 3, 31)), (date(2020, 4, 1), date(2020, 6, 30))],
             # A leap day
-            [ ("next", "qtr", date(2020,2,29)), (date(2020,4,1), date(2020,6,30)) ],
-
+            [("next", "qtr", date(2020, 2, 29)), (date(2020, 4, 1), date(2020, 6, 30))],
             # month
-            [ ("this", "month", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
-            [ ("this", "month", date(2020,10,31)), (date(2020,10,1), date(2020,10,31)) ],
+            [
+                ("this", "month", date(2020, 12, 31)),
+                (date(2020, 12, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("this", "month", date(2020, 10, 31)),
+                (date(2020, 10, 1), date(2020, 10, 31)),
+            ],
             # Leap and non leap days
-            [ ("this", "month", date(2020,2,2)), (date(2020,2,1), date(2020,2,29)) ],
-            [ ("this", "month", date(2019,2,2)), (date(2019,2,1), date(2019,2,28)) ],
-            [ ("next", "month", date(2019,2,2)), (date(2019,3,1), date(2019,3,31)) ],
-            [ ("prior", "month", date(2019,2,2)), (date(2019,1,1), date(2019,1,31)) ],
-
+            [
+                ("this", "month", date(2020, 2, 2)),
+                (date(2020, 2, 1), date(2020, 2, 29)),
+            ],
+            [
+                ("this", "month", date(2019, 2, 2)),
+                (date(2019, 2, 1), date(2019, 2, 28)),
+            ],
+            [
+                ("next", "month", date(2019, 2, 2)),
+                (date(2019, 3, 1), date(2019, 3, 31)),
+            ],
+            [
+                ("prior", "month", date(2019, 2, 2)),
+                (date(2019, 1, 1), date(2019, 1, 31)),
+            ],
             # mtd
-            [ ("this", "mtd", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
-            [ ("current", "mtd", date(2020,12,31)), (date(2020,12,1), date(2020,12,31)) ],
-            [ ("prior", "mtd", date(2020,12,31)), (date(2020,11,1), date(2020,11,30)) ],
-            [ ("next", "mtd", date(2020,12,31)), (date(2021,1,1), date(2021,1,31)) ],
-            [ ("this", "mtd", date(2020,6,8)), (date(2020,6,1), date(2020,6,8)) ],
-            [ ("current", "mtd", date(2020,6,8)), (date(2020,6,1), date(2020,6,8)) ],
-            [ ("prior", "mtd", date(2020,6,8)), (date(2020,5,1), date(2020,5,8)) ],
-            [ ("next", "mtd", date(2020,6,8)), (date(2020,7,1), date(2020,7,8)) ],
-            [ ("this", "mtd", date(2020,1,1)), (date(2020,1,1), date(2020,1,1)) ],
+            [
+                ("this", "mtd", date(2020, 12, 31)),
+                (date(2020, 12, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("current", "mtd", date(2020, 12, 31)),
+                (date(2020, 12, 1), date(2020, 12, 31)),
+            ],
+            [
+                ("prior", "mtd", date(2020, 12, 31)),
+                (date(2020, 11, 1), date(2020, 11, 30)),
+            ],
+            [
+                ("next", "mtd", date(2020, 12, 31)),
+                (date(2021, 1, 1), date(2021, 1, 31)),
+            ],
+            [("this", "mtd", date(2020, 6, 8)), (date(2020, 6, 1), date(2020, 6, 8))],
+            [
+                ("current", "mtd", date(2020, 6, 8)),
+                (date(2020, 6, 1), date(2020, 6, 8)),
+            ],
+            [("prior", "mtd", date(2020, 6, 8)), (date(2020, 5, 1), date(2020, 5, 8))],
+            [("next", "mtd", date(2020, 6, 8)), (date(2020, 7, 1), date(2020, 7, 8))],
+            [("this", "mtd", date(2020, 1, 1)), (date(2020, 1, 1), date(2020, 1, 1))],
             # Long to short months
-            [ ("prior", "mtd", date(2020,3,30)), (date(2020,2,1), date(2020,2,29)) ],
+            [
+                ("prior", "mtd", date(2020, 3, 30)),
+                (date(2020, 2, 1), date(2020, 2, 29)),
+            ],
             # Short to long months count the number of days that have occurred
-            [ ("next", "mtd", date(2020,6,30)), (date(2020,7,1), date(2020,7,30)) ],
-
+            [("next", "mtd", date(2020, 6, 30)), (date(2020, 7, 1), date(2020, 7, 30))],
             # day
-            [ ("this", "day", date(2020,12,31)), (date(2020,12,31), date(2020,12,31)) ],
-            [ ("next", "day", date(2020,12,31)), (date(2021,1,1), date(2021,1,1)) ],
-            [ ("prior", "day", date(2020,12,31)), (date(2020,12,30), date(2020,12,30)) ],
-
+            [
+                ("this", "day", date(2020, 12, 31)),
+                (date(2020, 12, 31), date(2020, 12, 31)),
+            ],
+            [("next", "day", date(2020, 12, 31)), (date(2021, 1, 1), date(2021, 1, 1))],
+            [
+                ("prior", "day", date(2020, 12, 31)),
+                (date(2020, 12, 30), date(2020, 12, 30)),
+            ],
         ]
 
         for date_range_args, expected in data:
             actual = calc_date_range(*date_range_args)
             assert actual == expected
 
-
     def test_bad_inputs(self):
         with pytest.raises(ValueError):
-            calc_date_range("THIS", "day", date(2020,12,31))
+            calc_date_range("THIS", "day", date(2020, 12, 31))
 
         with pytest.raises(ValueError):
-            calc_date_range("flugelhorn", "day", date(2020,12,31))
+            calc_date_range("flugelhorn", "day", date(2020, 12, 31))
 
         with pytest.raises(ValueError):
-            calc_date_range("current", "domino", date(2020,12,31))
+            calc_date_range("current", "domino", date(2020, 12, 31))

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -188,7 +188,7 @@ expr
 """,
         ),
         (
-            'if(age is null,1,0)',
+            "if(age is null,1,0)",
             """
 expr
   case
@@ -203,7 +203,7 @@ expr
 """,
         ),
         (
-            'if(birth_date is prior year,1,0)',
+            "if(birth_date is prior year,1,0)",
             """
 expr
   case
@@ -220,7 +220,7 @@ expr
 """,
         ),
         (
-            'if(not(birth_date is prior year),1,0)',
+            "if(not(birth_date is prior year),1,0)",
             """
 expr
   case
@@ -239,7 +239,7 @@ expr
 """,
         ),
         (
-            'if(birth_date is THIS qtr or age > 12,1,0)',
+            "if(birth_date is THIS qtr or age > 12,1,0)",
             """
 expr
   case

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -195,7 +195,7 @@ expr
     relation_expr_using_is
       column\tage
       is
-      null\tnull
+      null
     expr
       number\t1
     expr
@@ -213,6 +213,25 @@ expr
       is_comparison
         prior
         year
+    expr
+      number\t1
+    expr
+      number\t0
+""",
+        ),
+        (
+            'if(not(birth_date is prior year),1,0)',
+            """
+expr
+  case
+    not_bool_factor
+      not
+      relation_expr_using_is
+        column\tbirth_date
+        is
+        is_comparison
+          prior
+          year
     expr
       number\t1
     expr

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -208,9 +208,11 @@ expr
 expr
   case
     relation_expr_using_is
-      column\tage
+      column\tbirth_date
       is
-      null\tnull
+      is_comparison
+        prior
+        year
     expr
       number\t1
     expr
@@ -220,5 +222,4 @@ expr
     ]
     for v, pretty_tree in values:
         tree = field_parser.parse(v)
-        print(tree.pretty())
         assert tree.pretty().strip() == pretty_tree.strip()

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -28,6 +28,7 @@ def test_parsers():
     (war_total + war_total) / war_total             # 1,1,0,0,0,0
     if(war_total BETWEEN 1 AND 5, 5)                # 1,1,0,0,0,0
     if(war_total BETWEEN 1 AND 5, 4, 2)             # 1,1,0,0,0,0
+    if(war_total is null, 4, 2)                     # 1,1,0,0,0,0    
     couNT(*)                                        # 1,0,0,0,0,0
     AVG(war_total) + 1.0                            # 1,0,0,0,0,0
     sum(war_total)                                  # 1,0,0,0,0,0
@@ -186,8 +187,22 @@ expr
       string_literal	"oldsters"
 """,
         ),
+        (
+            'if(age is null,1,0)',
+            """
+expr
+  case
+    relation_expr_using_is
+      column\tage
+      is
+      null
+    expr
+      number\t1
+    expr
+      number\t0
+""",
+        ),
     ]
     for v, pretty_tree in values:
         tree = field_parser.parse(v)
-        print(tree.pretty())
         assert tree.pretty().strip() == pretty_tree.strip()

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -195,7 +195,22 @@ expr
     relation_expr_using_is
       column\tage
       is
-      null
+      null\tnull
+    expr
+      number\t1
+    expr
+      number\t0
+""",
+        ),
+        (
+            'if(birth_date is prior year,1,0)',
+            """
+expr
+  case
+    relation_expr_using_is
+      column\tage
+      is
+      null\tnull
     expr
       number\t1
     expr
@@ -205,4 +220,5 @@ expr
     ]
     for v, pretty_tree in values:
         tree = field_parser.parse(v)
+        print(tree.pretty())
         assert tree.pretty().strip() == pretty_tree.strip()

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -238,6 +238,29 @@ expr
       number\t0
 """,
         ),
+        (
+            'if(birth_date is THIS qtr or age > 12,1,0)',
+            """
+expr
+  case
+    bool_expr
+      relation_expr_using_is
+        column\tbirth_date
+        is
+        is_comparison
+          THIS
+          qtr
+      or
+      relation_expr
+        column\tage
+        >
+        number\t12
+    expr
+      number\t1
+    expr
+      number\t0
+""",
+        ),
     ]
     for v, pretty_tree in values:
         tree = field_parser.parse(v)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,7 +23,6 @@ oven.engine.execute(
 )
 
 
-
 # Test dynamic date filtering
 TABLEDEF = """
         CREATE TABLE IF NOT EXISTS datetester
@@ -36,9 +35,7 @@ start_dt = date(date.today().year, date.today().month, 1)
 # Add dates for the 50 months around the current date
 for offset_month in range(-50, 50):
     dt = start_dt + relativedelta(months=offset_month)
-    oven.engine.execute(
-        "insert into datetester values ('{}', 1)".format(dt)
-    )
+    oven.engine.execute("insert into datetester values ('{}', 1)".format(dt))
 
 
 # Create a table for testing summarization
@@ -338,6 +335,7 @@ class ScoresWithNulls(Base):
 
     __tablename__ = "scores_with_nulls"
     __table_args__ = {"extend_existing": True}
+
 
 class TagScores(Base):
     username = Column("username", String(), primary_key=True)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,8 @@ from sqlalchemy import Column, Date, DateTime, Float, Integer, String, distinct,
 from sqlalchemy.ext.declarative import declarative_base
 
 from recipe import Dimension, Metric, Shelf, get_oven
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 oven = get_oven("sqlite://")
 Base = declarative_base(bind=oven.engine)
@@ -19,6 +21,25 @@ oven.engine.execute(TABLEDEF)
 oven.engine.execute(
     "insert into foo values ('hi', 'there', 5, '2005-01-01', '2005-01-01 12:15:00'), ('hi', 'fred', 10, '2015-05-15', '2013-10-15 05:20:10')"
 )
+
+
+
+# Test dynamic date filtering
+TABLEDEF = """
+        CREATE TABLE IF NOT EXISTS datetester
+        (dt date,
+         count integer);
+"""
+
+oven.engine.execute(TABLEDEF)
+start_dt = date(date.today().year, date.today().month, 1)
+# Add dates for the 50 months around the current date
+for offset_month in range(-50, 50):
+    dt = start_dt + relativedelta(months=offset_month)
+    oven.engine.execute(
+        "insert into datetester values ('{}', 1)".format(dt)
+    )
+
 
 # Create a table for testing summarization
 TABLEDEF = """
@@ -318,7 +339,6 @@ class ScoresWithNulls(Base):
     __tablename__ = "scores_with_nulls"
     __table_args__ = {"extend_existing": True}
 
-
 class TagScores(Base):
     username = Column("username", String(), primary_key=True)
     department = Column("department", String())
@@ -338,6 +358,13 @@ class Census(Base):
     pop2008 = Column("pop2008", Integer())
 
     __tablename__ = "census"
+    __table_args__ = {"extend_existing": True}
+
+
+class DateTester(Base):
+    dt = Column("dt", Date(), primary_key=True)
+    count = Column("count", Integer())
+    __tablename__ = "datetester"
     __table_args__ = {"extend_existing": True}
 
 

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -1388,7 +1388,11 @@ count_star:
 """,
             ScoresWithNulls,
         )
-        recipe = Recipe(shelf=shelf, session=self.session).dimensions("username").metrics("count_star")        
+        recipe = (
+            Recipe(shelf=shelf, session=self.session)
+            .dimensions("username")
+            .metrics("count_star")
+        )
         assert (
             recipe.to_sql()
             == """SELECT scores_with_nulls.username AS username,
@@ -1396,14 +1400,18 @@ count_star:
 FROM scores_with_nulls
 GROUP BY username"""
         )
-        self.assert_recipe_csv(recipe, """username,count_star,username_id
+        self.assert_recipe_csv(
+            recipe,
+            """username,count_star,username_id
 annika,2,annika
 chip,3,chip
 chris,1,chris
-""")
+""",
+        )
 
         # Build a recipe using the first recipe
-        shelf2 = self.create_shelf("""
+        shelf2 = self.create_shelf(
+            """
 _version: 2
 count_star:
     kind: Metric
@@ -1411,16 +1419,23 @@ count_star:
 max_username:
     kind: Metric
     field: "max(username)"        
-""", recipe)
-        recipe2 = Recipe(shelf=shelf2, session=self.session).metrics("count_star", "max_username")
+""",
+            recipe,
+        )
+        recipe2 = Recipe(shelf=shelf2, session=self.session).metrics(
+            "count_star", "max_username"
+        )
         print("two")
-        assert recipe2.to_sql() == """SELECT count(*) AS count_star,
+        assert (
+            recipe2.to_sql()
+            == """SELECT count(*) AS count_star,
        max(anon_1.username) AS max_username
 FROM
   (SELECT scores_with_nulls.username AS username,
           count(*) AS count_star
    FROM scores_with_nulls
    GROUP BY username) AS anon_1"""
+        )
         self.assert_recipe_csv(recipe2, "count_star,max_username\n3,chris\n")
 
 

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -1146,3 +1146,26 @@ OFFSET 0"""
 11168,Tennessee,77.0,11168
 """,
         )
+
+    def test_is(self):
+        """Test fields using is"""
+        shelf = self.validated_shelf("ingredients1.yaml", MyTable)
+        recipe = (
+            Recipe(shelf=shelf, session=self.session).metrics("dt_test").dimensions("first")
+        )
+        assert recipe.to_sql() == """SELECT foo.first AS first,
+       sum(CASE
+               WHEN (foo.birth_date IS NULL) THEN foo.age
+               ELSE 1
+           END) AS dt_test
+FROM foo
+GROUP BY first"""
+        self.assert_recipe_csv(
+            recipe,
+            """first,dt_test,first_id
+hi,2,hi
+""",
+        )
+        
+
+


### PR DESCRIPTION
This PR improves SQL generation, adds tests, and adds intelligent date ranges.

* Refactors grammar definition to remove duplicate definitions.
* Fixes sql generation for AND and OR
* Fixes sql generation for division when one of the terms is a constant (like `sum(people) / 100.0`)
* Adds IS NULL as a boolean expression
* Adds "Intelligent date" calculations to allow more useful date calculations.

### Intelligent dates

The existing syntax supports human-language relative date expressions like `date BETWEEN "1 year ago" and "today"` where these strings are evaluated using dateparser. However, doesn't allow a user to define many commonly needed date expressions. For instance, if you'd like to filter from the start of the current year to today it is not possible with these expressions. You can write `date BETWEEN "1/1/2020" and "today"` but this doesn't support year boundaries.

Intelligent dates are expressions that look like this

    date IS {OFFSET} {PERIOD}

Offsets define whether we want to look at the current period or a prior or next period. The period will define a starting and ending date.

Allowed **offsets** are PRIOR, PREVIOUS, LAST, CURRENT, THIS, and NEXT. PRIOR, PREVIOUS and LAST are all synonyms for looking at the period prior to the current one. CURRENT or THIS look at the period around the current date and NEXT looks at the next period.

**Periods** are YEAR, YTD, QTR, MONTH, MTD, and DAY. Both offsets and periods are recognized case insensitively.

Let's look at some examples assuming the date is **June 15, 2020**.

```
date IS CURRENT YTD
-> same as date BETWEEN "2020-01-01" AND "2020-06-15"

date is PRIOR YTD
-> same as date BETWEEN "2019-01-01" AND "2019-06-15"

date IS THIS MONTH
-> same as date BETWEEN "2020-06-01" AND "2020-06-30"

date is Next Month
-> same as date BETWEEN "2020-07-01" AND "2020-07-31"

date is current qtr
-> same as date BETWEEN "2020-04-01" AND "2020-06-30"
```



