### PR TITLE
When building filters, cast to string if necessary

### DIFF
--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from sqlalchemy import Float, String, and_, between, case, cast, func, or_, text
 
+from six import string_types
 from recipe.compat import str
 from recipe.exceptions import BadIngredient
 from recipe.utils import AttrDict
@@ -237,7 +238,7 @@ class Ingredient(object):
         filter_column = self.columns[0]
 
         # If we pass a string value, convert the column to string for comparison
-        if isinstance(value, str) and not isinstance(filter_column.type, String):
+        if isinstance(value, string_types) and not isinstance(filter_column.type, String):
             filter_column = cast(filter_column, String)
 
         if operator is None or operator == "eq":
@@ -262,11 +263,11 @@ class Ingredient(object):
         elif operator == "isnot":
             return Filter(filter_column.isnot(value))
         elif operator == "like":
-            if not isinstance(value, str):
+            if not isinstance(value, string_types):
                 raise ValueError("Building a filter with like must use a str value")
             return Filter(filter_column.like(value))
         elif operator == "ilike":
-            if not isinstance(value, str):
+            if not isinstance(value, string_types):
                 raise ValueError("Building a filter with ilike must use a str value")
             return Filter(filter_column.ilike(value))
         elif operator == "quickselect":

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -235,7 +235,7 @@ class Ingredient(object):
             A Filter object
         """
         filter_column = self.columns[0]
-        
+
         # If we pass a string value, convert the column to string for comparison
         if isinstance(value, str) and not isinstance(filter_column.type, String):
             filter_column = cast(filter_column, String)

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -238,7 +238,9 @@ class Ingredient(object):
         filter_column = self.columns[0]
 
         # If we pass a string value, convert the column to string for comparison
-        if isinstance(value, string_types) and not isinstance(filter_column.type, String):
+        if isinstance(value, string_types) and not isinstance(
+            filter_column.type, String
+        ):
             filter_column = cast(filter_column, String)
 
         if operator is None or operator == "eq":

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -1,7 +1,7 @@
 from functools import total_ordering
 from uuid import uuid4
 
-from sqlalchemy import Float, and_, between, case, cast, func, or_, text
+from sqlalchemy import Float, String, and_, between, case, cast, func, or_, text
 
 from recipe.compat import str
 from recipe.exceptions import BadIngredient
@@ -235,6 +235,10 @@ class Ingredient(object):
             A Filter object
         """
         filter_column = self.columns[0]
+        
+        # If we pass a string value, convert the column to string for comparison
+        if isinstance(value, str) and not isinstance(filter_column.type, String):
+            filter_column = cast(filter_column, String)
 
         if operator is None or operator == "eq":
             # Default operator is 'eq' so if no operator is provided, handle
@@ -258,8 +262,12 @@ class Ingredient(object):
         elif operator == "isnot":
             return Filter(filter_column.isnot(value))
         elif operator == "like":
+            if not isinstance(value, str):
+                raise ValueError("Building a filter with like must use a str value")
             return Filter(filter_column.like(value))
         elif operator == "ilike":
+            if not isinstance(value, str):
+                raise ValueError("Building a filter with ilike must use a str value")
             return Filter(filter_column.ilike(value))
         elif operator == "quickselect":
             for qs in self.quickselects:

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -204,7 +204,10 @@ class TestIngredientBuildFilter(object):
         filt = d.build_filter("moo", "like")
         assert str(filt.filters[0]) == "CAST(foo.age AS VARCHAR) LIKE :param_1"
         filt = d.build_filter("moo", "ilike")
-        assert str(filt.filters[0]) == "lower(CAST(foo.age AS VARCHAR)) LIKE lower(:param_1)"
+        assert (
+            str(filt.filters[0])
+            == "lower(CAST(foo.age AS VARCHAR)) LIKE lower(:param_1)"
+        )
         # None values get converted to IS
         filt = d.build_filter(None, "eq")
         assert str(filt.filters[0]) == "foo.age IS NULL"

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -308,12 +308,12 @@ class TestIngredientBuildFilter(object):
         assert str(filt.filters[0]) == "foo.first BETWEEN :first_1 AND :first_2"
 
         with pytest.raises(ValueError):
-            filt = d.build_filter("moo", "in")
+            d.build_filter("moo", "in")
         # Between must have 2 values
         with pytest.raises(ValueError):
-            filt = d.build_filter(["moo", "foo", "tru"], operator="between")
+            d.build_filter(["moo", "foo", "tru"], operator="between")
         with pytest.raises(ValueError):
-            filt = d.build_filter(["moo"], operator="between")
+            d.build_filter(["moo"], operator="between")
 
     def test_quickselects(self):
         d = Dimension(


### PR DESCRIPTION
This PR fixes an instance where a dimension is filtered using a string. For instance; the Paginate extension allows a query parameter which will search using `ilike` on dimensions in the recipe. If a dimension is defined with a non-string field this will cause a sql error.

This PR checks the column data type and if it not a String, casts it to string in SQL before performing the ilike.

This PR also checks the value when building a filter using like or ilike operators to ensure that the value is a string. If the value is not a string a ValueError will be raised.