### PR TITLE
Make shelf construction more robust

### DIFF
--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -23,6 +23,7 @@ from recipe.ingredients import (
     Having,
     IdValueDimension,
     Ingredient,
+    InvalidIngredient,
     LookupDimension,
     Metric,
     WtdAvgMetric,

--- a/recipe/schemas/config_constructors.py
+++ b/recipe/schemas/config_constructors.py
@@ -189,10 +189,5 @@ def create_ingredient_from_config(ingr_dict, selectable):
     try:
         return IngredientClass(*args, **ingr_dict)
     except BadIngredient as e:
-        error = {
-            "type": "bad_ingredient",
-            "extra": {
-                "details": str(e),
-            }
-        }
+        error = {"type": "bad_ingredient", "extra": {"details": str(e),}}
         return InvalidIngredient(error=error)

--- a/recipe/schemas/config_constructors.py
+++ b/recipe/schemas/config_constructors.py
@@ -13,6 +13,7 @@ from .utils import (
     find_column,
     ingredient_class_for_name,
 )
+from recipe.ingredients import InvalidIngredient
 
 
 # constant used for ensuring safe division
@@ -185,4 +186,13 @@ def create_ingredient_from_config(ingr_dict, selectable):
             extra.get("field"), selectable
         )
 
-    return IngredientClass(*args, **ingr_dict)
+    try:
+        return IngredientClass(*args, **ingr_dict)
+    except BadIngredient as e:
+        error = {
+            "type": "bad_ingredient",
+            "extra": {
+                "details": str(e),
+            }
+        }
+        return InvalidIngredient(error=error)

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -239,10 +239,5 @@ def create_ingredient_from_parsed(ingr_dict, selectable):
     try:
         return IngredientClass(*args, **ingr_dict)
     except BadIngredient as e:
-        error = {
-            "type": "bad_ingredient",
-            "extra": {
-                "details": str(e),
-            }
-        }
+        error = {"type": "bad_ingredient", "extra": {"details": str(e),}}
         return InvalidIngredient(error=error)

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -18,6 +18,7 @@ from .utils import (
     calc_date_range,
 )
 from recipe.exceptions import BadIngredient
+from recipe.ingredients import InvalidIngredient
 
 
 @v_args(inline=True)  # Affects the signatures of the methods
@@ -235,4 +236,13 @@ def create_ingredient_from_parsed(ingr_dict, selectable):
             )
         ]
 
-    return IngredientClass(*args, **ingr_dict)
+    try:
+        return IngredientClass(*args, **ingr_dict)
+    except BadIngredient as e:
+        error = {
+            "type": "bad_ingredient",
+            "extra": {
+                "details": str(e),
+            }
+        }
+        return InvalidIngredient(error=error)

--- a/tests/parsed_ingredients/census.yaml
+++ b/tests/parsed_ingredients/census.yaml
@@ -14,6 +14,11 @@ pop2000:
 pop2008:
     kind: Measure
     field: pop2008
+baddim:
+    kind: Dimension
+    field: sex
+    # raw_field is a reserved key
+    raw_field: age
 age_buckets:
     kind: Dimension
     field: age

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -14,6 +14,7 @@ from tests.test_base import Census, MyTable, oven, ScoresWithNulls, DateTester
 from recipe import (
     AutomaticFilters,
     BadIngredient,
+    InvalidIngredient,
     Recipe,
     Shelf,
     BadRecipe,
@@ -1134,6 +1135,19 @@ Tennessee,0.38567639950103244,The Volunteer State,Tennessee
 Vermont,0.4374284968466102,The Green Mountain State,Vermont
 """,
         )
+
+    def test_shelf_with_invalidingredient(self):
+        """Build a recipe using a shelf that uses field references """
+        shelf = self.validated_shelf("census.yaml", Census)
+        assert isinstance(shelf["baddim"], InvalidIngredient)
+        recipe = (
+            Recipe(shelf=shelf, session=self.session)
+            .dimensions("baddim")
+            .metrics("pop2000")
+        )
+        # Trying to run the recipe raises an exception with the bad ingredient details
+        with pytest.raises(BadIngredient):
+            recipe.to_sql()
 
     def test_complex_census_from_validated_yaml_math(self):
         """Build a recipe that uses complex definitions dimensions and

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -611,6 +611,7 @@ invalid:
             == "raw is a reserved role in dimensions"
         )
 
+
 class TestShelfFromConfig(TestShelfFromValidatedYaml):
     def make_shelf(self, content, table=MyTable):
         obj = safe_load(content)

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -591,6 +591,23 @@ invalid_in_referred:
             self.shelf["invalid_in_referred"].error["extra"]["column_name"] == "invalid"
         )
 
+    def test_invalid_definition(self):
+        content = """
+oldage:
+    kind: Metric
+    field:
+        value: age
+invalid:
+    kind: Dimension
+    field: age
+    lookup: moo
+"""
+        self.make_shelf(content)
+        assert isinstance(self.shelf["oldage"], Metric)
+        assert isinstance(self.shelf["invalid"], InvalidIngredient)
+        print(self.shelf["invalid"].error)
+        assert self.shelf["invalid"].error["extra"]["details"] == "lookup must be a dictionary"
+
 
 class TestShelfFromConfig(TestShelfFromValidatedYaml):
     def make_shelf(self, content, table=MyTable):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -606,7 +606,10 @@ invalid:
         assert isinstance(self.shelf["oldage"], Metric)
         assert isinstance(self.shelf["invalid"], InvalidIngredient)
         print(self.shelf["invalid"].error)
-        assert self.shelf["invalid"].error["extra"]["details"] == "lookup must be a dictionary"
+        assert (
+            self.shelf["invalid"].error["extra"]["details"]
+            == "lookup must be a dictionary"
+        )
 
 
 class TestShelfFromConfig(TestShelfFromValidatedYaml):

--- a/tests/test_shelf.py
+++ b/tests/test_shelf.py
@@ -600,17 +600,16 @@ oldage:
 invalid:
     kind: Dimension
     field: age
-    lookup: moo
+    # raw_field is a reserved name and can't be assigned in config.
+    raw_field: first
 """
         self.make_shelf(content)
         assert isinstance(self.shelf["oldage"], Metric)
         assert isinstance(self.shelf["invalid"], InvalidIngredient)
-        print(self.shelf["invalid"].error)
         assert (
             self.shelf["invalid"].error["extra"]["details"]
-            == "lookup must be a dictionary"
+            == "raw is a reserved role in dimensions"
         )
-
 
 class TestShelfFromConfig(TestShelfFromValidatedYaml):
     def make_shelf(self, content, table=MyTable):


### PR DESCRIPTION
When ingredient constructor fails returning BadIngredient create an InvalidIngredient with an appropriate error. This ensures the Shelf can be created.

This issue arose because a developer created a dimension with lookup containing a string rather than a dict. We could extend sureberus schemas as well.