### PR TITLE
Set default bucket_default_label to "Not found"

### DIFF
--- a/recipe/schemas/config_schemas.py
+++ b/recipe/schemas/config_schemas.py
@@ -296,7 +296,7 @@ def _move_buckets_to_field(value):
     """ Move buckets from a dimension into the field """
     # return value
     buckets = value.pop("buckets", None)
-    buckets_default_label = value.pop("buckets_default_label", None)
+    buckets_default_label = value.pop("buckets_default_label", "Not found")
     if buckets:
         if "field" in value:
             value["field"]["buckets"] = buckets

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -107,6 +107,8 @@ def _convert_bucket_to_field(bucket, bucket_default_label, use_indices=False):
         idx += 1
 
     # Add the default value
+    if bucket_default_label is None:
+        bucket_default_label = "Not found"
     if use_indices:
         parts.append(str(9999))
     else:

--- a/tests/ingredients/census.yaml
+++ b/tests/ingredients/census.yaml
@@ -24,6 +24,16 @@ age_buckets:
     - label: 'teens'
       lt: 20
     buckets_default_label: 'oldsters'
+age_buckets_nolabel:
+    kind: Dimension
+    field: age
+    buckets:
+    - label: 'babies'
+      lt: 2
+    - label: 'children'
+      lt: 13
+    - label: 'teens'
+      lt: 20
 mixed_buckets:
     kind: Dimension
     field: age

--- a/tests/parsed_ingredients/census.yaml
+++ b/tests/parsed_ingredients/census.yaml
@@ -25,6 +25,16 @@ age_buckets:
     - label: 'teens'
       condition: '<20'
     buckets_default_label: 'oldsters'
+age_buckets_nolabel:
+    kind: Dimension
+    field: age
+    buckets:
+    - label: 'babies'
+      condition: '<2'
+    - label: 'children'
+      condition: '<13'
+    - label: 'teens'
+      condition: '<20'
 mixed_buckets:
     kind: Dimension
     field: age

--- a/tests/schemas/test_config_schemas.py
+++ b/tests/schemas/test_config_schemas.py
@@ -194,6 +194,7 @@ def test_field_buckets_ref():
                         "lt": 200,
                     }
                 ],
+                "buckets_default_label": "Not found",
                 "value": "moo",
             },
             "kind": "dimension",
@@ -390,7 +391,6 @@ def test_dimension_buckets():
     }
 
     x = normalize_schema(shelf_schema, v, allow_unknown=False)
-
     # The dimension field gets inserted into the buckets
     assert x == {
         "a": {
@@ -405,6 +405,7 @@ def test_dimension_buckets():
                         "label": "over20",
                     }
                 ],
+                "buckets_default_label": "Not found",
                 "value": "foo",
             },
             "icon": "squee",

--- a/tests/schemas/test_parsed_schemas.py
+++ b/tests/schemas/test_parsed_schemas.py
@@ -150,7 +150,7 @@ test:
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert (
         result["test"]["field"]
-        == 'if((moo)>2,"foo",state in (1,2),"cow",(moo)in (3,4),"horse",NULL)'
+        == 'if((moo)>2,"foo",state in (1,2),"cow",(moo)in (3,4),"horse","Not found")'
     )
     assert (
         result["test"]["extra_fields"][0]["field"]
@@ -174,7 +174,7 @@ test:
     result = normalize_schema(shelf_schema, v, allow_unknown=False)
     assert (
         result["test"]["field"]
-        == 'if((moo)<2,"undertwo",(moo)>"2","foo",state in ("1", "2"),"cow",NULL)'
+        == 'if((moo)<2,"undertwo",(moo)>"2","foo",state in ("1", "2"),"cow","Not found")'
     )
     assert (
         result["test"]["extra_fields"][0]["field"]


### PR DESCRIPTION
Having bucket_default_label = None causes problems for projects using this library and also results in the output of this dimension being mixed types (some strings and some None).