### PR TITLE
Fix for relation_expr_using_is

### DIFF
--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -141,7 +141,7 @@ class TransformToSQLAlchemyExpression(Transformer):
         """A relation expression like age is null or
         birth_date is last month"""
         # TODO: Why is this not handled by the tokenization
-        if str(right).upper() == "NULL":
+        if str(right).upper() == "NULL" or right is None:
             return left.is_(None)
         else:
             return left.between(*right)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ SQLAlchemy>=1.2.2
 sqlparse==0.3.0
 stevedore==1.31.0
 tablib==0.12.1
-pyyaml==5.1.2
+pyyaml>=5
 sureberus==0.14.0
 dateparser==0.7.2
 attrs==19.3.0


### PR DESCRIPTION
A fix for parsing of expressions like `if(age IS NULL, 1, 0)`