### PR TITLE
RECIPE-116 Fix pagination search to use value role

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [2.7, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -481,6 +481,7 @@ class Paginate(RecipeExtension):
     The default search fields are all dimensions used in the recipe.
     Search keys can be customized with `pagination_search_keys`.
     Search may be disabled by setting `.apply_pagination_filters(False)`
+    The value role will be targetted when searching dimensions.
 
     **Sorting**
 
@@ -691,7 +692,13 @@ class Paginate(RecipeExtension):
                 # build a filter for each search key and use in the recipe
                 ingredient = self.recipe._shelf.get(key, None)
                 if ingredient:
-                    filters.append(ingredient.build_filter(q, operator="ilike"))
+                    filters.append(
+                        ingredient.build_filter(
+                            q, 
+                            operator="ilike", 
+                            target_role="value"
+                        )
+                    )
 
             # Build a big or filter for the search
             if filters:

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -221,7 +221,7 @@ class Ingredient(object):
         """
         return not (self._order() == other._order())
 
-    def _build_scalar_filter(self, value, operator=None):
+    def _build_scalar_filter(self, value, operator=None, target_role=None):
         """Build a Filter given a single value.
 
         Args:
@@ -230,12 +230,17 @@ class Ingredient(object):
             operator (`str`)
                 A valid scalar operator. The default operator
                 is `eq`
+            target_role (`str`) 
+                An optional role to build the filter against
 
         Returns:
 
             A Filter object
         """
-        filter_column = self.columns[0]
+        if target_role and target_role in self.roles:
+            filter_column = self.roles.get(target_role)
+        else:
+            filter_column = self.columns[0]
 
         # If we pass a string value, convert the column to string for comparison
         if isinstance(value, string_types) and not isinstance(
@@ -283,7 +288,7 @@ class Ingredient(object):
         else:
             raise ValueError("Unknown operator {}".format(operator))
 
-    def _build_vector_filter(self, value, operator=None):
+    def _build_vector_filter(self, value, operator=None, target_role=None):
         """Build a Filter given a list of values.
 
         Args:
@@ -292,12 +297,17 @@ class Ingredient(object):
             operator (:obj:`str`)
                 A valid vector operator. The default operator is
                 `in`.
+            target_role (`str`) 
+                An optional role to build the filter against
 
         Returns:
 
             A Filter object
         """
-        filter_column = self.columns[0]
+        if target_role and target_role in self.roles:
+            filter_column = self.roles.get(target_role)
+        else:
+            filter_column = self.columns[0]
 
         if operator is None or operator == "in":
             # Default operator is 'in' so if no operator is provided, handle
@@ -358,7 +368,7 @@ class Ingredient(object):
         else:
             raise ValueError("Unknown operator {}".format(operator))
 
-    def build_filter(self, value, operator=None):
+    def build_filter(self, value, operator=None, target_role=None):
         """
         Builds a filter based on a supplied value and optional operator. If
         no operator is supplied an ``in`` filter will be used for a list and a
@@ -376,6 +386,8 @@ class Ingredient(object):
 
                 The default operator is 'in' if value is a list and
                 'eq' if value is a string, number, boolean or None.
+            target_role (`str`) 
+                An optional role to build the filter against
 
         Returns:
 
@@ -385,9 +397,9 @@ class Ingredient(object):
         value_is_scalar = not isinstance(value, (list, tuple))
 
         if value_is_scalar:
-            return self._build_scalar_filter(value, operator=operator)
+            return self._build_scalar_filter(value, operator=operator, target_role=target_role)
         else:
-            return self._build_vector_filter(value, operator=operator)
+            return self._build_vector_filter(value, operator=operator, target_role=target_role)
 
     @property
     def expression(self):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Date, DateTime, Float, Integer, String, distinct, func
 from sqlalchemy.ext.declarative import declarative_base
 
-from recipe import Dimension, Metric, Filter, Shelf, get_oven
+from recipe import IdValueDimension, Dimension, Metric, Filter, Shelf, get_oven
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
@@ -435,6 +435,7 @@ tagscores_shelf = Shelf(
 census_shelf = Shelf(
     {
         "state": Dimension(Census.state),
+        "idvalue_state": IdValueDimension(Census.state, "State:"+Census.state),
         "sex": Dimension(Census.sex),
         "age": Dimension(Census.age),
         "pop2000": Metric(func.sum(Census.pop2000)),

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1204,38 +1204,39 @@ OFFSET 0""",
         assert sales_row.department == "sales"
         assert sales_row.score == 80.0
 
-        def test_summarize_over_scores_order(self):
-            """ Order bys are hoisted to the outer query """
-            self.shelf = scores_shelf
+    def test_summarize_over_scores_order(self):
+        """ Order bys are hoisted to the outer query """
+        self.shelf = scores_shelf
 
-            recipe = (
-                self.recipe()
-                .metrics("score")
-                .dimensions("department", "username")
-                .summarize_over("username")
-                .order_by("department")
-            )
+        recipe = (
+            self.recipe()
+            .metrics("score")
+            .dimensions("department", "username")
+            .summarize_over("username")
+            .order_by("department")
+        )
 
-            assert (
-                recipe.to_sql()
-                == """SELECT summarize.department,
-           avg(summarize.score) AS score
-    FROM
-      (SELECT scores.department AS department,
-              scores.username AS username,
-              avg(scores.score) AS score
-       FROM scores
-       GROUP BY scores.department,
-                scores.username
-       ORDER BY scores.department) AS summarize
-    GROUP BY summarize.department
-    ORDER BY summarize.department"""
-            )
-            ops_row, sales_row = recipe.all()
-            assert ops_row.department == "ops"
-            assert ops_row.score == 87.5
-            assert sales_row.department == "sales"
-            assert sales_row.score == 80.0
+        print(recipe.to_sql())
+        assert (
+            recipe.to_sql()
+            == """SELECT summarize.department,
+       avg(summarize.score) AS score
+FROM
+  (SELECT scores.department AS department,
+          scores.username AS username,
+          avg(scores.score) AS score
+   FROM scores
+   GROUP BY department,
+            username
+   ORDER BY department) AS summarize
+GROUP BY summarize.department
+ORDER BY summarize.department"""
+        )
+        ops_row, sales_row = recipe.all()
+        assert ops_row.department == "ops"
+        assert ops_row.score == 87.5
+        assert sales_row.department == "sales"
+        assert sales_row.score == 80.0
 
     def test_summarize_over_scores_order_anonymize(self):
         """ Order bys are hoisted to the outer query """


### PR DESCRIPTION
Pagination searches are not working correctly on IdValueDimension. This is because they are building search filters against the first column defined in columns (which is the id role).

This PR allows Ingredient.build_filters to target a role by supplying `target_role`. If that role is found, the filters are built against that database column.

The Paginate mixin is updated to target the "value" role when applying a pagination_q. 

Tests and documentation added. The paginate_q test was broken due to bad indentation. One other test was found to be badly indented. This is fixed. 