### PR TITLE
Fix types

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -400,7 +400,8 @@ class Ingredient(object):
                 non_none_value = sorted([v for v in value if v is not None])
                 if non_none_value:
                     return and_(
-                        filter_column.isnot(None), filter_column.notin_(non_none_value),
+                        filter_column.isnot(None),
+                        filter_column.notin_(non_none_value),
                     )
                 else:
                     return filter_column.isnot(None)

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -140,34 +140,34 @@ class TestIngredientBuildFilter(object):
 
         # Test building scalar filters
         filt = d.build_filter("moo")
-        assert str(filt) == "foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.first = 'moo'"
         filt = d.build_filter("moo", "eq")
-        assert str(filt) == "foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.first = 'moo'"
         filt = d.build_filter("moo", "ne")
-        assert str(filt) == "foo.first != :first_1"
+        assert filter_to_string(filt) == "foo.first != 'moo'"
         filt = d.build_filter("moo", "lt")
-        assert str(filt) == "foo.first < :first_1"
+        assert filter_to_string(filt) == "foo.first < 'moo'"
         filt = d.build_filter("moo", "lte")
-        assert str(filt) == "foo.first <= :first_1"
+        assert filter_to_string(filt) == "foo.first <= 'moo'"
         filt = d.build_filter("moo", "gt")
-        assert str(filt) == "foo.first > :first_1"
+        assert filter_to_string(filt) == "foo.first > 'moo'"
         filt = d.build_filter("moo", "gte")
-        assert str(filt) == "foo.first >= :first_1"
+        assert filter_to_string(filt) == "foo.first >= 'moo'"
         filt = d.build_filter("moo", "is")
-        assert str(filt) == "foo.first IS :first_1"
+        assert filter_to_string(filt) == "foo.first IS 'moo'"
         filt = d.build_filter("moo", "isnot")
-        assert str(filt) == "foo.first IS NOT :first_1"
+        assert filter_to_string(filt) == "foo.first IS NOT 'moo'"
         filt = d.build_filter("moo", "like")
-        assert str(filt) == "foo.first LIKE :first_1"
+        assert filter_to_string(filt) == "foo.first LIKE 'moo'"
         filt = d.build_filter("moo", "ilike")
-        assert str(filt) == "lower(foo.first) LIKE lower(:first_1)"
+        assert filter_to_string(filt) == "lower(foo.first) LIKE lower('moo')"
         # None values get converted to IS
         filt = d.build_filter(None, "eq")
-        assert str(filt) == "foo.first IS NULL"
+        assert filter_to_string(filt) == "foo.first IS NULL"
 
         # str filter values are acceptable
         filt = d.build_filter(u"Τη γλώσ")
-        assert str(filt) == "foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.first = 'Τη γλώσ'"
 
         # operator must agree with value
         with pytest.raises(ValueError):
@@ -185,34 +185,34 @@ class TestIngredientBuildFilter(object):
 
         # Test building scalar filters
         filt = d.build_filter("moo")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) = :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) = 'moo'"
         filt = d.build_filter("moo", "eq")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) = :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) = 'moo'"
         filt = d.build_filter("moo", "ne")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) != :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) != 'moo'"
         filt = d.build_filter("moo", "lt")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) < :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) < 'moo'"
         filt = d.build_filter("moo", "lte")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) <= :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) <= 'moo'"
         filt = d.build_filter("moo", "gt")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) > :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) > 'moo'"
         filt = d.build_filter("moo", "gte")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) >= :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) >= 'moo'"
         filt = d.build_filter("moo", "is")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) IS :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) IS 'moo'"
         filt = d.build_filter("moo", "isnot")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) IS NOT :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) IS NOT 'moo'"
         filt = d.build_filter("moo", "like")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) LIKE :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) LIKE 'moo'"
         filt = d.build_filter("moo", "ilike")
-        assert str(filt) == "lower(CAST(foo.age AS VARCHAR)) LIKE lower(:param_1)"
+        assert filter_to_string(filt) == "lower(CAST(foo.age AS VARCHAR)) LIKE lower('moo')"
         # None values get converted to IS
         filt = d.build_filter(None, "eq")
-        assert str(filt) == "foo.age IS NULL"
+        assert filter_to_string(filt) == "foo.age IS NULL"
 
         # str filter values are acceptable
         filt = d.build_filter(u"Τη γλώσ")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) = :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) = 'Τη γλώσ'"
 
         # operator must agree with value
         with pytest.raises(ValueError):
@@ -230,30 +230,30 @@ class TestIngredientBuildFilter(object):
 
         # Test building scalar filters
         filt = d.build_filter(5)
-        assert str(filt) == "foo.age = :age_1"
+        assert filter_to_string(filt) == "foo.age = 5"
         filt = d.build_filter(5, "eq")
-        assert str(filt) == "foo.age = :age_1"
+        assert filter_to_string(filt) == "foo.age = 5"
         filt = d.build_filter(5, "ne")
-        assert str(filt) == "foo.age != :age_1"
+        assert filter_to_string(filt) == "foo.age != 5"
         filt = d.build_filter(5, "lt")
-        assert str(filt) == "foo.age < :age_1"
+        assert filter_to_string(filt) == "foo.age < 5"
         filt = d.build_filter(5, "lte")
-        assert str(filt) == "foo.age <= :age_1"
+        assert filter_to_string(filt) == "foo.age <= 5"
         filt = d.build_filter(5, "gt")
-        assert str(filt) == "foo.age > :age_1"
+        assert filter_to_string(filt) == "foo.age > 5"
         filt = d.build_filter(5, "gte")
-        assert str(filt) == "foo.age >= :age_1"
+        assert filter_to_string(filt) == "foo.age >= 5"
         filt = d.build_filter(5, "is")
-        assert str(filt) == "foo.age IS :age_1"
+        assert filter_to_string(filt) == "foo.age IS 5"
         filt = d.build_filter(5, "isnot")
-        assert str(filt) == "foo.age IS NOT :age_1"
+        assert filter_to_string(filt) == "foo.age IS NOT 5"
         # None values get converted to IS
         filt = d.build_filter(None, "eq")
-        assert str(filt) == "foo.age IS NULL"
+        assert filter_to_string(filt) == "foo.age IS NULL"
 
         # str filter values are acceptable
         filt = d.build_filter(u"Τη γλώσ")
-        assert str(filt) == "CAST(foo.age AS VARCHAR) = :param_1"
+        assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) = 'Τη γλώσ'"
 
         # operator must agree with value
         with pytest.raises(ValueError):
@@ -276,28 +276,29 @@ class TestIngredientBuildFilter(object):
 
         # Test building scalar filters
         filt = d.build_filter(["moo"])
-        assert str(filt) == "foo.first IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IN ('moo')"
         filt = d.build_filter(["moo", None])
-        assert str(filt) == "foo.first IS NULL OR foo.first IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IS NULL OR foo.first IN ('moo')"
         filt = d.build_filter([None, "moo", None, None])
-        assert str(filt) == "foo.first IS NULL OR foo.first IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IS NULL OR foo.first IN ('moo')"
         filt = d.build_filter([None, None])
-        assert str(filt) == "foo.first IS NULL"
+        assert filter_to_string(filt) == "foo.first IS NULL"
 
         filt = d.build_filter(["moo", "foo"])
-        assert str(filt) == "foo.first IN (:first_1, :first_2)"
+        # Values are sorted
+        assert filter_to_string(filt) == "foo.first IN ('foo', 'moo')"
         filt = d.build_filter(["moo"], operator="in")
-        assert str(filt) == "foo.first IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IN ('moo')"
         filt = d.build_filter(["moo"], operator="notin")
-        assert str(filt) == "foo.first NOT IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first NOT IN ('moo')"
         filt = d.build_filter(["moo", None], operator="notin")
-        assert str(filt) == "foo.first IS NOT NULL AND foo.first NOT IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
         filt = d.build_filter([None, "moo", None], operator="notin")
-        assert str(filt) == "foo.first IS NOT NULL AND foo.first NOT IN (:first_1)"
+        assert filter_to_string(filt) == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
         filt = d.build_filter([None, None], operator="notin")
-        assert str(filt) == "foo.first IS NOT NULL"
+        assert filter_to_string(filt) == "foo.first IS NOT NULL"
         filt = d.build_filter(["moo", "foo"], operator="between")
-        assert str(filt) == "foo.first BETWEEN :first_1 AND :first_2"
+        assert filter_to_string(filt) == "foo.first BETWEEN 'moo' AND 'foo'"
 
         with pytest.raises(ValueError):
             d.build_filter("moo", "in")
@@ -312,7 +313,18 @@ class TestIngredientBuildFilter(object):
         # Test building scalar filters
         filt = d.build_filter("2020-01-01")
         assert (
-            filter_to_string(filt) == "CAST(foo.birth_date AS VARCHAR) = '2020-01-01'"
+            filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
+        )
+
+        filt = d.build_filter("2020-01-01T03:05")
+        assert (
+            filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
+        )
+
+        # An unparsable date will be treated as a string
+        filt = d.build_filter("2020-01-01T03:05X523")
+        assert (
+            filter_to_string(filt) == "CAST(foo.birth_date AS VARCHAR) = '2020-01-01T03:05X523'"
         )
 
         # Evaluated as timestamp=0
@@ -351,9 +363,9 @@ class TestIngredientBuildFilter(object):
 
         # Test building scalar filters
         filt = d.build_filter("a", operator="quickselect")
-        assert str(filt) == "foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.first = 'a'"
         filt = d.build_filter("b", operator="quickselect")
-        assert str(filt) == "foo.last = :last_1"
+        assert filter_to_string(filt) == "foo.last = 'b'"
 
         with pytest.raises(ValueError):
             filt = d.build_filter("c", operator="quickselect")
@@ -368,13 +380,13 @@ class TestIngredientBuildFilter(object):
 
         # Test building vector filters
         filt = d.build_filter(["a"], operator="quickselect")
-        assert str(filt) == "foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.first = 'a'"
         filt = d.build_filter(["b"], operator="quickselect")
-        assert str(filt) == "foo.last = :last_1"
+        assert filter_to_string(filt) == "foo.last = 'b'"
         filt = d.build_filter(["a", "b"], operator="quickselect")
-        assert str(filt) == "foo.first = :first_1 OR foo.last = :last_1"
+        assert filter_to_string(filt) == "foo.first = 'a' OR foo.last = 'b'"
         filt = d.build_filter(["b", "a"], operator="quickselect")
-        assert str(filt) == "foo.last = :last_1 OR foo.first = :first_1"
+        assert filter_to_string(filt) == "foo.last = 'b' OR foo.first = 'a'"
 
         with pytest.raises(ValueError):
             filt = d.build_filter(["c"], operator="quickselect")

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -205,7 +205,10 @@ class TestIngredientBuildFilter(object):
         filt = d.build_filter("moo", "like")
         assert filter_to_string(filt) == "CAST(foo.age AS VARCHAR) LIKE 'moo'"
         filt = d.build_filter("moo", "ilike")
-        assert filter_to_string(filt) == "lower(CAST(foo.age AS VARCHAR)) LIKE lower('moo')"
+        assert (
+            filter_to_string(filt)
+            == "lower(CAST(foo.age AS VARCHAR)) LIKE lower('moo')"
+        )
         # None values get converted to IS
         filt = d.build_filter(None, "eq")
         assert filter_to_string(filt) == "foo.age IS NULL"
@@ -292,9 +295,15 @@ class TestIngredientBuildFilter(object):
         filt = d.build_filter(["moo"], operator="notin")
         assert filter_to_string(filt) == "foo.first NOT IN ('moo')"
         filt = d.build_filter(["moo", None], operator="notin")
-        assert filter_to_string(filt) == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
+        assert (
+            filter_to_string(filt)
+            == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
+        )
         filt = d.build_filter([None, "moo", None], operator="notin")
-        assert filter_to_string(filt) == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
+        assert (
+            filter_to_string(filt)
+            == "foo.first IS NOT NULL AND foo.first NOT IN ('moo')"
+        )
         filt = d.build_filter([None, None], operator="notin")
         assert filter_to_string(filt) == "foo.first IS NOT NULL"
         filt = d.build_filter(["moo", "foo"], operator="between")
@@ -312,19 +321,16 @@ class TestIngredientBuildFilter(object):
         d = Dimension(MyTable.birth_date)
         # Test building scalar filters
         filt = d.build_filter("2020-01-01")
-        assert (
-            filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
-        )
+        assert filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
 
         filt = d.build_filter("2020-01-01T03:05")
-        assert (
-            filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
-        )
+        assert filter_to_string(filt) == "foo.birth_date = '2020-01-01'"
 
         # An unparsable date will be treated as a string
         filt = d.build_filter("2020-01-01T03:05X523")
         assert (
-            filter_to_string(filt) == "CAST(foo.birth_date AS VARCHAR) = '2020-01-01T03:05X523'"
+            filter_to_string(filt)
+            == "CAST(foo.birth_date AS VARCHAR) = '2020-01-01T03:05X523'"
         )
 
         # Evaluated as timestamp=0


### PR DESCRIPTION
This PR provides a more consistent identification of column types.

Not all columns used in ingredients have an identifiable column type. In particular, when using SQL functions like `func.date_trunc`, the column type may not be annotated. In these cases we're being a little smarter.

This PR also changes some tests to use the more descriptive `filter_to_string` utility function which renders a filter as a string with parameters inserted. This makes tests easier to read. 

A few build_filter date tests are added.