### PR TITLE
Use caching in total count

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -123,8 +123,14 @@ class Recipe(object):
         Returns:
             A count of the number of rows that are returned by this query.
         """
-        self.query()
-        return self._count_query.scalar()
+
+        if query is None:
+            query = self.query()
+
+        count_query = self._session.query(func.count().label("countr")).select_from(
+            query.limit(None).offset(None).order_by(None).subquery()
+        )
+        return count_query.scalar()
 
     def reset(self):
         self._query = None
@@ -460,12 +466,6 @@ class Recipe(object):
         # cache results
 
         self._query = recipe_parts["query"]
-        
-        count_query_inner = self._query.limit(None).offset(None).order_by(None)
-        self._count_query = self._session.query(func.count().label("count")).select_from(
-            count_query_inner.subquery()
-        )
-
         return self._query
 
     def _table(self):

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -123,6 +123,7 @@ class Recipe(object):
         Returns:
             A count of the number of rows that are returned by this query.
         """
+        return 7
         # If there is an ordering we take it off to make this
         # count run faster, then set the recipe to dirty so the
         # query is generated again

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -125,7 +125,7 @@ class Recipe(object):
         if query is None:
             query = self.query()
 
-        count_query = self._session.query(func.count().label("countr")).select_from(
+        count_query = self._session.query(func.count().label("count")).select_from(
             query.limit(None).offset(None).order_by(None).subquery()
         )
 

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import warnings
+from recipe_caching.mappers import FromCache
 from uuid import uuid4
 
 import attr
@@ -134,6 +135,12 @@ class Recipe(object):
         count_query = self._session.query(func.count().label("count")).select_from(
             query.subquery()
         )
+        if hasattr(query, "region"):
+            count_query.region = query.region
+        if hasattr(query, "cache_prefix"):
+            count_query.cache_prefix = query.cache_prefix
+        if hasattr(query, "cache_key"):
+            count_query.cache_key = query.cache_key
         cnt = count_query.scalar()
 
         # Clear the query so it is regenerated

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -124,7 +124,7 @@ class Recipe(object):
             A count of the number of rows that are returned by this query.
         """
         self.query()
-        return self._count_query().scalar
+        return self._count_query.scalar
 
     def reset(self):
         self._query = None

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -135,8 +135,8 @@ class Recipe(object):
         count_query = self._session.query(func.count().label("count")).select_from(
             query.subquery()
         )
-        count_query._cache_region = self._cache_region
-
+        if hasattr(query, "_cache_region"):
+            count_query._cache_region = query._cache_region
         if hasattr(query, "region"):
             count_query.region = query.region
         if hasattr(query, "cache_prefix"):

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -127,9 +127,13 @@ class Recipe(object):
         if query is None:
             query = self.query()
 
+        print("CR\n"*20)
+        print(query._cache_region, type(query))
         count_query = self._session.query(func.count().label("countr")).select_from(
             query.limit(None).offset(None).order_by(None).subquery()
         )
+        count_query._cache_region = query._cache_region
+        print(count_query._cache_region, type(count_query))
         return count_query.scalar()
 
     def reset(self):

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -135,6 +135,8 @@ class Recipe(object):
         count_query = self._session.query(func.count().label("count")).select_from(
             query.subquery()
         )
+        count_query._cache_region = self._cache_region
+
         if hasattr(query, "region"):
             count_query.region = query.region
         if hasattr(query, "cache_prefix"):

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -124,7 +124,7 @@ class Recipe(object):
             A count of the number of rows that are returned by this query.
         """
         self.query()
-        return self._count_query.scalar
+        return self._count_query.scalar()
 
     def reset(self):
         self._query = None


### PR DESCRIPTION
Total count is used automatically when caching but it does not get caching configuration applied. This results in paginated queries running slowly.