### PR TITLE
Unambiguous column syntax

### DIFF
--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -90,8 +90,9 @@ base_field_grammar = (
            | product "*" atom                  -> mul
            | product "/" atom                  -> div
     ?conversion:  /({allowed_conv_keys})/i    
-    ?convertedcol: conversion "(" column ")"
-    ?column.0: {column_defn}                   -> column
+    ?convertedcol: conversion "(" fld ")"
+    ?fld.0: NAME | column                      
+    ?column.0 "[" NAME "]"                     
 """.format(
         **base_field_grammar_args
     )

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -75,8 +75,8 @@ base_field_grammar = (
 
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal
-            | /true/i                          -> true
-            | /false/i                         -> false
+            | /true/i                          -> bool
+            | /false/i                         -> bool
     STAR: "*"
     COMMENT: /#.*/
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -26,8 +26,7 @@ base_field_grammar = (
            | product "*" atom                  -> mul
            | product "/" atom                  -> div
     ?conversion:  /({allowed_conv_keys})/i
-    ?convertedcol: conversion "(" fld ")"
-    ?fld.0: NAME | column                      -> fld
+    ?convertedcol: conversion "(" column ")"
     ?column.0: "[" NAME "]" | NAME             -> column
 
     ?start: bool_expr | partial_relation_expr

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -29,6 +29,7 @@ base_field_grammar = (
     ?convertedcol: conversion "(" fld ")"
     ?fld.0: NAME | column                      -> fld
     ?column.0: "[" NAME "]" | NAME             -> column
+
     ?start: bool_expr | partial_relation_expr
 
     // Pairs of boolean expressions and expressions
@@ -75,8 +76,8 @@ base_field_grammar = (
 
     ?const.1: NUMBER                           -> number
             | ESCAPED_STRING                   -> string_literal
-            | /true/i                          -> bool
-            | /false/i                         -> bool
+            | /true/i                          -> true
+            | /false/i                         -> false
     STAR: "*"
     COMMENT: /#.*/
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -1,7 +1,6 @@
-from lark import Lark, Transformer, v_args
+from lark import Lark
 from .engine_support import aggregations_by_engine, conversions_by_engine
 from .utils import convert_by_engine_keys_to_regex
-from ..compat import basestring
 
 
 # Generate a regex expression containing all the by_engine keys
@@ -9,20 +8,27 @@ allowed_aggr_keys = convert_by_engine_keys_to_regex(aggregations_by_engine)
 allowed_conv_keys = convert_by_engine_keys_to_regex(conversions_by_engine)
 
 
-# TODO: We may want to match columns based on fields that exist in
-# a source table. Allowing column definition to be changed is a start.
-column_defn = "NAME"
 base_field_grammar_args = {
     "allowed_aggr_keys": allowed_aggr_keys,
     "allowed_conv_keys": allowed_conv_keys,
-    "column_defn": column_defn,
 }
 
 
-# Base grammar for boolean expressions
+# Base grammar for field expressions
 # This grammar depends on a definition of atom which will be
-# added in the field grammars
-base_grammar = """
+# added in the specific field grammars
+base_field_grammar = (
+    """
+    ?sum: product
+        | sum "+" product                      -> add
+        | sum "-" product                      -> sub
+    ?product: atom
+           | product "*" atom                  -> mul
+           | product "/" atom                  -> div
+    ?conversion:  /({allowed_conv_keys})/i
+    ?convertedcol: conversion "(" fld ")"
+    ?fld.0: NAME | column                      -> fld
+    ?column.0: "[" NAME "]" | NAME             -> column
     ?start: bool_expr | partial_relation_expr
 
     // Pairs of boolean expressions and expressions
@@ -80,23 +86,9 @@ base_grammar = """
     %import common.WS_INLINE
     %ignore COMMENT
     %ignore WS_INLINE
-"""
-base_field_grammar = (
-    """
-    ?sum: product
-        | sum "+" product                      -> add
-        | sum "-" product                      -> sub
-    ?product: atom
-           | product "*" atom                  -> mul
-           | product "/" atom                  -> div
-    ?conversion:  /({allowed_conv_keys})/i
-    ?convertedcol: conversion "(" fld ")"
-    ?fld.0: NAME | column                      -> fld
-    ?column.0: "[" NAME "]" | NAME             -> column
 """.format(
         **base_field_grammar_args
     )
-    + base_grammar
 )
 
 # A grammar that does not include aggregate expressions

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -27,7 +27,8 @@ base_field_grammar = (
            | product "/" atom                  -> div
     ?conversion:  /({allowed_conv_keys})/i
     ?convertedcol: conversion "(" column ")"
-    ?column.0: "[" NAME "]" | NAME             -> column
+    ?column.0: "[" NAME "]"     -> column
+             | NAME             -> column
 
     ?start: bool_expr | partial_relation_expr
 

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -89,16 +89,15 @@ base_field_grammar = (
     ?product: atom
            | product "*" atom                  -> mul
            | product "/" atom                  -> div
-    ?conversion:  /({allowed_conv_keys})/i    
+    ?conversion:  /({allowed_conv_keys})/i
     ?convertedcol: conversion "(" fld ")"
-    ?fld.0: NAME | column                      
-    ?column.0 "[" NAME "]"                     
+    ?fld.0: NAME | column                      -> fld
+    ?column.0: "[" NAME "]" | NAME             -> column
 """.format(
         **base_field_grammar_args
     )
     + base_grammar
 )
-
 
 # A grammar that does not include aggregate expressions
 noag_field_grammar = (

--- a/recipe/schemas/field_grammar.py
+++ b/recipe/schemas/field_grammar.py
@@ -17,8 +17,7 @@ base_field_grammar_args = {
 # Base grammar for field expressions
 # This grammar depends on a definition of atom which will be
 # added in the specific field grammars
-base_field_grammar = (
-    """
+base_field_grammar = """
     ?sum: product
         | sum "+" product                      -> add
         | sum "-" product                      -> sub
@@ -88,8 +87,7 @@ base_field_grammar = (
     %ignore COMMENT
     %ignore WS_INLINE
 """.format(
-        **base_field_grammar_args
-    )
+    **base_field_grammar_args
 )
 
 # A grammar that does not include aggregate expressions

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -17,7 +17,7 @@ logging.captureWarnings(True)
 
 
 def move_extra_fields(value):
-    """ Move any fields that look like "{role}_field" into the extra_fields
+    """Move any fields that look like "{role}_field" into the extra_fields
     list. These will be processed as fields. Rename them as {role}_expression.
     """
     if isinstance(value, dict):
@@ -158,8 +158,8 @@ def create_buckets(value):
 
 
 def ensure_aggregation(fld):
-    """ Ensure that a field has an aggregation by wrapping the entire field
-    in a sum if no aggregation is supplied. """
+    """Ensure that a field has an aggregation by wrapping the entire field
+    in a sum if no aggregation is supplied."""
     try:
         tree = field_parser.parse(fld)
         has_agex = list(tree.find_data("agex"))
@@ -180,12 +180,14 @@ def add_version(v):
 
 # Sureberus validators that check how a field parses
 
+
 def ParseValidator(parser):
     def validate(field, value, error):
         try:
             parser.parse(value)
         except LarkError as exc:
             error(field, f"Error parsing field: {exc}")
+
     return validate
 
 

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -1,5 +1,4 @@
 """Shelf config _version="2" supports parsed fields using a lark parser."""
-import attr
 from lark.exceptions import LarkError
 from six import string_types
 import logging
@@ -15,23 +14,6 @@ from .field_grammar import (
 )
 
 logging.captureWarnings(True)
-
-
-@attr.s
-class ParseValidator(object):
-    """A sureberus validator that checks that a field parses and matches
-    certain tokens"""
-
-    #: Message to display on failure
-    parser = attr.ib(default=field_parser)
-
-    def __call__(self, f, v, e):
-        """Check parsing"""
-        try:
-            tree = self.parser.parse(v)
-        except LarkError as exc:
-            # A Lark error message raised when the value doesn't parse
-            raise exc
 
 
 def move_extra_fields(value):
@@ -197,6 +179,16 @@ def add_version(v):
 
 
 # Sureberus validators that check how a field parses
+
+def ParseValidator(parser):
+    def validate(field, value, error):
+        try:
+            parser.parse(value)
+        except LarkError as exc:
+            error(field, f"Error parsing field: {exc}")
+    return validate
+
+
 validate_parses_with_agex = ParseValidator(parser=field_parser)
 validate_parses_without_agex = ParseValidator(parser=noag_field_parser)
 validate_any_condition = ParseValidator(parser=noag_any_condition_parser)

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -28,10 +28,11 @@ def test_parsers():
     (war_total + war_total) / war_total             # 1,1,0,0,0,0
     if(war_total BETWEEN 1 AND 5, 5)                # 1,1,0,0,0,0
     if(war_total BETWEEN 1 AND 5, 4, 2)             # 1,1,0,0,0,0
-    if(war_total is null, 4, 2)                     # 1,1,0,0,0,0    
+    if(war_total is null, 4, 2)                     # 1,1,0,0,0,0
     couNT(*)                                        # 1,0,0,0,0,0
     AVG(war_total) + 1.0                            # 1,0,0,0,0,0
-    sum([war_total])                                  # 1,0,0,0,0,0
+    sum(war_total)                                  # 1,0,0,0,0,0
+    sum([war_total])                                # 1,0,0,0,0,0
     max(war_total) - min(war_total)                 # 1,0,0,0,0,0
     min(war_total)-max(war_total-war_total)         # 1,0,0,0,0,0
     avg(war_total + 2.0)                            # 1,0,0,0,0,0

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -133,7 +133,6 @@ def test_complex_field_parser():
         ("[foo]", "expr\n  column\tfoo"),
         ("foo", "expr\n  column\tfoo"),
         ("True", "expr\n  true\tTrue"),
-
         (
             "couNT(*)",
             """

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -130,6 +130,10 @@ bool_expr
 def test_complex_field_parser():
     """Test the parse trees generated """
     values = [
+        ("[foo]", "expr\n  column\tfoo"),
+        ("foo", "expr\n  column\tfoo"),
+        ("True", "expr\n  true\tTrue"),
+
         (
             "couNT(*)",
             """

--- a/tests/schemas/test_parsers.py
+++ b/tests/schemas/test_parsers.py
@@ -31,7 +31,7 @@ def test_parsers():
     if(war_total is null, 4, 2)                     # 1,1,0,0,0,0    
     couNT(*)                                        # 1,0,0,0,0,0
     AVG(war_total) + 1.0                            # 1,0,0,0,0,0
-    sum(war_total)                                  # 1,0,0,0,0,0
+    sum([war_total])                                  # 1,0,0,0,0,0
     max(war_total) - min(war_total)                 # 1,0,0,0,0,0
     min(war_total)-max(war_total-war_total)         # 1,0,0,0,0,0
     avg(war_total + 2.0)                            # 1,0,0,0,0,0

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -8,6 +8,14 @@ from dateutil.relativedelta import relativedelta
 oven = get_oven("sqlite://")
 Base = declarative_base(bind=oven.engine)
 
+
+oven.engine.execute(
+    """
+    CREATE TABLE IF NOT EXISTS weird_table_with_column_named_true
+        ("true" text);
+    """
+)
+
 TABLEDEF = """
         CREATE TABLE IF NOT EXISTS foo
         (first text,
@@ -338,6 +346,13 @@ class ScoresWithNulls(Base):
     test_date = Column("test_date", Date())
 
     __tablename__ = "scores_with_nulls"
+    __table_args__ = {"extend_existing": True}
+
+
+class WeirdTableWithColumnNamedTrue(Base):
+    true_ = Column("true", String(), primary_key=True)
+
+    __tablename__ = "weird_table_with_column_named_true"
     __table_args__ = {"extend_existing": True}
 
 

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -9,7 +9,9 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 import pytest
 from six import text_type
-from tests.test_base import Census, MyTable, oven, ScoresWithNulls, DateTester
+from tests.test_base import (
+    Census, MyTable, oven, ScoresWithNulls, DateTester, WeirdTableWithColumnNamedTrue
+)
 
 from recipe import (
     AutomaticFilters,
@@ -1292,6 +1294,23 @@ class TestParsedSQLGeneration(object):
 
     def assert_recipe_csv(self, recipe, csv_text):
         assert recipe.dataset.export("csv", lineterminator=text_type("\n")) == csv_text
+
+    def test_weird_table_with_column_named_true(self):
+        shelf = self.create_shelf(
+            """
+_version: 2
+"true":
+    kind: Dimension
+    field: "[true]"
+            """,
+            WeirdTableWithColumnNamedTrue
+        )
+
+        recipe = Recipe(shelf=shelf, session=self.session).dimensions("true")
+        assert recipe.to_sql() == """SELECT weird_table_with_column_named_true."true" AS "true"
+FROM weird_table_with_column_named_true
+GROUP BY "true"
+            """.strip()
 
     def test_complex_field(self):
         """Test parsed field definitions that use math, field references and more"""

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -10,7 +10,12 @@ from dateutil.relativedelta import relativedelta
 import pytest
 from six import text_type
 from tests.test_base import (
-    Census, MyTable, oven, ScoresWithNulls, DateTester, WeirdTableWithColumnNamedTrue
+    Census,
+    MyTable,
+    oven,
+    ScoresWithNulls,
+    DateTester,
+    WeirdTableWithColumnNamedTrue,
 )
 
 from recipe import (
@@ -1303,14 +1308,17 @@ _version: 2
     kind: Dimension
     field: "[true]"
             """,
-            WeirdTableWithColumnNamedTrue
+            WeirdTableWithColumnNamedTrue,
         )
 
         recipe = Recipe(shelf=shelf, session=self.session).dimensions("true")
-        assert recipe.to_sql() == """SELECT weird_table_with_column_named_true."true" AS "true"
+        assert (
+            recipe.to_sql()
+            == """SELECT weird_table_with_column_named_true."true" AS "true"
 FROM weird_table_with_column_named_true
 GROUP BY "true"
             """.strip()
+        )
 
     def test_complex_field(self):
         """Test parsed field definitions that use math, field references and more"""


### PR DESCRIPTION
Support column identifiers wrapped in [] to be unambiguous about the fact that they're columns.

`field: "true"` breaks things, because it tries to create a dimension using a boolean as a column name. This PR allows us to use `field: "[true]"` to refer to the column named `true` in the database.

TODO: when inferring ingredients, generate this syntax