### PR TITLE
Fix column type for timestamp

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.2
+current_version = 0.23.3
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+
+v0.23.3 (2021-04-29)
+-----------------------------------------
+* Fix column_type for timestamps
+
 v0.23.2 (2021-02-09)
 -----------------------------------------
 * Apply a default ordering when paginating

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.23.2.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.23.3.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.23.2...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.23.3...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.23.2"
+version = release = "0.23.3"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -49,7 +49,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.23.2"
+__version__ = "0.23.3"
 
 __all__ = [
     "BadIngredient",

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -52,7 +52,11 @@ def convert_datetime(v):
 
 
 def column_type(c):
-    """Determine the datatype of a SQLAlchemy column expression """
+    """Determine the datatype of a SQLAlchemy column expression.
+
+    Developers note: This is very naive. This can be improved by
+    using data types discovered during lark expression parsing.
+    """
     try:
         if hasattr(c, "type"):
             col_type = str(c.type).upper()
@@ -60,8 +64,11 @@ def column_type(c):
             col_type = None
     except CompileError:
         # Some SQLAlchemy expressions don't have a defined type
-        if str(c).lower().startswith("date_trunc"):
+        col_expr = str(c).lower()
+        if col_expr.startswith("date_trunc"):
             col_type = "DATE"
+        elif col_expr.startswith("timestamp_trunc"):
+            col_type = "TIMESTAMP"
         else:
             col_type = "STRING"
 

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -11,7 +11,7 @@ from recipe.utils import AttrDict
 
 
 def convert_date(v):
-    """Convert a passed parameter to a date if possible """
+    """Convert a passed parameter to a date if possible"""
     if v is None:
         return v
     elif isinstance(v, str):
@@ -32,7 +32,7 @@ def convert_date(v):
 
 
 def convert_datetime(v):
-    """Convert a passed parameter to a datetime if possible """
+    """Convert a passed parameter to a datetime if possible"""
     if v is None:
         return v
     elif isinstance(v, str):
@@ -189,7 +189,7 @@ class Ingredient(object):
         return u"({}){} {}".format(self.__class__.__name__, self.id, self._stringify())
 
     def _format_value(self, value):
-        """Formats value using any stored formatters. """
+        """Formats value using any stored formatters."""
         for f in self.formatters:
             value = f(value)
         return value
@@ -675,7 +675,7 @@ class Dimension(Ingredient):
 
     @property
     def id_prop(self):
-        """ The label of this dimensions id in the query columns """
+        """The label of this dimensions id in the query columns"""
         if "id" in self.role_keys:
             return self.id + "_id"
         else:
@@ -750,7 +750,7 @@ class Metric(Ingredient):
         self.roles = {"value": expression}
 
     def build_filter(self, value, operator=None):
-        """Building filters with Metric returns Having objects. """
+        """Building filters with Metric returns Having objects."""
         f = super().build_filter(value, operator=operator)
         return Having(f.filters[0])
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.23.2",
+    version="0.23.3",
     description="Lego construction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",

--- a/tests/schemas/test_lark_grammar.py
+++ b/tests/schemas/test_lark_grammar.py
@@ -12,7 +12,7 @@ utc_offset = -1 * time.localtime().tm_gmtoff / 3600.0 + time.localtime().tm_isds
 
 
 def to_sql(expr):
-    """Utility to print sql for a expression """
+    """Utility to print sql for a expression"""
     return str(expr.compile(compile_kwargs={"literal_binds": True}))
 
 
@@ -108,7 +108,7 @@ class TestSQLAlchemyBuilder(TestBase):
             self.assertEqual(data_type, expected_data_type)
 
     def test_selectable_recipe(self):
-        """Test a selectable that is a recipe """
+        """Test a selectable that is a recipe"""
         recipe = (
             Recipe(shelf=mytable_shelf, session=oven.Session())
             .metrics("age")
@@ -552,7 +552,7 @@ Can't convert 'potato' to a date.
 
 
 class TestDataTypesTableDatesInBigquery(TestDataTypesTableDates):
-    """Test date code generated against a bigquery backend """
+    """Test date code generated against a bigquery backend"""
 
     def setUp(self):
         SQLAlchemyBuilder.clear_builder_cache()

--- a/tests/schemas/test_lark_grammar.py
+++ b/tests/schemas/test_lark_grammar.py
@@ -8,7 +8,7 @@ from recipe import Recipe
 from recipe.schemas.lark_grammar import SQLAlchemyBuilder
 from tests.test_base import DataTypesTable, mytable_shelf, oven
 
-utc_offset = -1 * time.localtime().tm_gmtoff / 3600 + time.localtime().tm_isdst
+utc_offset = -1 * time.localtime().tm_gmtoff / 3600.0 + time.localtime().tm_isdst
 
 
 def to_sql(expr):

--- a/tests/schemas/test_lark_grammar.py
+++ b/tests/schemas/test_lark_grammar.py
@@ -8,7 +8,7 @@ from recipe import Recipe
 from recipe.schemas.lark_grammar import SQLAlchemyBuilder
 from tests.test_base import DataTypesTable, mytable_shelf, oven
 
-utc_offset = -1 * time.localtime().tm_gmtoff / 3600.0
+utc_offset = -1 * time.localtime().tm_gmtoff / 3600 + time.localtime().tm_isdst
 
 
 def to_sql(expr):


### PR DESCRIPTION
Columns created by timestamp_trunc aggregations are not being identified as the correct column type. This affects filter generation.