### PR TITLE
Fix filtering on unfilterable strings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.3
+current_version = 0.23.4
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+v0.23.4 (2021-05-03)
+-----------------------------------------
+* Improve automatic filtering with uncompilable ingredients
 
 v0.23.3 (2021-04-29)
 -----------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.23.3.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.23.4.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.23.3...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.23.4...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.23.3"
+version = release = "0.23.4"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -49,7 +49,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.23.3"
+__version__ = "0.23.4"
 
 __all__ = [
     "BadIngredient",

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import CompileError
 from datetime import date, datetime
 from time import gmtime
 from recipe.exceptions import BadIngredient
-from recipe.utils import AttrDict
+from recipe.utils import AttrDict, filter_to_string
 
 
 def convert_date(v):
@@ -491,7 +491,7 @@ class Filter(Ingredient):
         self.filters = [expression]
 
     def _stringify(self):
-        return " ".join(str(expr) for expr in self.filters)
+        return filter_to_string(self)
 
     @property
     def expression(self):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.23.3",
+    version="0.23.4",
     description="Lego construction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -442,7 +442,7 @@ class TestFilter(object):
         filters.add(f2)
         assert len(filters) == 2
 
-        assert str(f1) == "(Filter)f1 foo.first = :first_1"
+        assert str(f1) == "(Filter)f1 foo.first = 'moo'"
 
     def test_expression(self):
         f = Filter(MyTable.first == "foo")
@@ -455,7 +455,7 @@ class TestFilter(object):
 
     def test_filter_describe(self):
         f1 = Filter(MyTable.first == "moo", id="moo")
-        assert f1.describe() == "(Filter)moo foo.first = :first_1"
+        assert f1.describe() == "(Filter)moo foo.first = 'moo'"
 
 
 class TestHaving(object):

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -72,7 +72,7 @@ class TestIngredients(object):
         )
 
     def test_comparisons(self):
-        """ Items sort in a fixed order"""
+        """Items sort in a fixed order"""
         ingr = Ingredient(columns=[MyTable.first], id=1)
         ingr2 = Ingredient(columns=[MyTable.first], id=2)
         dim = Dimension(MyTable.first, id=3)
@@ -126,7 +126,7 @@ class TestIngredients(object):
         assert len(extras) == 1
 
     def test_ingredient_cmp(self):
-        """ Ingredients are sorted by id """
+        """Ingredients are sorted by id"""
         ingra = Ingredient(id="b", columns=[MyTable.first])
         ingrb = Ingredient(id="a", columns=[MyTable.last])
         assert ingrb < ingra
@@ -134,7 +134,7 @@ class TestIngredients(object):
 
 class TestIngredientBuildFilter(object):
     def test_scalar_filter(self):
-        """Test scalar filters on a string dimension """
+        """Test scalar filters on a string dimension"""
         d = Dimension(MyTable.first)
 
         # Test building scalar filters
@@ -182,7 +182,7 @@ class TestIngredientBuildFilter(object):
             filt = d.build_filter(["moo"], "cows")
 
     def test_scalar_filter_on_int(self):
-        """Test scalar filters on an integer dimension """
+        """Test scalar filters on an integer dimension"""
         d = Dimension(MyTable.age)
 
         # Test building scalar filters
@@ -433,7 +433,7 @@ class TestIngredientBuildFilter(object):
 
 class TestFilter(object):
     def test_filter_cmp(self):
-        """ Filters are compared on their filter expression """
+        """Filters are compared on their filter expression"""
         filters = set()
         f1 = Filter(MyTable.first == "moo", id="f1")
         f2 = Filter(MyTable.first == "foo", id="f2")
@@ -460,7 +460,7 @@ class TestFilter(object):
 
 class TestHaving(object):
     def test_having_cmp(self):
-        """ Filters are compared on their filter expression """
+        """Filters are compared on their filter expression"""
         havings = set()
         f1 = Having(func.sum(MyTable.age) > 2, id="h1")
         f2 = Having(func.sum(MyTable.age) > 3, id="h2")


### PR DESCRIPTION
Some filters raise compilation errors when attempting to stringify them. Notably a vector filter built using an dimension using `age(date)`

The stringified filter is used to determine if a particular filter has already been used in a recipe. In this case, if the filter can't be stringified, we just default to a uuid.