### PR TITLE
Allow dates to be constructed from y,m,d

### DIFF
--- a/recipe/schemas/lark_grammar.py
+++ b/recipe/schemas/lark_grammar.py
@@ -123,7 +123,7 @@ def make_lark_grammar(columns):
     {make_columns_grammar(columns)}
 
     {gather_columns("unusable_col", columns, "unusable", [])}
-    {gather_columns("date.1", columns, "date", ["date_conv", "day_conv", "week_conv", "month_conv", "quarter_conv", "year_conv", "dt_day_conv", "dt_week_conv", "dt_month_conv", "dt_quarter_conv", "dt_year_conv", "datetime_to_date_conv", "date_aggr", "date_if_statement", "date_coalesce"])}
+    {gather_columns("date.1", columns, "date", ["date_conv", "date_fn", "day_conv", "week_conv", "month_conv", "quarter_conv", "year_conv", "dt_day_conv", "dt_week_conv", "dt_month_conv", "dt_quarter_conv", "dt_year_conv", "datetime_to_date_conv", "date_aggr", "date_if_statement", "date_coalesce"])}
     {gather_columns("datetime.2", columns, "datetime", ["datetime_conv", "datetime_if_statement", "datetime_coalesce"])}
     // Datetimes that are converted to the end of day
     {gather_columns("datetime_end.1", columns, "datetime", ["datetime_end_conv", "datetime_aggr"])}
@@ -182,6 +182,7 @@ def make_lark_grammar(columns):
 
     // Date
     date_conv.3: /date/i "(" ESCAPED_STRING ")"
+    date_fn.3: /date/i "(" num "," num "," num ")"
     datetime_to_date_conv.3: /date/i "(" datetime ")"  -> dt_day_conv
     datetime_conv.2: /date/i "(" ESCAPED_STRING ")"
     datetime_end_conv.1: /date/i "(" ESCAPED_STRING ")"
@@ -600,6 +601,9 @@ class TransformToSQLAlchemyExpression(Transformer):
             return self.columns[v.data]
         else:
             return v
+
+    def date_fn(self, _, y, m, d):
+        return func.date(y, m, d)
 
     def datetime(self, v):
         if isinstance(v, Tree):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 faker==2.0.4
 ordered-set==3.1.1
-SQLAlchemy>=1.2.2
+SQLAlchemy>=1.2.2,<1.4
 sqlparse==0.3.0
 stevedore==1.31.0
 tablib==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.argv[-1] == "test":
 # yapf: disable
 install = [
     'ordered-set',
-    'sqlalchemy>=1.2.2',
+    'sqlalchemy>=1.2.2,<1.4',
     'sqlparse',
     'tablib',
     'pyyaml',

--- a/tests/schemas/test_lark_grammar.py
+++ b/tests/schemas/test_lark_grammar.py
@@ -528,6 +528,8 @@ class TestDataTypesTableDates(TestBase):
         quarter([test_date]) > date("2020-12-30")        -> date_trunc('quarter', datatypes.test_date) > '2020-12-30'
         year([test_date]) > date("2020-12-30")           -> date_trunc('year', datatypes.test_date) > '2020-12-30'
         date([test_datetime])                            -> date_trunc('day', datatypes.test_datetime)
+        date(2020, 1, 1)                                 -> date(2020, 1, 1)
+        month(date(2020, 1, 1))                          -> date_trunc('month', date(2020, 1, 1))
         """
 
         for field, expected_sql in self.examples(good_examples):


### PR DESCRIPTION
Allow dates to be constructed from separate y,m,d numbers.

For instance, we can construct a date `date(2020, 1, 1)` or from separate columns `date(yearcol, monthcol, daycol)`