### PR TITLE
Avoid installing a top-level `tests` package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     author="Chris Gemignani",
     author_email="chris.gemignani@juiceanalytics.com",
     url="https://github.com/juiceinc/recipe",
-    packages=find_packages(),
+    packages=find_packages(include=["recipe*"]),
     include_package_data=True,
     license="MIT",
     classifiers=[


### PR DESCRIPTION
## Changes

Pass `include=["recipe*"]` to `find_packages` so we don't include the top-level `tests` package when installing recipe. This can conflict if multiple packages do it, and wreaks havoc with python's built-in unittest discovery