### PR TITLE
Store the originally added metrics and dimensions without deduping

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import warnings
+from copy import copy
 from uuid import uuid4
 
 import attr
@@ -89,6 +90,12 @@ class Recipe(object):
         self._use_cache = True
 
         self.stats = Stats()
+
+        # Store the original dimensions and metrics put into the recipe.
+        # These may contain duplicates, which will not exist after the
+        # ingredients are added to the cauldron.
+        self.raw_metrics = tuple()
+        self.raw_dimensions = tuple()
 
         if metrics is not None:
             self.metrics(*metrics)
@@ -277,6 +284,7 @@ class Recipe(object):
                          Metric objects
         :type metrics: list
         """
+        self.raw_metrics = self.raw_metrics + copy(metrics)
         for m in metrics:
             self._cauldron.use(self._shelf.find(m, Metric))
 
@@ -293,6 +301,7 @@ class Recipe(object):
                          Dimension objects
         :type dimensions: list
         """
+        self.raw_dimensions = self.raw_dimensions + copy(dimensions)
         for d in dimensions:
             self._cauldron.use(self._shelf.find(d, Dimension))
 

--- a/tests/schemas/test_lark_grammar.py
+++ b/tests/schemas/test_lark_grammar.py
@@ -1,7 +1,7 @@
 import time
 from unittest import TestCase
 from sqlalchemy.ext.serializer import loads, dumps
-from copy import deepcopy
+
 from freezegun import freeze_time
 
 from recipe import Recipe
@@ -614,6 +614,7 @@ class TestAggregations(TestBase):
         count_distinct(department)   -> count(DISTINCT datatypes.department)
         count_distinct(department = "MO" AND score > 20) -> count(DISTINCT (datatypes.department = 'MO' AND datatypes.score > 20))
         count_distinct(if(department = "MO" AND score > 20, department)) -> count(DISTINCT CASE WHEN (datatypes.department = 'MO' AND datatypes.score > 20) THEN datatypes.department END)
+        count(IF(department = "MO" AND score > 20, department)) -> count(CASE WHEN (datatypes.department = 'MO' AND datatypes.score > 20) THEN datatypes.department END)
         count(*)                     -> count(*)
         """
 

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -36,6 +36,27 @@ GROUP BY first"""
         assert recipe.all()[0].age == 15
         assert recipe.stats.rows == 1
 
+    def test_metrics_dimensions(self):
+        """Metric_ids and dimension_ids hold unique used metrics and dimensions.
+        raw_metrics and raw_dimensions store ingredients as added."""
+
+        # We call dimensions and metrics multiple times
+        recipe = self.recipe().metrics("age").dimensions("first", "first").metrics("age")
+        assert (
+            recipe.to_sql()
+            == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+GROUP BY first"""
+        )
+        assert recipe.all()[0].first == "hi"
+        assert recipe.all()[0].age == 15
+        assert recipe.stats.rows == 1
+        assert recipe.metric_ids == ("age",)
+        assert recipe.dimension_ids == ("first",)
+        assert recipe.raw_dimensions == ("first", "first")
+        assert recipe.raw_metrics == ("age", "age")
+
     def test_idvaluedimension(self):
         recipe = self.recipe().metrics("age").dimensions("firstlast")
         assert (


### PR DESCRIPTION
Store original metrics on a recipe to allow queries that reuse ingredients.