### PR TITLE
Add directives that will convert dates and datetimes to the nearest year/month/day.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.27.0
+current_version = 0.27.1
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.27.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.27.1.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.27.0...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.27.1...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.27.0"
+version = release = "0.27.1"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -49,7 +49,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"
 
 __all__ = [
     "BadIngredient",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.27.0",
+    version="0.27.1",
     description="A construction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",

--- a/tests/test_ingredients_yaml.py
+++ b/tests/test_ingredients_yaml.py
@@ -1743,6 +1743,46 @@ test:
             unique_sql.add(recipe.to_sql())
         assert len(unique_sql) == 3
 
+    def test_convert_date(self):
+        """We can convert dates using formats"""
+
+        shelf = self.shelf_from_yaml(
+            """
+_version: 2
+test:
+    kind: Dimension
+    field: dt
+    format: "%Y"
+test2:
+    kind: Dimension
+    field: dt
+    format: "<%Y>"
+test3:
+    kind: Dimension
+    field: dt
+    format: "<%B %Y>"
+test4:
+    kind: Dimension
+    field: dt
+    format: "%B %Y"
+test5:
+    kind: Dimension
+    field: dt
+    format: ".2f"
+""", DateTester,
+        )
+        recipe = Recipe(shelf=shelf, session=self.session).dimensions("test", "test2", "test3", "test4", "test5")
+        assert recipe.to_sql() == """SELECT date_trunc('year', datetester.dt) AS test,
+       date_trunc('year', datetester.dt) AS test2,
+       date_trunc('month', datetester.dt) AS test3,
+       date_trunc('month', datetester.dt) AS test4,
+       datetester.dt AS test5
+FROM datetester
+GROUP BY test,
+         test2,
+         test3,
+         test4,
+         test5"""
 
 class TestParsedFieldConfig(ConfigTestBase):
     """Parsed fields save the original config"""


### PR DESCRIPTION
Add directives to convert dates and datetimes to the nearest year/month/day. This is used when the display format of an date or datetime ingredient is showing only years, we will convert the dates to years in sql.