### PR TITLE
Adding support for date and datetime conversions in MSSQL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.29.0 (2021-11-17)
+-----------------------------------------
+* Improve mssql support
+
 v0.28.1 (2021-10-28)
 -----------------------------------------
 * Fix for splitting operators in automatic filters

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -191,7 +191,10 @@ class Ingredient(object):
                 for col, lbl in reversed(list(zip(self.columns, self._labels)))
             ]
         else:
-            return reversed(self.columns)
+            if self.ordering == "desc":
+                return [col.desc() for col in reversed(self.columns)]
+            else:
+                return reversed(self.columns)
 
     @property
     def cauldron_extras(self):

--- a/recipe/schemas/lark_grammar.py
+++ b/recipe/schemas/lark_grammar.py
@@ -650,6 +650,8 @@ class TransformToSQLAlchemyExpression(Transformer):
         """Truncate to the day"""
         if self.drivername == "bigquery":
             return func.date_trunc(fld, text("day"))
+        elif self.drivername.startswith("mssql"):
+            return func.datefromparts(func.year(fld), func.month(fld), func.day(fld))
         else:
             # Postgres + redshift
             return func.date_trunc("day", fld)
@@ -658,6 +660,8 @@ class TransformToSQLAlchemyExpression(Transformer):
         """Truncate to mondays"""
         if self.drivername == "bigquery":
             return func.date_trunc(fld, text("week(monday)"))
+        elif self.drivername.startswith("mssql"):
+            raise GrammarError("week is not supported on mssql")
         else:
             # Postgres + redshift
             return func.date_trunc("week", fld)
@@ -665,6 +669,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def month_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.date_trunc(fld, text("month"))
+        elif self.drivername.startswith("mssql"):
+            return func.datefromparts(func.year(fld), func.month(fld), 1)
         else:
             # Postgres + redshift
             return func.date_trunc("month", fld)
@@ -672,6 +678,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def quarter_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.date_trunc(fld, text("quarter"))
+        elif self.drivername.startswith("mssql"):
+            raise GrammarError("quarter is not supported on mssql")
         else:
             # Postgres + redshift
             return func.date_trunc("quarter", fld)
@@ -679,6 +687,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def year_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.date_trunc(fld, text("year"))
+        elif self.drivername.startswith("mssql"):
+            return func.datefromparts(func.year(fld), 1, 1)
         else:
             # Postgres + redshift
             return func.date_trunc("year", fld)
@@ -687,6 +697,8 @@ class TransformToSQLAlchemyExpression(Transformer):
         """Truncate to day"""
         if self.drivername == "bigquery":
             return func.timestamp_trunc(fld, text("day"))
+        elif self.drivername.startswith("mssql"):
+            return func.datetimefromparts(func.year(fld), func.month(fld), func.day(fld), 0, 0, 0, 0)
         else:
             # Postgres + redshift
             return func.date_trunc("day", fld)
@@ -695,6 +707,8 @@ class TransformToSQLAlchemyExpression(Transformer):
         """Truncate to mondays"""
         if self.drivername == "bigquery":
             return func.timestamp_trunc(fld, text("week(monday)"))
+        elif self.drivername.startswith("mssql"):
+            raise GrammarError("week is not supported on mssql")
         else:
             # Postgres + redshift
             return func.date_trunc("week", fld)
@@ -702,6 +716,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def dt_month_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.timestamp_trunc(fld, text("month"))
+        elif self.drivername.startswith("mssql"):
+            return func.datetimefromparts(func.year(fld), func.month(fld), 1, 0, 0, 0, 0)
         else:
             # Postgres + redshift
             return func.date_trunc("month", fld)
@@ -709,6 +725,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def dt_quarter_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.timestamp_trunc(fld, text("quarter"))
+        elif self.drivername.startswith("mssql"):
+            raise GrammarError("quarter is not supported on mssql")
         else:
             # Postgres + redshift
             return func.date_trunc("quarter", fld)
@@ -716,6 +734,8 @@ class TransformToSQLAlchemyExpression(Transformer):
     def dt_year_conv(self, _, fld):
         if self.drivername == "bigquery":
             return func.timestamp_trunc(fld, text("year"))
+        elif self.drivername.startswith("mssql"):
+            return text(func.datetimefromparts(func.year(fld), 1, 1, 0, 0, 0, 0).compile(compile_kwargs={"literal_binds": True}))
         else:
             # Postgres + redshift
             return func.date_trunc("year", fld)

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -67,6 +67,11 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
 
     args = []
 
+    if builder.drivername.startswith("mssql"):
+        group_by_strategy = "direct"
+    else:
+        group_by_strategy = "labels"
+
     # For some formats, we will automatically convert dates
     format = ingr_dict.get("format")
     if isinstance(format, str) and format.startswith("<") and format.endswith(">"):
@@ -106,6 +111,7 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
                     return InvalidIngredient(error=error)
                 args = [expr]
             else:
+                ingr_dict["group_by_strategy"] = group_by_strategy
                 fld_defn = ingr_dict.pop("field", None)
                 buckets = ingr_dict.pop("buckets", None)
                 buckets_default_label = ingr_dict.pop("buckets_default_label", None)

--- a/tests/test_recipe_database.py
+++ b/tests/test_recipe_database.py
@@ -88,7 +88,8 @@ count:
         )
 
     def teardown(self):
-        self.meta.drop_all(self.oven.engine)
+        if not self.skip_tests:
+            self.meta.drop_all(self.oven.engine)
 
     def shelf_from_yaml(self, yaml_config, selectable):
         """Create a shelf directly from configuration"""

--- a/tests/test_recipe_database.py
+++ b/tests/test_recipe_database.py
@@ -1,0 +1,166 @@
+"""Test Recipe against multiple database engines"""
+
+from copy import copy
+from datetime import date, datetime
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    String,
+    Table,
+    distinct,
+    func,
+    join,
+    MetaData,
+    insert,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sureberus.schema import Boolean
+from yaml import safe_load
+
+from recipe import Dimension, Metric, Recipe, Shelf, get_oven
+from recipe import oven
+from recipe.ingredients import Having
+
+
+
+class TestRecipeIngredients(object):
+    def setup(self):
+        self.oven = get_oven(connection_string)
+
+        self.meta = MetaData(bind=self.oven.engine)
+        self.session = self.oven.Session()
+
+        self.table = Table(
+            "foo",
+            self.meta,
+            Column("first", String),
+            Column("last", String),
+            Column("age", Integer),
+            Column("birth_date", Date),
+            Column("dt", DateTime),
+            extend_existing=True,
+        )
+
+        self.shelf = Shelf(
+            {
+                "first": Dimension(self.table.c.first, group_by_strategy="direct"),
+                "last": Dimension(self.table.c.last, group_by_strategy="direct"),
+                "firstlast": Dimension(
+                    self.table.c.last,
+                    id_expression=self.table.c.first,
+                    group_by_strategy="direct",
+                ),
+                "age": Metric(func.sum(self.table.c.age)),
+                "count": Metric(func.count("*")),
+            }
+        )
+        self.meta.create_all(self.oven.engine)
+
+        data = [
+            {
+                "first": "hi",
+                "last": "there",
+                "age": 5,
+                "birth_date": date(2015, 1, 1),
+                "dt": datetime(2005, 12, 1, 12, 15),
+            },
+            {
+                "first": "hi",
+                "last": "fred",
+                "age": 10,
+                "birth_date": date(2015, 5, 15),
+                "dt": datetime(2013, 10, 15, 5, 20, 10),
+            },
+        ]
+        with self.oven.engine.connect() as conn:
+            for row in data:
+                result = conn.execute(insert(self.table).values(**row))
+
+    def shelf_from_yaml(self, yaml_config, selectable):
+        """Create a shelf directly from configuration"""
+        return Shelf.from_validated_yaml(yaml_config, selectable)
+
+    def teardown(self):
+        self.meta.drop_all(self.oven.engine)
+
+    #     def recipe(self, **kwargs):
+    #         return Recipe(shelf=self.shelf, session=self.session, **kwargs)
+
+    #     def test_dimension(self):
+    #         recipe = self.recipe().metrics("age","count").dimensions("first")
+    #         assert recipe.all()[0].first == "hi"
+    #         assert recipe.all()[0].age == 15
+    #         assert recipe.all()[0].count == 2
+    #         assert recipe.stats.rows == 1
+
+    #     def test_idvaluedimension(self):
+    #         recipe = self.recipe().metrics("age").dimensions("firstlast")
+    #         assert recipe.all()[0].firstlast == "fred"
+    #         assert recipe.all()[0].firstlast_id == "hi"
+    #         assert recipe.all()[0].age == 10
+    #         assert recipe.all()[1].firstlast == "there"
+    #         assert recipe.all()[1].firstlast_id == "hi"
+    #         assert recipe.all()[1].age == 5
+    #         assert recipe.stats.rows == 2
+
+    #     def test_having(self):
+
+    #         hv = Having(func.sum(self.table.c.age) < 10)
+    #         recipe = (
+    #             self.recipe()
+    #             .metrics("age")
+    #             .dimensions("last")
+    #             .filters(self.table.c.age > 2)
+    #             .filters(hv)
+    #             .order_by("last")
+    #         )
+    #         assert (
+    #             recipe.dataset.csv.replace("\r\n", "\n")
+    #             == """last,age,last_id
+    # there,5,there
+    # """
+    #         )
+
+    def test_convert_date(self):
+        """We can convert dates using formats"""
+
+        shelf = self.shelf_from_yaml(
+            """
+_version: 2
+test:
+    kind: Dimension
+    field: dt
+    format: "%Y"
+test2:
+    kind: Dimension
+    field: dt
+    format: "<%Y>"
+test3:
+    kind: Dimension
+    field: dt
+    format: "<%B %Y>"
+test4:
+    kind: Dimension
+    field: dt
+    format: "%B %Y"
+test5:
+    kind: Dimension
+    field: dt
+    format: ".2f"
+count:
+    kind: Measure
+    field: count(*)
+""",
+            self.table,
+        )
+        recipe = Recipe(shelf=shelf, session=self.session).dimensions("test").metrics("count")
+        print(recipe.to_sql())
+        print(recipe.all())
+        assert recipe.all()[0].test == datetime(2005, 12, 1, 12, 15)
+        # assert recipe.all()[0].test5 == datetime(2005, 1, 1)


### PR DESCRIPTION
Improve support when using MSSQL.

* Fix a bug with order_by when ingredients are using a direct group by strategy
* Add MSSQL support for year, month, day date and datetime conversions. Quarter and week are not yet supported.
* Use group_by_strategy of "direct" when creating dimensions on mssql
* Add rudimentary multi-database testing support.
