### PR TITLE
Fix automatic filtering with dimension keys containing __

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.29.1 (2021-12-03)
+-----------------------------------------
+* Fix automatic filters when dimension ids contain double underscores
+
 v0.29.0 (2021-11-17)
 -----------------------------------------
 * Improve mssql support

--- a/recipe/extensions.py
+++ b/recipe/extensions.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from recipe.core import Recipe
 from recipe.exceptions import BadRecipe
-from recipe.ingredients import Dimension, Ingredient, Metric, Filter
+from recipe.ingredients import ALLOWED_OPERATORS, Dimension, Ingredient, Metric, Filter
 from recipe.utils import FakerAnonymizer, recipe_arg, pad_values
 
 Base = declarative_base()
@@ -223,8 +223,15 @@ class AutomaticFilters(RecipeExtension):
         The dim may contain a dimension id and an optional operator
         """
         operator = None
+
+        # Check to see if the dim endswith a valid operator
         if "__" in dim:
-            dim, operator = dim.rsplit("__", 1)
+            newdim, operator = dim.rsplit("__", 1)
+            operator = operator.lower()
+            if operator in ALLOWED_OPERATORS:
+                dim = newdim
+            else:
+                operator = None
         if self.include_keys is not None and dim not in self.include_keys:
             # Ignore keys that are not in include_keys
             return None

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -11,6 +11,25 @@ from recipe.utils.datatype import (
     datatype_from_column_expression,
 )
 
+ALLOWED_OPERATORS = set(
+    [
+        "eq",
+        "ne",
+        "lt",
+        "lte",
+        "gt",
+        "gte",
+        "is",
+        "isnot",
+        "like",
+        "ilike",
+        "quickselect",
+        "in",
+        "notin",
+        "between",
+    ]
+)
+
 
 @total_ordering
 class Ingredient(object):
@@ -247,6 +266,8 @@ class Ingredient(object):
             A Filter object
         """
 
+        # Developer's note: Valid operators should appear in ALLOWED_OPERATORS
+        # This is used by the AutomaticFilter extension.
         if operator is None:
             operator = "eq"
         if target_role and target_role in self.roles:
@@ -321,6 +342,9 @@ class Ingredient(object):
 
             A Filter object
         """
+
+        # Developer's note: Valid operators should appear in ALLOWED_OPERATORS
+        # This is used by the AutomaticFilter extension.
         if operator is None:
             operator = "in"
         if target_role and target_role in self.roles:
@@ -358,8 +382,7 @@ class Ingredient(object):
                 non_none_value = sorted([v for v in value if v is not None])
                 if non_none_value:
                     return and_(
-                        filter_column.isnot(None),
-                        filter_column.notin_(non_none_value),
+                        filter_column.isnot(None), filter_column.notin_(non_none_value)
                     )
                 else:
                     return filter_column.isnot(None)

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -459,7 +459,7 @@ WHERE foo.first = 'cow'
 GROUP BY first"""
         )
 
-    def test_operators(self):
+    def test_invalid_operators(self):
         """Only valid operators are parsed from the dimension"""
         # Using operators
         # A valid operator is used
@@ -481,7 +481,16 @@ GROUP BY first"""
             recipe.all()
 
         # If we add this to the shelf, it works.
-        self.shelf["last__mike"] = Dimension(MyTable.last)
+        self.shelf = Shelf(
+            {
+                "first": Dimension(MyTable.first),
+                "last": Dimension(MyTable.last),
+                "firstlast": Dimension(MyTable.last, id_expression=MyTable.first),
+                "age": Metric(func.sum(MyTable.age)),
+                "last__mike": Dimension(MyTable.last),
+            }
+        )
+
         recipe = self.recipe().metrics("age").dimensions("first")
         recipe = recipe.automatic_filters({"last__mike": "moo"})
         assert (

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -459,6 +459,52 @@ WHERE foo.first = 'cow'
 GROUP BY first"""
         )
 
+    def test_operators(self):
+        """Only valid operators are parsed from the dimension"""
+        # Using operators
+        # A valid operator is used
+        recipe = self.recipe().metrics("age").dimensions("first")
+        recipe = recipe.automatic_filters({"last__like": "moo"})
+        assert (
+            recipe.to_sql()
+            == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.last LIKE 'moo'
+GROUP BY first"""
+        )
+
+        # This is an invalid operator and will get looked up on the shelf
+        recipe = self.recipe().metrics("age").dimensions("first")
+        recipe = recipe.automatic_filters({"last__mike": "moo"})
+        with pytest.raises(BadRecipe):
+            recipe.all()
+
+        # If we add this to the shelf, it works.
+        self.shelf["last__mike"] = Dimension(MyTable.last)
+        recipe = self.recipe().metrics("age").dimensions("first")
+        recipe = recipe.automatic_filters({"last__mike": "moo"})
+        assert (
+            recipe.to_sql()
+            == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.last = 'moo'
+GROUP BY first"""
+        )
+
+        # We can chain a valid operator
+        recipe = self.recipe().metrics("age").dimensions("first")
+        recipe = recipe.automatic_filters({"last__mike__like": "moo"})
+        assert (
+            recipe.to_sql()
+            == """SELECT foo.first AS first,
+       sum(foo.age) AS age
+FROM foo
+WHERE foo.last LIKE 'moo'
+GROUP BY first"""
+        )
+
 
 class TestAnonymizeRecipeExtension(object):
     def setup(self):


### PR DESCRIPTION
This fixes an issue with dimension keys that contain double underscores. For instance "field__adfkjls" (a field ending with an underscore was suffixed with a "_" and a random key. These were being split on the double underscore and the ending part was being treated as an operator. Ordinarily this would raise a BadRecipe but in this case the dimension wasn't found on the shelf so it was ignored. 

