### PR TITLE
Group by direct with snowflake

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,6 @@
 Changelog
 =========
 
-v0.30.1 (2021-03-16)
------------------------------------------
-* Fix an error in ordering with mixed case columns/labels when using snowflake
-
 v0.30.0 (2021-02-15)
 -----------------------------------------
 * Breaking chagne: removed support for v1 ingredient configuration.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.30.1 (2021-03-16)
+-----------------------------------------
+* Fix an error in ordering with mixed case columns/labels when using snowflake
+
 v0.30.0 (2021-02-15)
 -----------------------------------------
 * Breaking chagne: removed support for v1 ingredient configuration.

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -97,11 +97,11 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
 
     try:
         if kind in ("metric", "dimension"):
-            if kind == "metric":
+            ingr_dict["group_by_strategy"] = ingr_dict.get(
+                "group_by_strategy", default_group_by_strategy
+            )
 
-                ingr_dict["group_by_strategy"] = ingr_dict.get(
-                    "group_by_strategy", default_group_by_strategy
-                )
+            if kind == "metric":
                 fld_defn = ingr_dict.pop("field", None)
                 # SQLAlchemy ingredient with required aggregation
                 expr, datatype = builder.parse(
@@ -121,9 +121,6 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
                     return InvalidIngredient(error=error)
                 args = [expr]
             else:
-                ingr_dict["group_by_strategy"] = ingr_dict.get(
-                    "group_by_strategy", default_group_by_strategy
-                )
                 fld_defn = ingr_dict.pop("field", None)
                 buckets = ingr_dict.pop("buckets", None)
                 buckets_default_label = ingr_dict.pop("buckets_default_label", None)

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -84,7 +84,9 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
     }
     convert_datetimes_with = convert_datetimes_lookup.get(format)
 
-    if builder.drivername.startswith("mssql"):
+    if builder.drivername.startswith("mssql") or builder.drivername.startswith(
+        "snowflake"
+    ):
         # SQLServer can not use aliases in group bys and also
         # does not support date/time conversions due to an issue with pyodbc
         # parameters in queries
@@ -96,6 +98,10 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
     try:
         if kind in ("metric", "dimension"):
             if kind == "metric":
+
+                ingr_dict["group_by_strategy"] = ingr_dict.get(
+                    "group_by_strategy", default_group_by_strategy
+                )
                 fld_defn = ingr_dict.pop("field", None)
                 # SQLAlchemy ingredient with required aggregation
                 expr, datatype = builder.parse(


### PR DESCRIPTION
## Changes

This PR makes two changes

* Use group_by_strategy = direct for snowflake db. This will use expressions rather than labels in GROUP BY and ORDER BY.
* Pass group by strategy to measures so when they are used for ordering in group_by_strategy=direct, they can pass the correct expression.

## Background

Snowflake has some specific behaviors around identifiers. All identifiers are considered uppercase unless the table is constructed with a quote=True parameter. 

See this issue for some details.
https://github.com/snowflakedb/snowflake-sqlalchemy/issues/223

Even when quote=True ordering by labels will not be quoted. Here's a sample query that fails because `ORDER BY metric_goal5Completions_aol0lxp2 DESC` should be quoted as `ORDER BY "metric_goal5Completions_aol0lxp2" DESC`

```
SELECT workspace_5308302."google-analytics-metrics"."dimension2" AS dimension2,
       sum(workspace_5308302."google-analytics-metrics"."goal5Completions") AS "metric_goal5Completions_aol0lxp2",
       min(anon_1._total_count) AS _total_count
FROM workspace_5308302."google-analytics-metrics",
  (SELECT count(*) AS _total_count
   FROM
     (SELECT workspace_5308302."google-analytics-metrics"."dimension2" AS dimension2,
             sum(workspace_5308302."google-analytics-metrics"."goal5Completions") AS "metric_goal5Completions_aol0lxp2"
      FROM workspace_5308302."google-analytics-metrics"
      GROUP BY dimension2) AS anon_2) AS anon_1
GROUP BY dimension2
ORDER BY metric_goal5Completions_aol0lxp2 DESC
```

Changelog notes

v0.30.1 (2021-03-16)
-----------------------------------------
* Fix an error in ordering with mixed case columns/labels when using snowflake

