### PR TITLE
Allow count boolean expressions

### DIFF
--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -248,7 +248,7 @@ def make_grammar(columns):
     min_aggr.1: /min/i "(" num ")"
     max_aggr.1: /max/i "(" num ")"
     avg_aggr.1: /avg/i "(" num ")" | /average/i "(" num ")"
-    count_aggr.1: /count/i "(" (num | string | date | datetime | star) ")"
+    count_aggr.1: /count/i "(" (num | string | date | datetime | boolean | star) ")"
     count_distinct_aggr.1: /count_distinct/i "(" (num | string | date | datetime | boolean) ")"
     median_aggr.1: /median/i "(" num ")"
     percentile_aggr.1: /percentile\d\d?/i "(" num ")"

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -291,6 +291,7 @@ class TestSQLAlchemyBuilder(GrammarTestCase):
         min(department)                 -> str
         min(test_date)                  -> date
         count(*)                        -> num
+        count(department > "foo")       -> num
         substr(department, 5)           -> str
         substr(department, 5, 5)        -> str
         """
@@ -588,6 +589,8 @@ class TestDataTypesTable(GrammarTestCase):
         [score] between [score] and [score]                   -> datatypes.score BETWEEN datatypes.score AND datatypes.score
         [username] between "a" and "z"                        -> datatypes.username BETWEEN 'a' AND 'z'
         [username] between [department] and "z"               -> datatypes.username BETWEEN datatypes.department AND 'z'
+        count_distinct([score] > 80)                          -> count(DISTINCT (datatypes.score > 80))
+        count([score] > 80)                                   -> count(datatypes.score > 80)
         """
 
         for field, expected_sql in self.examples(good_examples):


### PR DESCRIPTION
Allow count and count_distinct expressions to be built using boolean fields or expressions

```
count([age] > 80)
```