### PR TITLE
Add support for an "and" operator in complex filters.

### DIFF
--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -369,6 +369,10 @@ class Ingredient(object):
         elif datatype == "datetime":
             value = list(map(convert_datetime, value))
 
+        if operator == "and":
+            conditions = [self.build_filter(x["value"], x["operator"]) for x in value]
+            return and_(*conditions)
+
         if operator in ("in", "notin"):
             if contains_complex_values(value):
                 # A list may contain additional operators or nones

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -436,6 +436,15 @@ class TestIngredientBuildFilter(RecipeTestCase):
                 None,
                 "foo.first IN ('horse', 'moo') OR foo.first NOT IN ('cow', 'pig')",
             ),
+            (
+                strdim,
+                [
+                    {"operator": "in", "value": [1, 2, 3]},
+                    {"operator": "notin", "value": [3, 4, 5]},
+                ],
+                "and",
+                "foo.first IN (1, 2, 3) AND foo.first NOT IN (3, 4, 5)",
+            ),
         ]
 
         baddata = [


### PR DESCRIPTION
You can do "or" easily with "in". but as far as I can tell there was no existing way to do "and".

## Changes

- in _build_vector_filter, if the operator is "and", return a SQLAlchemy `and_()` with conditions based on filters built from each value.

Question: do I need to do something with `target_role`?