### PR TITLE
Fix for compilation errors on bigquery timestamp columns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,13 @@
 Changelog
 =========
 
+v0.31.5 (2022-06-13)
+-----------------------------------------
+* Fix timestamp conversion functions in bigquery
+
 v0.31.4 (2022-04-04)
 -----------------------------------------
-*  Support `and` operator in complex filters
-
+* Support `and` operator in complex filters
 
 v0.31.3 (2022-04-04)
 -----------------------------------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ twine==3.4.2
 freezegun
 psycopg2-binary
 sqlalchemy-redshift
-pybigquery
-google-cloud-bigquery-storage
+sqlalchemy-bigquery
+google-api-core
 -e .

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -860,13 +860,13 @@ class TestDataTypesTableDatesInBigquery(TestDataTypesTableDates):
         """bigquery generates different sql for date conversions"""
         good_examples = f"""
         month([test_date]) > date("2020-12-30")          -> date_trunc(datatypes.test_date, month) > '2020-12-30'
-        month([test_datetime]) > date("2020-12-30")      -> timestamp_trunc(datatypes.test_datetime, month) > '2020-12-30'
-        date("2020-12-30") < month([test_datetime])      -> timestamp_trunc(datatypes.test_datetime, month) > '2020-12-30'
+        month([test_datetime]) > date("2020-12-30")      -> datetime(timestamp_trunc(datatypes.test_datetime, month)) > '2020-12-30'
+        date("2020-12-30") < month([test_datetime])      -> datetime(timestamp_trunc(datatypes.test_datetime, month)) > '2020-12-30'
         day([test_date]) > date("2020-12-30")            -> date_trunc(datatypes.test_date, day) > '2020-12-30'
         week([test_date]) > date("2020-12-30")           -> date_trunc(datatypes.test_date, week(monday)) > '2020-12-30'
         quarter([test_date]) > date("2020-12-30")        -> date_trunc(datatypes.test_date, quarter) > '2020-12-30'
         year([test_date]) > date("2020-12-30")           -> date_trunc(datatypes.test_date, year) > '2020-12-30'
-        date([test_datetime])                            -> timestamp_trunc(datatypes.test_datetime, day)
+        date([test_datetime])                            -> datetime(timestamp_trunc(datatypes.test_datetime, day))
         """
 
         for field, expected_sql in self.examples(good_examples):


### PR DESCRIPTION
Recipe can build filtering for TIMESTAMP fields. However, when the timestamp field was wrapped in a conversion function like `day(timestamp_fld)` which is converting the timestamp field to the nearest day, we were getting a sql compilation error. 

```
sqlalchemy.exc.DatabaseError: (google.cloud.bigquery.dbapi.exceptions.DatabaseError) 400
No matching signature for operator BETWEEN for argument types: TIMESTAMP, DATETIME, DATETIME
```

The conversion was returning a timestamp type object as far as bigquery is concerned but that annotation was missing to sqlalchemy. As a result, sqlalchemy is sending mixed types in the query. The timestamp_trunc function in sqlalchemy-bigquery is not type checked so the function return type is not annotated. 

This PR explicitly converts the expressions to return datetimes.

I tried to create a custom function for bigquery timestamp_trunc in engine_support with the appropriate type annotations but this kept creating a recursion error.