### PR TITLE
Add a utility function to make a schema

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.31.5
+current_version = 0.31.6
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.31.6 (2022-12-07)
+-----------------------------------------
+* Add a utility function make_schema
+
 v0.31.5 (2022-06-13)
 -----------------------------------------
 * Fix timestamp conversion functions in bigquery

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.31.5.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.31.6.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.31.5...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.31.6...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.31.5"
+version = release = "0.31.6"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -49,7 +49,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.31.5"
+__version__ = "0.31.6"
 
 __all__ = [
     "BadIngredient",

--- a/recipe/core.py
+++ b/recipe/core.py
@@ -162,7 +162,7 @@ class Recipe(object):
         return self
 
     @classmethod
-    def from_config(cls, shelf, obj, **kwargs):
+    def from_config(cls, shelf, spec, **kwargs):
         """
         Construct a Recipe from a plain Python dictionary.
 
@@ -181,13 +181,13 @@ class Recipe(object):
                     new[k] = d[k]
             return new
 
-        core_kwargs = subdict(obj, recipe_schema["schema"].keys())
+        core_kwargs = subdict(spec, recipe_schema["schema"].keys())
         core_kwargs = normalize_schema(recipe_schema, core_kwargs)
         core_kwargs["filters"] = [
             parse_unvalidated_condition(filter, shelf.Meta.select_from)
             if isinstance(filter, dict)
             else filter
-            for filter in obj.get("filters", [])
+            for filter in spec.get("filters", [])
         ]
         core_kwargs.update(kwargs)
         recipe = cls(shelf=shelf, **core_kwargs)
@@ -196,7 +196,7 @@ class Recipe(object):
         for ext in recipe.recipe_extensions:
             additional_schema = getattr(ext, "recipe_schema", None)
             if additional_schema is not None:
-                ext_data = subdict(obj, additional_schema.keys())
+                ext_data = subdict(spec, additional_schema.keys())
                 ext_data = normalize_dict(additional_schema, ext_data)
                 recipe = ext.from_config(ext_data)
         return recipe

--- a/recipe/exceptions.py
+++ b/recipe/exceptions.py
@@ -11,5 +11,12 @@ class InvalidColumnError(Exception):
         self.column_name = kwargs.pop("column_name", None)
         if not args:
             # default exception message
-            args = ['Invalid column "{}"'.format(self.column_name)]
+            args = [f'Invalid column "{self.column_name}"']
         super(InvalidColumnError, self).__init__(*args, **kwargs)
+
+
+class IngredientNotFoundError(KeyError):
+    """Dynamic ingredient can't be found. """
+    def __init__(self, message, ingr):
+        super().__init__(message)
+        self.ingr = ingr

--- a/recipe/exceptions.py
+++ b/recipe/exceptions.py
@@ -11,12 +11,5 @@ class InvalidColumnError(Exception):
         self.column_name = kwargs.pop("column_name", None)
         if not args:
             # default exception message
-            args = [f'Invalid column "{self.column_name}"']
+            args = ['Invalid column "{}"'.format(self.column_name)]
         super(InvalidColumnError, self).__init__(*args, **kwargs)
-
-
-class IngredientNotFoundError(KeyError):
-    """Dynamic ingredient can't be found. """
-    def __init__(self, message, ingr):
-        super().__init__(message)
-        self.ingr = ingr

--- a/recipe/schemas/__init__.py
+++ b/recipe/schemas/__init__.py
@@ -1,5 +1,4 @@
 from sureberus import schema as S
-
 from .parsed_schemas import shelf_schema
 
 # This schema is used with sureberus

--- a/recipe/utils/__init__.py
+++ b/recipe/utils/__init__.py
@@ -12,4 +12,5 @@ from .utils import (
     AttrDict,
     disaggregate,
     pad_values,
+    make_schema,
 )

--- a/recipe/utils/utils.py
+++ b/recipe/utils/utils.py
@@ -1,6 +1,7 @@
 import math
 import re
 import unicodedata
+from recipe.exceptions import IngredientNotFoundError
 
 from sqlalchemy.sql.functions import FunctionElement
 
@@ -58,3 +59,40 @@ def pad_values(values, prefix="RECIPE-DUMMY-VAL-", bin_size=11):
             return values + added_values
     else:
         return values
+
+
+def calculate_dynamic_ingredient(selections:dict, ingr:str) -> str:
+    """Convert an ingredient string from a dynamic value to a literal
+
+    If selections is {"selection": "student"}
+
+    @selection
+                    Return `student`
+    @selection2|default:"course"
+                    Return `course` (because selection2 was not found)
+    @selection|prefix:id_|default:"course"
+                    Return `id_student`
+    """
+    if not ingr.startswith("@"):
+        return ingr
+    ingredient_parts = ingr[1:].split("|")
+    ingr_name = ingredient_parts[0]
+    ingr_name = selections.get(ingr_name)
+    if isinstance(ingr_name, (list, tuple)):
+        ingr_name = ingr_name[0]
+    directives = {
+        "default": lambda ingr, default: ingr or default,
+        "prefix": lambda ingr, prefix: ingr if ingr is None else prefix + ingr,
+        "suffix": lambda ingr, suffix: ingr if ingr is None else ingr + suffix,
+    }
+    for directive in ingredient_parts[1:]:
+        directive_parts = directive.split(":")
+        directive_name = directive_parts[0]
+        if directive_name not in directives:
+            raise ValueError(f"Unknown ingredient directive: {directive_parts}")
+        ingr_name = directives[directive_name](ingr_name, *directive_parts[1:])
+
+    if not ingr_name:
+        raise IngredientNotFoundError(f"Couldn't find an ingredient based on: {ingr}\nAvailable selections: {selections.keys()}", ingr)
+
+    return ingr_name

--- a/recipe/utils/utils.py
+++ b/recipe/utils/utils.py
@@ -1,7 +1,8 @@
 import math
 import re
 import unicodedata
-from recipe.exceptions import IngredientNotFoundError
+from recipe.schemas import recipe_schema
+from sureberus import schema as S
 
 from sqlalchemy.sql.functions import FunctionElement
 
@@ -61,38 +62,10 @@ def pad_values(values, prefix="RECIPE-DUMMY-VAL-", bin_size=11):
         return values
 
 
-def calculate_dynamic_ingredient(selections:dict, ingr:str) -> str:
-    """Convert an ingredient string from a dynamic value to a literal
-
-    If selections is {"selection": "student"}
-
-    @selection
-                    Return `student`
-    @selection2|default:"course"
-                    Return `course` (because selection2 was not found)
-    @selection|prefix:id_|default:"course"
-                    Return `id_student`
-    """
-    if not ingr.startswith("@"):
-        return ingr
-    ingredient_parts = ingr[1:].split("|")
-    ingr_name = ingredient_parts[0]
-    ingr_name = selections.get(ingr_name)
-    if isinstance(ingr_name, (list, tuple)):
-        ingr_name = ingr_name[0]
-    directives = {
-        "default": lambda ingr, default: ingr or default,
-        "prefix": lambda ingr, prefix: ingr if ingr is None else prefix + ingr,
-        "suffix": lambda ingr, suffix: ingr if ingr is None else ingr + suffix,
-    }
-    for directive in ingredient_parts[1:]:
-        directive_parts = directive.split(":")
-        directive_name = directive_parts[0]
-        if directive_name not in directives:
-            raise ValueError(f"Unknown ingredient directive: {directive_parts}")
-        ingr_name = directives[directive_name](ingr_name, *directive_parts[1:])
-
-    if not ingr_name:
-        raise IngredientNotFoundError(f"Couldn't find an ingredient based on: {ingr}\nAvailable selections: {selections.keys()}", ingr)
-
-    return ingr_name
+def make_schema(recipe_extensions: list) -> dict:
+    """Make a sureberus schema to validate a recipe.from_config."""
+    schema = recipe_schema["schema"].copy()
+    for ext in recipe_extensions:
+        additional_schema = getattr(ext, "recipe_schema", {})
+        schema.update(additional_schema)
+    return S.Dict(schema=schema)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.31.5",
+    version="0.31.6",
     description="A construction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from recipe.utils import (
     replace_whitespace_with_space,
     generate_faker_seed,
     pad_values,
+    make_schema,
 )
 
 uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -220,3 +221,87 @@ class FakerAnonymizerTestCase(RecipeTestCase):
 
         assert isinstance(a("Value"), str)
         assert a("Value") == "foo moo"
+
+
+class TestMakeSchema(RecipeTestCase):
+    def test_make_schema(self):
+        s = make_schema([])
+        self.assertIsInstance(s, dict)
+        self.assertEqual(
+            s,
+            {
+                "schema": {
+                    "metrics": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "dimensions": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "filters": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "order_by": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                },
+                "type": "dict",
+                "required": True,
+            },
+        )
+
+    def test_make_schema_with_recipe_extensions(self):
+        from recipe.extensions import AutomaticFilters
+
+        # We can mixin schemas from extensions to get a combined schema
+        s = make_schema([AutomaticFilters])
+        self.assertIsInstance(s, dict)
+        self.assertEqual(
+            s,
+            {
+                "schema": {
+                    "metrics": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "dimensions": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "filters": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "order_by": {
+                        "schema": {"type": "string", "required": True},
+                        "type": "list",
+                        "required": False,
+                    },
+                    "automatic_filters": {
+                        "type": "dict",
+                        "keyschema": {"type": "string"},
+                    },
+                    "include_automatic_filter_keys": {
+                        "type": "list",
+                        "schema": {"type": "string"},
+                    },
+                    "exclude_automatic_filter_keys": {
+                        "type": "list",
+                        "schema": {"type": "string"},
+                    },
+                    "apply_automatic_filters": {"type": "boolean"},
+                },
+                "type": "dict",
+                "required": True,
+            },
+        )


### PR DESCRIPTION
This PR adds a utility function `make_schema(recipe_extensions)` that will make a sureberus schema to validate inputs to `Recipe.from_config` when a list of recipe_extensions are active. 