### PR TITLE
[JB-5152] cache parsed ingredient fields and the result of their validation in the context of a specific grammar

### DIFF
--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -1161,24 +1161,21 @@ class SQLAlchemyBuilder(object):
             self.cached_trees.get(key) if self.cached_trees is not None else None
         )
 
-        def tree_to_expression(t, v):
-            return self.tree_to_expression(
-                t,
-                v,
-                key,
-                enforce_aggregation,
-                debug,
-                convert_dates_with,
-                convert_datetimes_with,
-            )
+        extra_args = (
+            key,
+            enforce_aggregation,
+            debug,
+            convert_dates_with,
+            convert_datetimes_with,
+        )
 
         if cache_result is None:
             (tree, validator) = self._parse(text, forbid_aggregation)
-            return tree_to_expression(tree, validator)
+            return self.tree_to_expression(tree, validator, *extra_args)
         else:
             (tree, validator) = cache_result
             try:
-                return tree_to_expression(tree, validator)
+                return self.tree_to_expression(tree, validator, *extra_args)
             except Exception:
                 SLOG.exception("cached-tree-to-validator-error")
                 # If we get ANY error while dealing with the cached ingredient data, we
@@ -1188,7 +1185,7 @@ class SQLAlchemyBuilder(object):
                 # details encoded into the cached data).
                 del self.cached_trees[key]
                 (tree, validator) = self._parse(text, forbid_aggregation)
-                return tree_to_expression(tree, validator)
+                return self.tree_to_expression(tree, validator, *extra_args)
 
     def _parse(self, text, forbid_aggregation):
         tree = self.parser.parse(text, start="col")

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -1135,7 +1135,7 @@ class SQLAlchemyBuilder(object):
                 DataType: The datatype of the expression (bool, date, datetime, num, str)
         """
         key = f"sqlalchemy-expr-{text}-{forbid_aggregation}-{enforce_aggregation}-{convert_dates_with}-{convert_datetimes_with}"
-        result = self.cached_exprs is not None and self.cached_exprs.get(key)
+        result = self.cached_exprs.get(key) if self.cached_exprs is not None else None
         if result is not None:
             return (loads(result[0], self.selectable.metadata), result[1])
         tree = self.parser.parse(text, start="col")

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -226,6 +226,8 @@ class Shelf(object):
         selectable,
         ingredient_constructor=ingredient_from_validated_dict,
         metadata=None,
+        *,
+        ingredient_cache=None,
     ):
         """Create a shelf using a dict shelf definition.
 
@@ -265,7 +267,9 @@ class Shelf(object):
                     d[k] = ingredient_constructor(v, selectable)
                 else:
                     if builder is None:
-                        builder = SQLAlchemyBuilder.get_builder(selectable=selectable)
+                        builder = SQLAlchemyBuilder.get_builder(
+                            selectable=selectable, cache=ingredient_cache
+                        )
                     d[k] = ingredient_constructor(v, selectable, builder=builder)
             else:
                 d[k] = ingredient_constructor(v, selectable)

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -279,6 +279,8 @@ class Shelf(object):
                     d[k].error["extra"] = {}
                 d[k].error["extra"]["ingredient_name"] = k
         shelf = cls(d, select_from=selectable)
+        if builder and ingredient_cache is not None:
+            builder.save_cache()
 
         return shelf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sureberus==0.14.0
 dateparser==1.1.1
 attrs==19.3.0
 lark==1.1.2
+structlog>=19.2.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install = [
     'dateparser>=1.1.1',
     'attrs',
     'lark',
+    'structlog',
 ]
 # yapf: enable
 

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -4,9 +4,13 @@ Test recipes built from yaml files in the ingredients directory.
 """
 
 import os
+import time
+import warnings
+from copy import deepcopy
 from datetime import date
 
 from dateutil.relativedelta import relativedelta
+import yaml
 
 from recipe import AutomaticFilters, BadIngredient, InvalidIngredient, Shelf
 from tests.test_base import RecipeTestCase
@@ -26,9 +30,9 @@ class ConfigTestBase(RecipeTestCase):
         contents = open(fn).read()
         return self.shelf_from_yaml(contents, selectable)
 
-    def shelf_from_yaml(self, yaml_config, selectable):
+    def shelf_from_yaml(self, yaml_config, selectable, **kwargs):
         """Create a shelf directly from configuration"""
-        return Shelf.from_validated_yaml(yaml_config, selectable)
+        return Shelf.from_validated_yaml(yaml_config, selectable, **kwargs)
 
 
 class TestNullHandling(ConfigTestBase):
@@ -1346,6 +1350,100 @@ count_username:
             GROUP BY username) AS anon_1""",
         )
         self.assertRecipeCSV(recipe2, "count_star,count_username\n3,3\n")
+
+    def test_cache(self):
+        cache = Cache()
+        self.shelf_from_yaml(
+            """
+            username: {kind: Dimension, field: username}
+            count_star: {kind: Metric, field: count(*)}
+            convertdate: {kind: Dimension, field: month(test_date)}
+            """,
+            self.scores_with_nulls_table,
+            ingredient_cache=cache,
+        )
+        self.assertEqual(len(cache), 1)
+        ingredients = cache[list(cache.keys())[0]]
+        self.assertEqual(len(ingredients), 3)
+
+    def test_selectables_cache(self):
+        """Test cache when the selectable is a recipe"""
+        cache = Cache()
+        shelf = self.shelf_from_yaml(
+            """
+            username: {kind: Dimension, field: username}
+            count_star: {kind: Metric, field: 'count(*)'}
+            """,
+            self.scores_with_nulls_table,
+            ingredient_cache=cache,
+        )
+        recipe = self.recipe(shelf=shelf).dimensions("username").metrics("count_star")
+
+        self.assertEqual(len(cache), 1)
+        first_cache_key = list(cache.keys())[0]
+        self.assertEqual(len(cache[first_cache_key]), 2)
+
+        # Build a recipe using the first recipe
+        self.shelf_from_yaml(
+            "count_username: {kind: Metric, field: 'count(username)'}",
+            recipe,
+            ingredient_cache=cache,
+        )
+
+        self.assertEqual(len(cache), 2)
+        second_cache_key = list(cache.keys() - {first_cache_key})[0]
+        self.assertEqual(len(cache[second_cache_key]), 1)
+
+    def test_cache_is_faster(self):
+        yml = """
+        username: {kind: Dimension, field: username}
+        count_star: {kind: Metric, field: "count(*)"}
+        convertdate: {kind: Dimension, field: "month(test_date)"}
+        strings: {kind: Dimension, field: "string(test_date)+string(score)"}
+        total_nulls: {kind: Metric, field: "count_distinct(if(score IS NULL, username))"}
+        chip_nulls: {kind: Metric, field: 'sum(if(score IS NULL and username = "chip",1,0))'}
+        user_null_counter: {kind: Metric, field: 'if(username IS NULL, 1, 0)'}
+        chip_or_nulls: {kind: Metric, field: 'sum(if(score IS NULL OR (username = "chip"),1,0))'}
+        simple_math: {kind: Metric, field: "@count_star +  @total_nulls   + @chip_nulls"}
+        refs_division: {kind: Metric, field: "@count_star / 100.0"}
+        refs_as_denom: {kind: Metric, field: "12 / @count_star"}
+        math: {kind: Metric, field: "(@count_star / @count_star) + (5.0 / 2.0)"}
+        parentheses: {kind: Metric, field: "@count_star / (@count_star + (12.0 / 2.0))"}
+        """
+        config = yaml.safe_load(yml)
+        uncached_start = time.time()
+        COUNT = 2
+        for i in range(COUNT):
+            Shelf.from_config(deepcopy(config), self.scores_with_nulls_table)
+        uncached_duration = time.time() - uncached_start
+
+        cache = Cache()
+        # prime the cache
+        Shelf.from_config(
+            deepcopy(config), self.scores_with_nulls_table, ingredient_cache=cache
+        )
+        cached_start = time.time()
+        for i in range(COUNT):
+            Shelf.from_config(
+                deepcopy(config), self.scores_with_nulls_table, ingredient_cache=cache
+            )
+        cached_duration = time.time() - cached_start
+
+        # usually this performance is somewhere between 100 and 1000 times faster, but
+        # we should be conservative here
+        if not cached_duration < (uncached_duration / 50):
+            # let's just warn instead of actually failing the test suite
+            warnings.warn(
+                "cache was not fast enough: "
+                f"cached duration {cached_duration}, "
+                f"uncached duration: {uncached_duration}",
+                UserWarning,
+            )
+
+
+class Cache(dict):
+    def set(self, k, v):
+        self[k] = v
 
 
 class TestParsedIntellligentDates(ConfigTestBase):

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1440,7 +1440,6 @@ count_username:
                 UserWarning,
             )
 
-
     def test_broken_cache(self):
         """If the cache has corrupt data, it is ignored"""
         cache = Cache()


### PR DESCRIPTION
## Changes

### LARK_CACHE

Change the BUILDER_CACHE into a LARK_CACHE, which caches Lark instances in-memory based on the grammar definition as a key. This is a minor improvement in certain situations where there are multiple copies of an identical table: instead of caching based on the identity of the selectable, we now cache based on the grammar that the table generates. (generating the grammar based on the table is pretty trivial)

This doesn't go as far as it could, because this cache is in-process, meaning:
- it can't be shared with other servers
- it can't be shared with other processes on the same server
- it gets cycled out regularly as JB's nginx/uwsgi configuration forcefully recycles processes.

Unfortunately, we can't *serialize* the Lark processor using any of its `.save()`/`.load()` or `cache` functionality, because Lark doesn't support serializing Earley grammars, only LALR grammars.

### ingredient cache

Switch out the @functools.lru_cache with a parameterized cache that we put the `Tree` and `SQLAlchemyValidator` instances in. If, e.g., a django cache is passed in as the `ingredient_cache` argument to `Shelf.from_config`, then the Tree and SQLAlchemyValidator objects will be pickled into the cache.

I decided not to use SQLAlchemy's expression serialization/deserialization, because:

- those expressions encode the table names. This means we can't share the cached expressions across multiple tables with identical structure (common for stuff like our movie_trends apps). It also caused trouble with using Recipes (subqueries) as selectables.
- the vast majority of the time in constructing ingredient expressions is just in parsing and validating, not in SQLAlchemy expression builder. I didn't see any noticeable consistent difference between caching trees/validators vs caching the SQLAlchemy expression.


## Future performance work

1. It seems that if we switched from Earley to LALR, our parsing performance would probably be much better, at least according to the Lark docs. It would *also* allow us to cache the Lark instances cross-process.
2. Just having a single Lark grammar (with free-variable checking done in a *validator* instead of in the *parser*) would also totally make caching Lark instances moot
3. I believe we may have *other* performance problems in Shelf.from_config, like maybe in the normalize_schema call:

![image](https://user-images.githubusercontent.com/227068/213302499-ee445fcb-a67f-4b96-8c68-48474b4bdb62.png)


I don't know how accurate this Sentry graph is, but it seems to indicate that the time between loading and saving the ingredient cache is incredibly short (this is where all the parsing would be, which is cached out, but the SQLAlchemy expression building is still there and looks very fast), whereas there's a long span *before* that, and the only thing that it seems like it could be is the call to normalize_schema in Shelf.from_config. We should probably figure out a way to save the result of normalize_schema 

