### PR TITLE
Ensure datatypes are always str

### DIFF
--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -331,6 +331,7 @@ class SQLALchemyValidator(Visitor):
             dt = self._data_type(tree.children[0])
         else:
             dt = tree.data
+        dt = str(dt)  # Convert Tokens to strings
         if dt == "datetime_end":
             dt = "datetime"
         elif dt == "string":

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -299,6 +299,7 @@ class TestSQLAlchemyBuilder(GrammarTestCase):
 
         for field, expected_data_type in self.examples(good_examples):
             _, data_type = self.builder.parse(field)
+            self.assertIs(type(data_type), str)
             self.assertEqual(data_type, expected_data_type)
 
     def test_disallow_literals(self):


### PR DESCRIPTION
## Changes

Sometimes datatypes of ingredients would be an instance of `Token`. This usually didn't cause a problem because *somehow* Token objects are JSON serializable (~does lark monkeypatch the json module? I still haven't figured that out~ turns out `Token` is a subclass of `str`).

However, this is still undesirable since we're leaking implementation details out of Recipe about its use of Lark and it can cause confusing behavior