### PR TITLE
Step 1: Remove duplicated {dim}_id in response rows

### DIFF
--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -656,10 +656,9 @@ class Dimension(Ingredient):
         a row
         """
         # This will format the value field
-        for extra in super(Dimension, self).cauldron_extras:
-            yield extra
-
-        yield self.id + "_id", lambda row: getattr(row, self.id_prop)
+        yield from super(Dimension, self).cauldron_extras
+        if "id" not in self.role_keys:
+            yield (f"{self.id}_id", lambda row: getattr(row, self.id_prop))
 
     def make_column_suffixes(self):
         """Make sure we have the right column suffixes. These will be appended
@@ -671,20 +670,19 @@ class Dimension(Ingredient):
             value_suffix = ""
 
         return tuple(
-            value_suffix if role == "value" else "_" + role for role in self.role_keys
+            value_suffix if role == "value" else f"_{role}" for role in self.role_keys
         )
 
     @property
     def id_prop(self):
         """The label of this dimensions id in the query columns"""
         if "id" in self.role_keys:
-            return self.id + "_id"
-        else:
+            return f"{self.id}_id"
             # Use the value dimension
-            if self.formatters:
-                return self.id + "_raw"
-            else:
-                return self.id
+        if self.formatters:
+            return f"{self.id}_raw"
+        else:
+            return self.id
 
 
 class IdValueDimension(Dimension):

--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -189,7 +189,7 @@ class Ingredient(object):
             )
 
     @property
-    def query_columns(self):
+    def labeled_columns(self):
         """Yield labeled columns to be used as a select in a query."""
         self._labels = []
         for column, suffix in zip(self.columns, self.make_column_suffixes()):
@@ -206,7 +206,7 @@ class Ingredient(object):
         """
         # Ensure the labels are generated
         if not self._labels:
-            list(self.query_columns)
+            list(self.labeled_columns)
 
         if self.group_by_strategy == "labels":
             if self.ordering == "desc":
@@ -639,7 +639,7 @@ class Dimension(Ingredient):
     def group_by(self):
         # Ensure the labels are generated
         if not self._labels:
-            list(self.query_columns)
+            list(self.labeled_columns)
 
         if self.group_by_strategy == "labels":
             return [lbl for _, lbl in zip(self._group_by, self._labels)]

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -361,8 +361,8 @@ class Shelf(object):
                     )
                     raise InvalidColumnError(error_msg, column_name=column_name)
                 raise BadIngredient(str(ingredient.error))
-            if ingredient.query_columns:
-                columns.extend(ingredient.query_columns)
+            if ingredient.labeled_columns:
+                columns.extend(ingredient.labeled_columns)
             if ingredient.group_by:
                 group_bys.extend(ingredient.group_by)
             if ingredient.filters:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1100,16 +1100,16 @@ class PaginateTestCase(RecipeTestCase):
         self.assertRecipeCSV(
             recipe,
             """
-            idvalue_state_id,idvalue_state,pop2000,idvalue_state_id
-            Tennessee,State:Tennessee,5685230,Tennessee
+            idvalue_state_id,idvalue_state,pop2000
+            Tennessee,State:Tennessee,5685230
             """,
         )
 
         self.assertRecipeCSV(
             recipe,
             """
-            idvalue_state_id,idvalue_state,pop2000,idvalue_state_id
-            Tennessee,State:Tennessee,5685230,Tennessee
+            idvalue_state_id,idvalue_state,pop2000
+            Tennessee,State:Tennessee,5685230
             """,
         )
 

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -658,9 +658,7 @@ class TestDimension(RecipeTestCase):
             id="moo",
         )
         extras = list(d.cauldron_extras)
-        self.assertEqual(len(extras), 1)
-        # id gets injected in the response
-        self.assertEqual(extras[0][0], "moo_id")
+        self.assertEqual(len(extras), 0)
         self.assertEqual(d.role_keys, ["id", "value", "age"])
         self.assertEqual(len(d.group_by), 3)
         self.assertEqual(len(d.columns), 3)
@@ -726,21 +724,18 @@ class IdValueDimensionTestCase(RecipeTestCase):
             self.basic_table.c.first, self.basic_table.c.last, id="moo"
         )
         extras = list(d.cauldron_extras)
-        self.assertEqual(len(extras), 1)
-        # id gets injected in the response
-        self.assertEqual(extras[0][0], "moo_id")
+        self.assertEqual(len(extras), 0)
 
         d = IdValueDimension(
             self.basic_table.c.first,
             self.basic_table.c.last,
             id="moo",
-            formatters=[lambda x: x + "moo"],
+            formatters=[lambda x: f"{x}moo"],
         )
         extras = list(d.cauldron_extras)
-        self.assertEqual(len(extras), 2)
+        self.assertEqual(len(extras), 1)
         # formatted value and id gets injected in the response
         self.assertEqual(extras[0][0], "moo")
-        self.assertEqual(extras[1][0], "moo_id")
 
     def test_dimension_roles_cauldron_extras(self):
         """Creating a dimension with roles performs the same as
@@ -749,21 +744,18 @@ class IdValueDimensionTestCase(RecipeTestCase):
             self.basic_table.c.first, id_expression=self.basic_table.c.last, id="moo"
         )
         extras = list(d.cauldron_extras)
-        self.assertEqual(len(extras), 1)
-        # id gets injected in the response
-        self.assertEqual(extras[0][0], "moo_id")
+        self.assertEqual(len(extras), 0)
 
         d = Dimension(
             self.basic_table.c.first,
             id_expression=self.basic_table.c.last,
             id="moo",
-            formatters=[lambda x: x + "moo"],
+            formatters=[lambda x: f"{x}moo"],
         )
         extras = list(d.cauldron_extras)
-        self.assertEqual(len(extras), 2)
+        self.assertEqual(len(extras), 1)
         # formatted value and id gets injected in the response
         self.assertEqual(extras[0][0], "moo")
-        self.assertEqual(extras[1][0], "moo_id")
 
 
 class TestLookupDimension(RecipeTestCase):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -66,9 +66,9 @@ GROUP BY firstlast_id,
         self.assertRecipeCSV(
             recipe,
             """
-            firstlast_id,firstlast,age,firstlast_id
-            hi,fred,10,hi
-            hi,there,5,hi
+            firstlast_id,firstlast,age
+            hi,fred,10
+            hi,there,5
             """,
         )
 
@@ -95,9 +95,9 @@ GROUP BY d_id,
         self.assertRecipeCSV(
             recipe,
             """
-            d_id,d,d_age,age,d_id
-            hi,fred,10,10,hi
-            hi,there,5,5,hi
+            d_id,d,d_age,age
+            hi,fred,10,10
+            hi,there,5,5
             """,
         )
 
@@ -127,9 +127,9 @@ GROUP BY d_id,
         self.assertRecipeCSV(
             recipe,
             """
-            d_id,d_raw,d_age,age,d,d_id
-            hi,fred,10,10,DEFAULT,hi
-            hi,there,5,5,DEFAULT,hi
+            d_id,d_raw,d_age,age,d
+            hi,fred,10,10,DEFAULT
+            hi,there,5,5,DEFAULT
             """,
         )
 

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -982,17 +982,17 @@ ORDER BY state_raw""",
         self.assertRecipeCSV(
             recipe,
             """
-            state_idval_id,state_idval,avgage,state_idval_id
-            5033,Tennessee,84.0,5033
-            5562,Tennessee,83.0,5562
-            6452,Tennessee,82.0,6452
-            7322,Tennessee,81.0,7322
-            8598,Tennessee,80.0,8598
-            9583,Tennessee,79.0,9583
-            10501,Tennessee,84.0,10501
-            10672,Tennessee,78.0,10672
-            11141,Tennessee,83.0,11141
-            11168,Tennessee,77.0,11168
+            state_idval_id,state_idval,avgage
+            5033,Tennessee,84.0
+            5562,Tennessee,83.0
+            6452,Tennessee,82.0
+            7322,Tennessee,81.0
+            8598,Tennessee,80.0
+            9583,Tennessee,79.0
+            10501,Tennessee,84.0
+            10672,Tennessee,78.0
+            11141,Tennessee,83.0
+            11168,Tennessee,77.0
             """,
         )
 


### PR DESCRIPTION
This PR renames ingredient.query_columns to a more descriptive ingredient.labeled_columns.

Second, this PR fixes a bug wherein dimensions that already had an id expression were adding two properties to each response row named after the dimension id.

The first property was created by sqlalchemy and the second is added by the "enchant" process where we add extra properties to each response row. 

This doesn't cause a problem when returning lightweightnamedtuple but will cause us problems when we eventually upgrade to sqlalchemy 2