### PR TITLE
Step 4: Refactor ingredient construction

### DIFF
--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -110,6 +110,7 @@ def convert_filter(builder: SQLAlchemyBuilder, ingr_dict: dict, builder_kwargs: 
         expr, datatype = builder.parse(
             filt_expression, forbid_aggregation=True, **builder_kwargs
         )
+        # TODO: We should raise visible error here rather than ignoring non-bool.
         if datatype == "bool":
             ingr_dict["filters"] = [expr]
 

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -1,6 +1,6 @@
 """Convert parsed trees into SQLAlchemy objects """
 from datetime import date
-
+from .builders import SQLAlchemyBuilder
 from lark.exceptions import GrammarError, LarkError
 
 from recipe.exceptions import BadIngredient
@@ -38,7 +38,7 @@ def _convert_bucket_to_field(field, bucket, buckets_default_label, builder):
         try:
             # The expression may not contain aggregations
             builder.parse(cond, forbid_aggregation=True)
-        except:
+        except Exception:
             cond = f"{field} {cond}"
             # Ensure this is parsable
             builder.parse(cond, forbid_aggregation=True)
@@ -58,7 +58,107 @@ def _convert_bucket_to_field(field, bucket, buckets_default_label, builder):
     return "if(" + ",".join(parts) + ")", "if(" + ",".join(order_by_parts) + ")"
 
 
-def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
+def get_convert_dates(format: str):
+    """If a format only shows years or months, wrap dates in a conversion in the builder"""
+    if not isinstance(format, str):
+        return
+    if format == "%Y":
+        return "year_conv"
+    # A format for months but not days
+    elif (
+        "%B" in format and "%Y" in format and "%-d" not in format and "%d" not in format
+    ):
+        return "month_conv"
+
+
+def get_convert_datetimes(format: str):
+    """If a format only shows years or months, wrap datetimes in a conversion in the builder"""
+    if not isinstance(format, str):
+        return
+    if format == "%Y":
+        return "dt_year_conv"
+    # A format for months but not days
+    elif (
+        "%B" in format and "%Y" in format and "%-d" not in format and "%d" not in format
+    ):
+        return "dt_month_conv"
+    elif "%H" not in format:
+        return "dt_day_conv"
+
+
+def convert_quickselects(
+    builder: SQLAlchemyBuilder, ingr_dict: dict, builder_kwargs: dict
+):
+    """Convert quickselects from expressions to an object with name, expression"""
+    if "quickselects" in ingr_dict:
+        parsed_quickselects = []
+        for qs in ingr_dict.pop("quickselects", []):
+            condition_defn = qs.get("condition")
+            expr, _ = builder.parse(
+                condition_defn, forbid_aggregation=True, **builder_kwargs
+            )
+            parsed_quickselects.append({"name": qs["name"], "condition": expr})
+        ingr_dict["quickselects"] = parsed_quickselects
+
+
+def convert_filter(builder: SQLAlchemyBuilder, ingr_dict: dict, builder_kwargs: dict):
+    """If a filter property exists, validate that it is a boolean expression and add it
+    to the ingredient filters. Silently ignore if we return the wrong datatype."""
+    if "filter" in ingr_dict:
+        filt_expression = ingr_dict.pop("filter")
+
+        expr, datatype = builder.parse(
+            filt_expression, forbid_aggregation=True, **builder_kwargs
+        )
+        if datatype == "bool":
+            ingr_dict["filters"] = [expr]
+
+
+def convert_buckets_to_field_defn(
+    builder: SQLAlchemyBuilder, ingr_dict: dict, fld_defn: str, builder_kwargs: dict
+):
+    """If a buckets key exists, convert it to an expression, add
+    the order_by to extra_fields.
+    """
+    buckets = ingr_dict.pop("buckets", None)
+    buckets_default_label = ingr_dict.pop("buckets_default_label", None)
+    if buckets:
+        fld_defn, order_by_fld = _convert_bucket_to_field(
+            fld_defn, buckets, buckets_default_label, builder
+        )
+        if "extra_fields" not in ingr_dict:
+            ingr_dict["extra_fields"] = []
+        ingr_dict["extra_fields"].append(
+            {"name": "order_by_expression", "field": order_by_fld}
+        )
+    return fld_defn
+
+
+def convert_extra_fields(
+    builder: SQLAlchemyBuilder, ingr_dict: dict, builder_kwargs: dict
+):
+    """
+    Dimensions may contain extra expressions in the extra_fields list.
+
+    Convert extra fields to sqlalchemy expressions and add them directly to
+    the kwargs, saving datatypes in datatype_by_role
+    """
+    for extra_fld in ingr_dict.pop("extra_fields", []):
+        # Extra_fields will be dicts with two keys
+        # name and field
+        raw_role = extra_fld.get("name")
+        role = raw_role.rstrip("_expression")
+
+        expr, datatype = builder.parse(
+            extra_fld.get("field"), forbid_aggregation=True, **builder_kwargs
+        )
+        ingr_dict["datatype_by_role"]["role"] = datatype
+        ingr_dict[raw_role] = expr
+
+
+def create_ingredient_from_parsed(
+    ingr_dict: dict, builder: SQLAlchemyBuilder, debug: bool = False
+):
     """Create an ingredient from config version 2 object ."""
     kind = ingr_dict.pop("kind", "metric")
     IngredientClass = ingredient_class_for_name(kind.title())
@@ -67,22 +167,20 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
 
     args = []
 
-    # For some formats, we will automatically convert dates
-    format = ingr_dict.get("format")
-    if isinstance(format, str) and format.startswith("<") and format.endswith(">"):
-        format = format[1:-1]
-    convert_dates_lookup = {"%Y": "year_conv", "%B %Y": "month_conv"}
-    convert_dates_with = convert_dates_lookup.get(format)
-    convert_datetimes_lookup = {
-        "%Y": "dt_year_conv",
-        "%B %Y": "dt_month_conv",
-        "%B %-d, %Y": "dt_day_conv",
-        "%-d %b %Y": "dt_day_conv",
-        "%-m/%-d/%Y": "dt_day_conv",
-        "%B %-d, %Y": "dt_day_conv",
-        "%-m-%-d-%Y": "dt_day_conv",
+    clean_format = ingr_dict.get("format")
+    if (
+        isinstance(clean_format, str)
+        and clean_format.startswith("<")
+        and clean_format.endswith(">")
+    ):
+        clean_format = clean_format[1:-1]
+
+    # For some formats, we will automatically convert dates to year or month in the builder
+    builder_kwargs = {
+        "debug": debug,
+        "convert_dates_with": get_convert_dates(clean_format),
+        "convert_datetimes_with": get_convert_datetimes(clean_format),
     }
-    convert_datetimes_with = convert_datetimes_lookup.get(format)
 
     if builder.drivername.startswith("mssql") or builder.drivername.startswith(
         "snowflake"
@@ -96,107 +194,58 @@ def create_ingredient_from_parsed(ingr_dict, builder, debug=False):
         default_group_by_strategy = "labels"
 
     try:
-        if kind in ("metric", "dimension"):
+        if kind == "metric":
             ingr_dict["group_by_strategy"] = ingr_dict.get(
                 "group_by_strategy", default_group_by_strategy
             )
 
-            if kind == "metric":
-                fld_defn = ingr_dict.pop("field", None)
-                # SQLAlchemy ingredient with required aggregation
-                expr, datatype = builder.parse(
-                    fld_defn,
-                    enforce_aggregation=True,
-                    debug=debug,
-                    convert_dates_with=convert_dates_with,
-                    convert_datetimes_with=convert_datetimes_with,
-                )
-                # Save the data type in the ingredient
-                ingr_dict["datatype"] = datatype
-                if datatype != "num":
-                    error = {
-                        "type": "Can not parse field",
-                        "extra": {"details": "A string can not be aggregated"},
-                    }
-                    return InvalidIngredient(error=error)
-                args = [expr]
-            else:
-                fld_defn = ingr_dict.pop("field", None)
-                buckets = ingr_dict.pop("buckets", None)
-                buckets_default_label = ingr_dict.pop("buckets_default_label", None)
-                if buckets:
-                    fld_defn, order_by_fld = _convert_bucket_to_field(
-                        fld_defn, buckets, buckets_default_label, builder
-                    )
-                    if "extra_fields" not in ingr_dict:
-                        ingr_dict["extra_fields"] = []
-                    ingr_dict["extra_fields"].append(
-                        {"name": "order_by_expression", "field": order_by_fld}
-                    )
-                expr, datatype = builder.parse(
-                    fld_defn,
-                    forbid_aggregation=True,
-                    debug=debug,
-                    convert_dates_with=convert_dates_with,
-                    convert_datetimes_with=convert_datetimes_with,
-                )
-                # Save the data type in the ingredient
-                ingr_dict["datatype"] = datatype
-                args = [expr]
+            fld_defn = ingr_dict.pop("field", None)
+            # SQLAlchemy ingredient with required aggregation
+            expr, datatype = builder.parse(
+                fld_defn, enforce_aggregation=True, **builder_kwargs
+            )
+            # Save the data type in the ingredient
+            ingr_dict["datatype"] = datatype
+            if datatype != "num":
+                error = {
+                    "type": "Can not parse field",
+                    "extra": {"details": "A string can not be aggregated"},
+                }
+                return InvalidIngredient(error=error)
 
-                # Convert extra fields to sqlalchemy expressions and add them directly to
-                # the kwargs, saving datatypes
-                datatype_by_role = {"value": datatype}
-                for extra in ingr_dict.pop("extra_fields", []):
-                    raw_role = extra.get("name")
-                    if raw_role.endswith("_expression"):
-                        # Remove _expression to get the role
-                        role = raw_role[:-11]
-                    else:
-                        role = raw_role
+            convert_filter(builder, ingr_dict, builder_kwargs)
+            convert_quickselects(builder, ingr_dict, builder_kwargs)
+            args = [expr]
 
-                    expr, datatype = builder.parse(
-                        extra.get("field"),
-                        forbid_aggregation=True,
-                        debug=debug,
-                        convert_dates_with=convert_dates_with,
-                        convert_datetimes_with=convert_datetimes_with,
-                    )
-                    datatype_by_role[role] = datatype
-                    ingr_dict[raw_role] = expr
-                ingr_dict["datatype_by_role"] = datatype_by_role
+        elif kind == "dimension":
+            fld_defn = ingr_dict.pop("field", None)
+            fld_defn = convert_buckets_to_field_defn(
+                builder, ingr_dict, fld_defn, builder_kwargs
+            )
 
-            parsed_quickselects = []
-            for qs in ingr_dict.pop("quickselects", []):
-                condition_defn = qs.get("condition")
-                expr, _ = builder.parse(
-                    condition_defn,
-                    forbid_aggregation=True,
-                    debug=debug,
-                    convert_dates_with=convert_dates_with,
-                    convert_datetimes_with=convert_datetimes_with,
-                )
-                parsed_quickselects.append({"name": qs["name"], "condition": expr})
-            ingr_dict["quickselects"] = parsed_quickselects
+            expr, datatype = builder.parse(
+                fld_defn, forbid_aggregation=True, **builder_kwargs
+            )
+            # Save the data type in the ingredient
+            ingr_dict["datatype"] = datatype
+            args = [expr]
+            ingr_dict["datatype_by_role"] = {"value": datatype}
+
+            convert_extra_fields(builder, ingr_dict, builder_kwargs)
+            convert_filter(builder, ingr_dict, builder_kwargs)
+            convert_quickselects(builder, ingr_dict, builder_kwargs)
 
         elif kind == "filter":
             condition_defn = ingr_dict.get("condition")
-            expr, _ = builder.parse(
-                condition_defn,
-                forbid_aggregation=True,
-                debug=debug,
-                convert_dates_with=convert_dates_with,
-                convert_datetimes_with=convert_datetimes_with,
+            expr, datatype = builder.parse(
+                condition_defn, forbid_aggregation=True, **builder_kwargs
             )
             args = [expr]
+
         elif kind == "having":
             condition_defn = ingr_dict.get("condition")
-            expr, _ = builder.parse(
-                condition_defn,
-                forbid_aggregation=False,
-                debug=debug,
-                convert_dates_with=convert_dates_with,
-                convert_datetimes_with=convert_datetimes_with,
+            expr, datatype = builder.parse(
+                condition_defn, forbid_aggregation=False, **builder_kwargs
             )
             args = [expr]
 

--- a/recipe/schemas/parsed_constructors.py
+++ b/recipe/schemas/parsed_constructors.py
@@ -110,9 +110,12 @@ def convert_filter(builder: SQLAlchemyBuilder, ingr_dict: dict, builder_kwargs: 
         expr, datatype = builder.parse(
             filt_expression, forbid_aggregation=True, **builder_kwargs
         )
-        # TODO: We should raise visible error here rather than ignoring non-bool.
         if datatype == "bool":
             ingr_dict["filters"] = [expr]
+        else:
+            raise BadIngredient(
+                f"filter: '{filt_expression}' has data type '{datatype}'. It must must be boolean."
+            )
 
 
 def convert_buckets_to_field_defn(

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -186,7 +186,8 @@ ingredient_schema = S.Dict(
 strict_metric_schema = S.Dict(
     allow_unknown=False,
     schema={
-        "_version": S.String(default="2"),
+        # _version is deprecated.
+        "_version": S.String(required=False),
         "_shelf_meta": S.Dict(required=False),
         "icon": S.String(required=False),
         "_meta": S.Dict(required=False),
@@ -203,7 +204,8 @@ strict_metric_schema = S.Dict(
 strict_dimension_schema = S.Dict(
     allow_unknown=False,
     schema={
-        "_version": S.String(default="2"),
+        # _version is deprecated.
+        "_version": S.String(required=False),
         "_shelf_meta": S.Dict(required=False),
         "icon": S.String(required=False),
         "_meta": S.Dict(required=False),
@@ -230,7 +232,8 @@ strict_dimension_schema = S.Dict(
 strict_filter_schema = S.Dict(
     allow_unknown=False,
     schema={
-        "_version": S.String(default="2"),
+        # This _version is deprecated.
+        "_version": S.String(required=False),
         "_shelf_meta": S.Dict(required=False),
         "condition": field_schema,
     },
@@ -239,7 +242,8 @@ strict_filter_schema = S.Dict(
 strict_having_schema = S.Dict(
     allow_unknown=False,
     schema={
-        "_version": S.String(default="2"),
+        # _version is deprecated.
+        "_version": S.String(required=False),
         "_shelf_meta": S.Dict(required=False),
         "condition": field_schema,
     },

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -111,18 +111,12 @@ def _lowercase_kind(value):
 
 
 def _save_raw_config(value):
-    """Save the original config excluding _config and _meta """
+    """Save the original config excluding _config and _meta"""
     config = deepcopy(value)
     config.pop("_config", None)
     config.pop("_neta", None)
     value["_config"] = config
     return value
-
-
-def add_version(v):
-    # Add version to a parsed ingredient
-    v["_version"] = "2"
-    return v
 
 
 # A field that may OR MAY NOT contain an aggregation.
@@ -185,7 +179,6 @@ ingredient_schema = S.Dict(
         default_choice="metric",
     ),
     coerce=_chain(_lowercase_kind, _save_raw_config),
-    coerce_post=add_version,
     registry={},
 )
 
@@ -198,6 +191,7 @@ strict_metric_schema = S.Dict(
         "icon": S.String(required=False),
         "_meta": S.Dict(required=False),
         "_config": S.Dict(required=False),
+        "filter": S.String(required=False),
         "singular": S.String(required=False),
         "plural": S.String(required=False),
         "field": field_schema,
@@ -214,6 +208,7 @@ strict_dimension_schema = S.Dict(
         "icon": S.String(required=False),
         "_meta": S.Dict(required=False),
         "_config": S.Dict(required=False),
+        "filter": S.String(required=False),
         "singular": S.String(required=False),
         "plural": S.String(required=False),
         "field": field_schema,
@@ -264,7 +259,6 @@ strict_ingredient_schema = S.Dict(
         default_choice="metric",
     ),
     coerce=_chain(_lowercase_kind, _save_raw_config),
-    coerce_post=add_version,
     registry={},
 )
 

--- a/recipe/schemas/parsed_schemas.py
+++ b/recipe/schemas/parsed_schemas.py
@@ -211,6 +211,7 @@ strict_dimension_schema = S.Dict(
         "_meta": S.Dict(required=False),
         "_config": S.Dict(required=False),
         "filter": S.String(required=False),
+        "date_aggregation": S.String(required=False, allowed=["year", "month", "day"]),
         "singular": S.String(required=False),
         "plural": S.String(required=False),
         "field": field_schema,

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -262,15 +262,11 @@ class Shelf(object):
 
         for k, v in validated_shelf.items():
             if ingredient_constructor == ingredient_from_validated_dict:
-                version = str(v.get("_version", "1"))
-                if version == "1":
-                    d[k] = ingredient_constructor(v, selectable)
-                else:
-                    if builder is None:
-                        builder = SQLAlchemyBuilder.get_builder(
-                            selectable=selectable, cache=ingredient_cache
-                        )
-                    d[k] = ingredient_constructor(v, selectable, builder=builder)
+                if builder is None:
+                    builder = SQLAlchemyBuilder.get_builder(
+                        selectable=selectable, cache=ingredient_cache
+                    )
+                d[k] = ingredient_constructor(v, selectable, builder=builder)
             else:
                 d[k] = ingredient_constructor(v, selectable)
 

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1094,23 +1094,17 @@ WHERE scores_with_nulls.username = 'foo'
 GROUP BY username""",
         )
 
-        # Filters that aren't datatype=bool are ignored.
-        shelf = self.shelf_from_yaml(
-            """
-username:
-    kind: Dimension
-    field: username
-    filter: username
-""",
-            self.scores_with_nulls_table,
-        )
-        recipe = self.recipe(shelf=shelf).dimensions("username")
-        self.assertRecipeSQL(
-            recipe,
-            """SELECT scores_with_nulls.username AS username
-FROM scores_with_nulls
-GROUP BY username""",
-        )
+        # Filters that aren't datatype=bool raise errors.
+        with self.assertRaises(BadIngredient):
+            shelf = self.shelf_from_yaml(
+                """
+    username:
+        kind: Dimension
+        field: username
+        filter: username + "moo"
+    """,
+                self.scores_with_nulls_table,
+            )
 
     def test_complex_field(self):
         """Test parsed field definitions that use math, field references and more"""

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1074,6 +1074,26 @@ class TestParsedSQLGeneration(ConfigTestBase):
             """,
         )
 
+    def test_included_filter(self):
+        """Test ingredient definitions that include a filter expression"""
+        shelf = self.shelf_from_yaml(
+            """
+username:
+    kind: Dimension
+    field: username
+    filter: username = "foo"
+""",
+            self.scores_with_nulls_table,
+        )
+        recipe = self.recipe(shelf=shelf).dimensions("username")
+        self.assertRecipeSQL(
+            recipe,
+            """SSELECT scores_with_nulls.username AS username
+FROM scores_with_nulls
+WHERE scores_with_nulls.username = 'foo'
+GROUP BY username""",
+        )
+
     def test_complex_field(self):
         """Test parsed field definitions that use math, field references and more"""
         shelf = self.shelf_from_yaml(

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1088,9 +1088,27 @@ username:
         recipe = self.recipe(shelf=shelf).dimensions("username")
         self.assertRecipeSQL(
             recipe,
-            """SSELECT scores_with_nulls.username AS username
+            """SELECT scores_with_nulls.username AS username
 FROM scores_with_nulls
 WHERE scores_with_nulls.username = 'foo'
+GROUP BY username""",
+        )
+
+        # Filters that aren't datatype=bool are ignored.
+        shelf = self.shelf_from_yaml(
+            """
+username:
+    kind: Dimension
+    field: username
+    filter: username
+""",
+            self.scores_with_nulls_table,
+        )
+        recipe = self.recipe(shelf=shelf).dimensions("username")
+        self.assertRecipeSQL(
+            recipe,
+            """SELECT scores_with_nulls.username AS username
+FROM scores_with_nulls
 GROUP BY username""",
         )
 


### PR DESCRIPTION
This PR refactors how we create ingredients from config. 

Dimensions and Metrics now support a filter property which can be used to generate `Ingredient.filters` that will be applied when this ingredient is used. While this can be confusing it's also very powerful and has been specifically requested by users of the library.

We will use this filter property to to join multiple tables. 

### Other changes

A remnant of ingredient config version 1 was removed. Ingredients no longer require a `_version` property.