### PR TITLE
WIP Allow constants to be used in expressions

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -475,17 +475,14 @@ class Recipe(object):
         #             "havings": havings,
         #             "order_bys": list(order_bys)
         #         }
-        recipe_parts = self._cauldron.brew_query_parts(self._order_bys)
-
-        for extension in self.recipe_extensions:
-            recipe_parts = extension.modify_recipe_parts(recipe_parts)
+        parts = self._cauldron.brew_select_parts(self._order_bys)
 
         # Start building the query
-        query = self._session.query(*recipe_parts["columns"])
+        query = self._session.query(parts.columns)
         if self._select_from is not None:
             query = query.select_from(self._select_from)
-        recipe_parts["query"] = (
-            query.group_by(*recipe_parts["group_bys"])
+        parts.query = (
+            query.group_by(*parts.group_bys)
             .order_by(*recipe_parts["order_bys"])
             .filter(*recipe_parts["filters"])
         )

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -1,9 +1,10 @@
 import attr
 import re
-from typing import List
+from typing import List, Optional
+from datetime import datetime, date
 
 import structlog
-from sqlalchemy import Boolean, Date, DateTime, Integer, String, text
+from sqlalchemy import Boolean, Date, DateTime, Integer, String, Float, text, cast
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
 from sqlalchemy.sql.base import ColumnCollection
 from sqlalchemy.sql.sqltypes import Numeric
@@ -25,6 +26,7 @@ class Col:
 
     datatype: str = attr.ib()
     sqla_col = attr.ib()
+    name: str = attr.ib()
     idx: int = attr.ib(default=-1)
     namespace: str = attr.ib(default="")
 
@@ -45,10 +47,39 @@ class Col:
                 datatype = "bool"
             else:
                 datatype = "unusable"
-            return cls(namespace="", datatype=datatype, sqla_col=sqla_col)
+            return cls(
+                namespace="", datatype=datatype, sqla_col=sqla_col, name=sqla_col.name
+            )
+
+    @classmethod
+    def make_from_constant(cls, key, value):
+        """Make a column from a scalar constant"""
+        if is_valid_column(key):
+            datatype = "unusable"
+            sqla_col = None
+
+            if isinstance(value, str):
+                datatype = "str"
+                sqla_col = cast(value, String)
+            elif isinstance(value, date):
+                datatype = "date"
+                sqla_col = cast(value, Date)
+            elif isinstance(value, datetime):
+                datatype = "datetime"
+                sqla_col = cast(value, DateTime)
+            elif isinstance(value, int):
+                datatype = "num"
+                sqla_col = cast(value, Integer)
+            elif isinstance(value, float):
+                datatype = "num"
+                sqla_col = cast(value, Float)
+            elif isinstance(value, bool):
+                datatype = "bool"
+                sqla_col = cast(value, Boolean)
+            return cls(namespace="", datatype=datatype, sqla_col=sqla_col, name=key)
 
     @property
-    def rule_name(self) -> str:
+    def rule_name(self) -> str:  # sourcery skip: raise-specific-error
         """The name for the lark rule for this column"""
         if self.idx == -1:
             raise Exception("Must assign indexes first")
@@ -58,9 +89,9 @@ class Col:
     def field_name(self) -> str:
         """What to call this column in expressions."""
         if self.namespace:
-            return f"{self.namespace}\\.{self.sqla_col.name}"
+            return f"{self.namespace}\\.{self.name}"
         else:
-            return self.sqla_col.name
+            return self.name
 
     def as_rule(self):
         return f'    {self.rule_name}: "[" + /{self.field_name}/i + "]" | /{self.field_name}/i'
@@ -76,7 +107,7 @@ class ColCollection:
         """Sort columns by datatype and assign an index"""
         idx = 0
         prev_datatype = None
-        for col in sorted(self.columns, key=lambda c: (c.datatype, c.sqla_col.name)):
+        for col in sorted(self.columns, key=lambda c: (c.datatype, c.name)):
             if col.datatype != prev_datatype:
                 idx = 0
             col.idx = idx
@@ -134,7 +165,9 @@ def gather_columns(
         return f'{datatype_rule_name}: "DUMMYVALUNUSABLECOL"'
 
 
-def make_columns_for_selectable(selectable, *, namespace=None) -> ColumnCollection:
+def make_columns_for_selectable(
+    selectable, *, namespace: Optional[str] = None
+) -> ColumnCollection:
     """Return a dictionary of columns. The keys
     are unique lark rule names prefixed by the column type
     like num_0, num_1, string_0, etc.
@@ -156,10 +189,32 @@ def make_columns_for_selectable(selectable, *, namespace=None) -> ColumnCollecti
 
     columns = []
     for sqla_col in column_iterable:
-        col = Col.make_from_sqla_col(sqla_col)
-        if col:
+        if col := Col.make_from_sqla_col(sqla_col):
             columns.append(col)
 
+    cc = ColCollection(columns)
+    if namespace:
+        cc.set_namespace(namespace=namespace)
+    return cc
+
+
+def make_column_collection_for_constants(
+    constants: dict, *, namespace: Optional[str] = None
+) -> ColumnCollection:
+    """
+    Constants are a dict of names to scalar values to use in expressions
+    We will treat them as if they are another column collection
+
+    Args:
+        constants (dict): A dict with string keys and scalar values
+        namespace (str, optional): A namespace to add. Defaults to None.
+
+    Returns:
+        ColumnCollection: A column collection of constant values
+    """
+    columns = []
+    for k, v in constants.items():
+        columns.append(Col.make_from_constant(k, v))
     cc = ColCollection(columns)
     if namespace:
         cc.set_namespace(namespace=namespace)

--- a/recipe/schemas/transformers.py
+++ b/recipe/schemas/transformers.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
 )
 
 from . import engine_support
+from .expression_grammar import ColCollection
 from .utils import (
     calc_date_range,
     convert_to_end_datetime,
@@ -36,7 +37,13 @@ SLOG = structlog.get_logger(__name__)
 class TransformToSQLAlchemyExpression(Transformer):
     """Converts a field to a SQLAlchemy expression"""
 
-    def __init__(self, selectable, cc, drivername, forbid_aggregation=True):
+    def __init__(
+        self,
+        selectable,
+        cc: ColCollection,
+        drivername: str,
+        forbid_aggregation: bool = True,
+    ):
         self.text = None
         self.selectable = selectable
 

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -303,11 +303,7 @@ class Shelf(object):
         """
         from recipe import Recipe
 
-        from pprint import pprint
-
-        pprint(obj)
         constants = obj.pop("_constants", {})
-        pprint(obj)
 
         if isinstance(selectable, Recipe):
             selectable = selectable.subquery()
@@ -337,7 +333,6 @@ class Shelf(object):
                         extra_selectables=extra_selectables,
                         constants=constants,
                     )
-                print(builder.grammar)
                 d[k] = ingredient_constructor(v, selectable, builder=builder)
             else:
                 d[k] = ingredient_constructor(v, selectable)

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -15,6 +15,15 @@ from recipe.ingredients import Dimension, Filter, Ingredient, Metric, InvalidIng
 from recipe.schemas import shelf_schema
 from recipe.schemas.parsed_constructors import create_ingredient_from_parsed
 
+try:
+    # 1.4 and 2.0
+    from sqlalchemy.orm import Query
+except ImportError:
+    # 1.3
+    from sqlalchemy.orm.query import Query
+
+from sqlalchemy.sql.expression import Select
+
 from recipe.schemas.builders import SQLAlchemyBuilder
 
 _POP_DEFAULT = object()
@@ -46,6 +55,8 @@ class SelectParts:
     raw_order_by_keys: list = field(default_factory=list)
     order_bys: list = field(default_factory=list)
     all_filters: set = field(default_factory=set)
+    query: Query
+    select: Select
 
     def add_ingredient(self, ingredient):
         """Gather the SQLAlchemy fragments from this ingredient into a consolidated list."""

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -303,6 +303,12 @@ class Shelf(object):
         """
         from recipe import Recipe
 
+        from pprint import pprint
+
+        pprint(obj)
+        constants = obj.pop("_constants", {})
+        pprint(obj)
+
         if isinstance(selectable, Recipe):
             selectable = selectable.subquery()
         elif isinstance(selectable, str):
@@ -329,7 +335,9 @@ class Shelf(object):
                         selectable=selectable,
                         cache=ingredient_cache,
                         extra_selectables=extra_selectables,
+                        constants=constants,
                     )
+                print(builder.grammar)
                 d[k] = ingredient_constructor(v, selectable, builder=builder)
             else:
                 d[k] = ingredient_constructor(v, selectable)

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -55,8 +55,8 @@ class SelectParts:
     raw_order_by_keys: list = field(default_factory=list)
     order_bys: list = field(default_factory=list)
     all_filters: set = field(default_factory=set)
-    query: Query
-    select: Select
+    query: Query = None
+    select: Select = None
 
     def add_ingredient(self, ingredient):
         """Gather the SQLAlchemy fragments from this ingredient into a consolidated list."""

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -68,6 +68,18 @@ class BuildGrammarTestCase(RecipeTestCase):
         self.assertEqual(str_dedent(grammar), str_dedent(grammar_text))
 
     def test_make_columns_for_table(self):
+        # Selectable are
+        # self.selectables = [
+        #     self.basic_table,
+        #     self.datatypes_table,
+        #     self.recipe_from_config(
+        #         {"dimensions": ["first", "last"], "metrics": ["age"]}
+        #     ),
+        #     self.recipe_from_config({"dimensions": ["firstlast"], "metrics": ["age"]}),
+        #     BasicData,
+        #     DateTesterData,
+        # ]
+
         expected_column_keys = [
             ["date", "datetime", "num", "str", "str"],
             ["bool", "date", "datetime", "num", "str", "str", "str"],
@@ -80,6 +92,14 @@ class BuildGrammarTestCase(RecipeTestCase):
         for selectable, expected_column_keys in zip(
             self.selectables, expected_column_keys
         ):
+            print("Selectable is")
+            print(selectable)
+            from recipe import Recipe
+
+            if isinstance(selectable, Recipe):
+                print(selectable.to_sql())
+                self.assertEqual(1, 2)
+                continue
             cc = make_columns_for_selectable(selectable)
             ctypes = sorted([col.datatype for col in cc.columns])
             self.assertEqual(ctypes, expected_column_keys)
@@ -203,9 +223,23 @@ class BuildGrammarTestCase(RecipeTestCase):
             num.1: num_0 | NUMBER | extra_num_rule | "(" + num + ")"
             """,
         ]
+
+        expected_gathered_columns = [
+            """
+            unusable_col: "DUMMYVALUNUSABLECOL"
+            date.1: date_0 | extra_date_rule | "(" + date + ")"
+            datetime.2: datetime_0 | extra_datetime_rule | "(" + datetime + ")"
+            datetime_end.1: datetime_0 | datetime_end_conv | datetime_aggr | "(" + datetime_end + ")"
+            boolean.1: TRUE | FALSE | extra_bool_rule | "(" + boolean + ")"
+            string.1: str_0 | str_1 | ESCAPED_STRING | extra_string_rule | "(" + string + ")"
+            num.1: num_0 | NUMBER | extra_num_rule | "(" + num + ")"
+            """
+        ]
         for selectable, expected_gathered in zip(
             self.selectables, expected_gathered_columns
         ):
+            print("Selectable is")
+            print(selectable)
             columns = make_columns_for_selectable(selectable)
             gathered_columns = f"""
             {gather_columns("unusable_col", columns, "unusable")}


### PR DESCRIPTION
With namespace support, we can define constants in SQLAlchemy. We'll convert them to a SQLAlchemy expression of the same data type and then we can just use them.

However, this is not the best use of constants. We'd rather define them as expressions (maybe always aggregate expressions?) that can run against the whole table.

They could either run and be cached, or (better) run in a subquery. I think the selectables namespace support should allow this but haven't got it figured out yet.