### PR TITLE
Shelf constants

### DIFF
--- a/recipe/schemas/builders.py
+++ b/recipe/schemas/builders.py
@@ -43,7 +43,6 @@ class SQLAlchemyBuilder:
         extra_selectables: Optional[List] = None,
         cache=None,
     ):
-        print("Getting builder")
         return cls(
             selectable,
             constants=constants,

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -164,7 +164,11 @@ def has_constant_expressions(constants: dict) -> bool:
     return any(is_constant_expression(v) for v in constants.values())
 
 
-def make_column_collection_for_constants(
+def has_constant_literals(constants: dict) -> bool:
+    return any(not is_constant_expression(v) for v in constants.values())
+
+
+def make_column_collection_for_constant_literals(
     constants: dict, *, namespace: Optional[str] = None
 ) -> ColCollection:
     """

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -1,9 +1,10 @@
 import attr
 import re
-from typing import List
+from typing import List, Optional
+from datetime import datetime, date
 
 import structlog
-from sqlalchemy import Boolean, Date, DateTime, Integer, String, text
+from sqlalchemy import Boolean, Date, DateTime, Integer, String, Float, text, cast
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
 from sqlalchemy.sql.base import ColumnCollection
 from sqlalchemy.sql.sqltypes import Numeric
@@ -25,6 +26,7 @@ class Col:
 
     datatype: str = attr.ib()
     sqla_col = attr.ib()
+    name: str = attr.ib()
     idx: int = attr.ib(default=-1)
     namespace: str = attr.ib(default="")
 
@@ -45,10 +47,39 @@ class Col:
                 datatype = "bool"
             else:
                 datatype = "unusable"
-            return cls(namespace="", datatype=datatype, sqla_col=sqla_col)
+            return cls(
+                namespace="", datatype=datatype, sqla_col=sqla_col, name=sqla_col.name
+            )
+
+    @classmethod
+    def make_from_constant(cls, key, value):
+        """Make a column from a scalar constant"""
+        if is_valid_column(key):
+            datatype = "unusable"
+            sqla_col = None
+
+            if isinstance(value, str):
+                datatype = "str"
+                sqla_col = cast(value, String)
+            elif isinstance(value, date):
+                datatype = "date"
+                sqla_col = cast(value, Date)
+            elif isinstance(value, datetime):
+                datatype = "datetime"
+                sqla_col = cast(value, DateTime)
+            elif isinstance(value, int):
+                datatype = "num"
+                sqla_col = cast(value, Integer)
+            elif isinstance(value, float):
+                datatype = "num"
+                sqla_col = cast(value, Float)
+            elif isinstance(value, bool):
+                datatype = "bool"
+                sqla_col = cast(value, Boolean)
+            return cls(namespace="", datatype=datatype, sqla_col=sqla_col, name=key)
 
     @property
-    def rule_name(self) -> str:
+    def rule_name(self) -> str:  # sourcery skip: raise-specific-error
         """The name for the lark rule for this column"""
         if self.idx == -1:
             raise Exception("Must assign indexes first")
@@ -58,9 +89,9 @@ class Col:
     def field_name(self) -> str:
         """What to call this column in expressions."""
         if self.namespace:
-            return f"{self.namespace}\\.{self.sqla_col.name}"
+            return f"{self.namespace}\\.{self.name}"
         else:
-            return self.sqla_col.name
+            return self.name
 
     def as_rule(self):
         return f'    {self.rule_name}: "[" + /{self.field_name}/i + "]" | /{self.field_name}/i'
@@ -76,7 +107,7 @@ class ColCollection:
         """Sort columns by datatype and assign an index"""
         idx = 0
         prev_datatype = None
-        for col in sorted(self.columns, key=lambda c: (c.datatype, c.sqla_col.name)):
+        for col in sorted(self.columns, key=lambda c: (c.datatype, c.name)):
             if col.datatype != prev_datatype:
                 idx = 0
             col.idx = idx
@@ -134,7 +165,9 @@ def gather_columns(
         return f'{datatype_rule_name}: "DUMMYVALUNUSABLECOL"'
 
 
-def make_columns_for_selectable(selectable, *, namespace=None) -> ColumnCollection:
+def make_columns_for_selectable(
+    selectable, *, namespace: Optional[str] = None
+) -> ColumnCollection:
     """Return a dictionary of columns. The keys
     are unique lark rule names prefixed by the column type
     like num_0, num_1, string_0, etc.
@@ -156,10 +189,32 @@ def make_columns_for_selectable(selectable, *, namespace=None) -> ColumnCollecti
 
     columns = []
     for sqla_col in column_iterable:
-        col = Col.make_from_sqla_col(sqla_col)
-        if col:
+        if col := Col.make_from_sqla_col(sqla_col):
             columns.append(col)
 
+    cc = ColCollection(columns)
+    if namespace:
+        cc.set_namespace(namespace=namespace)
+    return cc
+
+
+def make_column_collection_for_constants(
+    constants: dict, *, namespace: Optional[str] = None
+) -> ColumnCollection:
+    """
+    Constants are a dict of names to scalar values to use in expressions
+    We will treat them as if they are another column collection
+
+    Args:
+        constants (dict): A dict with string keys and scalar values
+        namespace (str, optional): A namespace to add. Defaults to None.
+
+    Returns:
+        ColumnCollection: A column collection of constant values
+    """
+    columns = []
+    for k, v in constants.items():
+        columns.append(Col.make_from_constant(k, v))
     cc = ColCollection(columns)
     if namespace:
         cc.set_namespace(namespace=namespace)

--- a/recipe/schemas/transformers.py
+++ b/recipe/schemas/transformers.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
 )
 
 from . import engine_support
+from .expression_grammar import ColCollection
 from .utils import (
     calc_date_range,
     convert_to_end_datetime,
@@ -36,7 +37,13 @@ SLOG = structlog.get_logger(__name__)
 class TransformToSQLAlchemyExpression(Transformer):
     """Converts a field to a SQLAlchemy expression"""
 
-    def __init__(self, selectable, cc, drivername, forbid_aggregation=True):
+    def __init__(
+        self,
+        selectable,
+        cc: ColCollection,
+        drivername: str,
+        forbid_aggregation: bool = True,
+    ):
         self.text = None
         self.selectable = selectable
 

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -303,6 +303,12 @@ class Shelf(object):
         """
         from recipe import Recipe
 
+        from pprint import pprint
+
+        pprint(obj)
+        constants = obj.pop("_constants", {})
+        pprint(obj)
+
         if isinstance(selectable, Recipe):
             selectable = selectable.subquery()
         elif isinstance(selectable, str):
@@ -329,7 +335,9 @@ class Shelf(object):
                         selectable=selectable,
                         cache=ingredient_cache,
                         extra_selectables=extra_selectables,
+                        constants=constants,
                     )
+                print(builder.grammar)
                 d[k] = ingredient_constructor(v, selectable, builder=builder)
             else:
                 d[k] = ingredient_constructor(v, selectable)

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -12,7 +12,7 @@ from recipe.schemas.builders import SQLAlchemyBuilder
 from recipe.schemas.expression_grammar import (
     gather_columns,
     is_valid_column,
-    make_columns_for_selectable,
+    make_column_collection_for_selectable,
     make_columns_grammar,
 )
 from recipe.utils.formatting import expr_to_str
@@ -58,7 +58,7 @@ class BuildGrammarTestCase(RecipeTestCase):
 
     def assertSelectableGrammar(self, selectable, grammar_text: str, *, namespace=None):
         grammar = make_columns_grammar(
-            make_columns_for_selectable(selectable, namespace=namespace)
+            make_column_collection_for_selectable(selectable, namespace=namespace)
         )
 
         if str_dedent(grammar) != str_dedent(grammar_text):
@@ -80,14 +80,14 @@ class BuildGrammarTestCase(RecipeTestCase):
         for selectable, expected_column_keys in zip(
             self.selectables, expected_column_keys
         ):
-            cc = make_columns_for_selectable(selectable)
+            cc = make_column_collection_for_selectable(selectable)
             ctypes = sorted([col.datatype for col in cc.columns])
             self.assertEqual(ctypes, expected_column_keys)
 
         with self.assertRaises(Exception):
-            make_columns_for_selectable(None)
+            make_column_collection_for_selectable(None)
         with self.assertRaises(Exception):
-            make_columns_for_selectable("foo")
+            make_column_collection_for_selectable("foo")
 
     def test_make_columns_grammar(self):
         expected_grammars = [
@@ -206,7 +206,7 @@ class BuildGrammarTestCase(RecipeTestCase):
         for selectable, expected_gathered in zip(
             self.selectables, expected_gathered_columns
         ):
-            columns = make_columns_for_selectable(selectable)
+            columns = make_column_collection_for_selectable(selectable)
             gathered_columns = f"""
             {gather_columns("unusable_col", columns, "unusable")}
             {gather_columns("date.1", columns, "date", additional_rules=["extra_date_rule"])}

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -327,16 +327,17 @@ class TestSQLAlchemyBuilder(GrammarTestCase):
 
     def test_disallow_literals(self):
         examples = """
-        "22"          -> error
-        2.0           -> error
-        2.0 + 1.0     -> error
-        "220" + "foo" -> error
-        5             -> error
+        "22"          -> str
+        2.0           -> num
+        2.0 + 1.0     -> num
+        "220" + "foo" -> str
+        5             -> num
         """
 
-        for field, _ in self.examples(examples):
-            with self.assertRaises(GrammarError):
-                self.builder.parse(field)
+        for field, expected_data_type in self.examples(examples):
+            _, data_type = self.builder.parse(field, debug=True)
+            self.assertIs(type(data_type), str)
+            self.assertEqual(data_type, expected_data_type)
 
     def test_selectable_recipe(self):
         """Test a selectable that is a recipe"""

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1565,7 +1565,6 @@ class TestShelfConstants(ConfigTestBase):
             .metrics("count_star", "count_star_times_two")
             .dimensions("username")
         )
-        # FIXME: why is this named foo here?!!
         self.assertRecipeSQL(
             recipe,
             """SELECT scores_with_nulls.username || CAST('two' AS VARCHAR) AS username,
@@ -1573,8 +1572,8 @@ class TestShelfConstants(ConfigTestBase):
        CAST(2 AS INTEGER) * count(*) AS count_star_times_two
 FROM scores_with_nulls,
 
-  (SELECT sum(foo.score) AS sumscore
-   FROM scores_with_nulls AS foo) AS constants
+  (SELECT sum(scores_with_nulls.score) AS sumscore
+   FROM scores_with_nulls) AS constants
 GROUP BY username""",
         )
         self.assertRecipeCSV(
@@ -1628,8 +1627,8 @@ Vermont,609480,Vermont""",
        END AS pop2000_of_total
 FROM census,
 
-  (SELECT sum(foo.pop2000) AS ttlpop
-   FROM census AS foo) AS constants
+  (SELECT sum(census.pop2000) AS ttlpop
+   FROM census) AS constants
 GROUP BY state""",
         )
         self.assertRecipeCSV(

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1565,6 +1565,7 @@ class TestShelfConstants(ConfigTestBase):
             .metrics("count_star", "count_star_times_two")
             .dimensions("username")
         )
+        # FIXME: why is this named foo here?!!
         self.assertRecipeSQL(
             recipe,
             """SELECT scores_with_nulls.username || CAST('two' AS VARCHAR) AS username,

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -17,7 +17,7 @@ from tests.test_base import RecipeTestCase
 
 
 class ConfigTestBase(RecipeTestCase):
-    """A base class for testing shelves built from v1 or v2 config."""
+    """A base class for testing shelves built from config."""
 
     # The directory to look for yaml config files
     yaml_location = "shelf_config"
@@ -1540,6 +1540,53 @@ count_username:
         )
         self.assertRecipeCSV(recipe2, "count_star,count_username\n3,3\n")
 
+
+class TestShelfConstants(ConfigTestBase):
+    def test_simple_constant(self):
+        cache = Cache()
+        shelf = self.shelf_from_yaml(
+            """
+            _constants: {
+                two: 2,
+                twofloat: 2.0,
+                twostr: "two"
+            }
+            username: {kind: Dimension, field: username+constants.twostr}
+            count_star: {kind: Metric, field: count(*)}
+            count_star_times_two: {kind: Metric, field: count(*)*constants.two}
+            convertdate: {kind: Dimension, field: month(test_date)}
+            """,
+            self.scores_with_nulls_table,
+            ingredient_cache=cache,
+        )
+        recipe = (
+            self.recipe(shelf=shelf)
+            .metrics("count_star", "count_star_times_two")
+            .dimensions("username")
+        )
+        self.assertRecipeSQL(
+            recipe,
+            """SELECT scores_with_nulls.username || CAST('two' AS VARCHAR) AS username,
+       count(*) AS count_star,
+       count(*) * CAST(2 AS INTEGER) AS count_star_times_two
+FROM scores_with_nulls
+GROUP BY username""",
+        )
+        self.assertRecipeCSV(
+            recipe,
+            """username,count_star,count_star_times_two,username_id
+annikatwo,2,4,annikatwo
+chiptwo,3,6,chiptwo
+christwo,1,2,christwo""",
+        )
+
+
+class Cache(dict):
+    def set(self, k, v):
+        self[k] = v
+
+
+class TestCache(ConfigTestBase):
     def test_cache(self):
         cache = Cache()
         self.shelf_from_yaml(
@@ -1660,11 +1707,6 @@ count_username:
         )
         # the cache should be reinitialized, and should be identical to the old cache
         self.assertEqual(cache, og_cache)
-
-
-class Cache(dict):
-    def set(self, k, v):
-        self[k] = v
 
 
 class TestParsedIntellligentDates(ConfigTestBase):

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1546,12 +1546,6 @@ class TestShelfConstants(ConfigTestBase):
         cache = Cache()
         shelf = self.shelf_from_yaml(
             """
-            _constants: {
-                two: 2,
-                twofloat: 2.0,
-                twostr: "two",
-                sumscore: sum(score)
-            }
             username: {kind: Dimension, field: username+constants.twostr}
             count_star: {kind: Metric, field: count(*) * constants.sumscore}
             count_star_times_two: {kind: Metric, field: constants.two*count(*)}
@@ -1559,6 +1553,12 @@ class TestShelfConstants(ConfigTestBase):
             """,
             self.scores_with_nulls_table,
             ingredient_cache=cache,
+            constants={
+                "two": 2,
+                "twofloat": 2.0,
+                "twostr": "two",
+                "sumscore": "sum(score)",
+            },
         )
         recipe = (
             self.recipe(shelf=shelf)
@@ -1588,15 +1588,13 @@ christwo,260.0,2,christwo""",
         cache = Cache()
         shelf = self.shelf_from_yaml(
             """
-            _constants: {
-                ttlpop: sum(pop2000)
-            }
             state: {kind: Dimension, field: state}
             pop2000: {kind: Metric, field: sum(pop2000)}
             pop2000_of_total: {kind: Metric, field: sum(pop2000)/constants.ttlpop}
             """,
             self.census_table,
             ingredient_cache=cache,
+            constants={"ttlpop": "sum(pop2000)"},
         )
         recipe = self.recipe(shelf=shelf).metrics("pop2000").dimensions("state")
         self.assertRecipeSQL(


### PR DESCRIPTION
With namespace support, we can define constants in SQLAlchemy. We'll convert them to a SQLAlchemy expression of the same data type and then we can just use them.

Constants can be either literal values or aggregates. Constants are available in the constants namespace. Here's an example.

This is the shelf definition in yaml
```
state: {kind: Dimension, field: state}
pop2000: {kind: Metric, field: sum(pop2000)}
pop2000_of_total: {kind: Metric, field: sum(pop2000)/constants.ttlpop}
```

Constants is a dictionary of keys and expressions or scalars.
```
constants = {
    "ttlpop": "sum(pop2000)"
}
```


The pop2000_of_total metric divides `sum(pop2000)` based on whatever groupings the query is using by a grand total `sum(pop2000)` 

This generates a SQL query like this

```
SELECT census.state AS state,
       CASE
           WHEN (constants.ttlpop = 0) THEN NULL
           ELSE CAST(sum(census.pop2000) AS FLOAT) / CAST(constants.ttlpop AS FLOAT)
       END AS pop2000_of_total
FROM census,
  (SELECT sum(census.pop2000) AS ttlpop
   FROM census AS census) AS constants
GROUP BY state
```
