### PR TITLE
Add datediff, improve aggregation

### DIFF
--- a/recipe/core.py
+++ b/recipe/core.py
@@ -186,13 +186,7 @@ class Recipe(object):
 
         core_kwargs = subdict(spec, recipe_schema["schema"].keys())
         core_kwargs = normalize_schema(recipe_schema, core_kwargs)
-        core_kwargs["filters"] = [
-            # FIXME: This doesn't exist
-            parse_unvalidated_condition(filter, shelf.Meta.select_from)
-            if isinstance(filter, dict)
-            else filter
-            for filter in spec.get("filters", [])
-        ]
+        core_kwargs["filters"] = spec.get("filters", [])
         core_kwargs.update(kwargs)
         recipe = cls(shelf=shelf, **core_kwargs)
 

--- a/recipe/schemas/builders.py
+++ b/recipe/schemas/builders.py
@@ -88,7 +88,7 @@ class SQLAlchemyBuilder:
 
         # If we have expressions, we'll build a select statement
         # using the expressions, and make these into constants.
-        # Note, constants can only be aggregate expressions on the base selectable.
+        # This limits constants to aggregate expressions on the base selectable.
         if has_constant_expressions(constants):
             self.columns = make_column_collection_for_selectable(selectable)
             self.finalize_grammar()

--- a/recipe/schemas/engine_support.py
+++ b/recipe/schemas/engine_support.py
@@ -73,47 +73,47 @@ class bq_percentile99(expression.FunctionElement):
 
 @compiles(bq_median, "bigquery")
 def bqmedian(element, compiler, **kw):
-    return "approx_quantiles(%s, 2)[OFFSET(1)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 2)[OFFSET(1)]"
 
 
 @compiles(bq_percentile1, "bigquery")
 def bqpercentile1(element, compiler, **kw):
-    return "approx_quantiles(%s, 100)[OFFSET(1)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 100)[OFFSET(1)]"
 
 
 @compiles(bq_percentile5, "bigquery")
 def bqpercentile5(element, compiler, **kw):
-    return "approx_quantiles(%s, 20)[OFFSET(1)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 20)[OFFSET(1)]"
 
 
 @compiles(bq_percentile10, "bigquery")
 def bqpercentile10(element, compiler, **kw):
-    return "approx_quantiles(%s, 10)[OFFSET(1)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 10)[OFFSET(1)]"
 
 
 @compiles(bq_percentile25, "bigquery")
 def bqpercentile25(element, compiler, **kw):
-    return "approx_quantiles(%s, 4)[OFFSET(1)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 4)[OFFSET(1)]"
 
 
 @compiles(bq_percentile75, "bigquery")
 def bqpercentile75(element, compiler, **kw):
-    return "approx_quantiles(%s, 4)[OFFSET(3)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 4)[OFFSET(3)]"
 
 
 @compiles(bq_percentile90, "bigquery")
 def bqpercentile90(element, compiler, **kw):
-    return "approx_quantiles(%s, 10)[OFFSET(9)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 10)[OFFSET(9)]"
 
 
 @compiles(bq_percentile95, "bigquery")
 def bqpercentile95(element, compiler, **kw):
-    return "approx_quantiles(%s, 20)[OFFSET(19)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 20)[OFFSET(19)]"
 
 
 @compiles(bq_percentile99, "bigquery")
 def bqpercentile99(element, compiler, **kw):
-    return "approx_quantiles(%s, 100)[OFFSET(99)]" % compiler.process(element.clauses)
+    return f"approx_quantiles({compiler.process(element.clauses)}, 100)[OFFSET(99)]"
 
 
 # An age calculation for bigquery
@@ -128,10 +128,8 @@ class bq_age(expression.FunctionElement):
 def bqage(element, compiler, **kw):
     clauses = compiler.process(element.clauses)
     return (
-        "DATE_DIFF(CURRENT_DATE, %s, YEAR) - " % clauses
-        + "IF(EXTRACT(MONTH FROM CURRENT_DATE) + EXTRACT(DAY FROM CURRENT_DATE)/100.0 "
-        + "< EXTRACT(MONTH FROM %s)+ EXTRACT(DAY FROM %s)/100.0, 1, 0)"
-        % (clauses, clauses)
+        f"DATE_DIFF(CURRENT_DATE, {clauses}, YEAR) - IF(EXTRACT(MONTH FROM CURRENT_DATE) + EXTRACT(DAY FROM CURRENT_DATE)/100.0 "
+        + f"< EXTRACT(MONTH FROM {clauses})+ EXTRACT(DAY FROM {clauses})/100.0, 1, 0)"
     )
 
 
@@ -222,7 +220,7 @@ conversions = {
 
 conversions_redshift = {
     # age doesn't work on all databases
-    "age": lambda fld: postgres_age(fld),
+    "age": lambda fld: postgres_age(fld)
 }
 
 conversions_bigquery = {

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -279,7 +279,7 @@ def make_grammar(columns):
     {gather_columns("datetime_end.1", columns, "datetime", additional_rules=["datetime_end_conv", "datetime_aggr"])}
     {gather_columns("boolean.1", columns, "bool", additional_rules=["TRUE", "FALSE", "bool_expr", "date_bool_expr", "datetime_bool_expr", "str_like_expr", "vector_expr", "between_expr", "date_between_expr", "datetime_between_expr", "not_boolean", "or_boolean", "and_boolean", "paren_boolean", "intelligent_date_expr", "intelligent_datetime_expr"])}
     {gather_columns("string.1", columns, "str", additional_rules=["ESCAPED_STRING", "string_add", "string_cast", "string_coalesce", "string_substr", "string_if_statement", "string_aggr"])}
-    {gather_columns("num.1", columns, "num", additional_rules=["NUMBER", "num_add", "num_sub", "num_mul", "num_div", "int_cast", "num_coalesce", "aggr", "error_aggr", "num_if_statement", "age_conv"])}
+    {gather_columns("num.1", columns, "num", additional_rules=["NUMBER", "num_add", "num_sub", "num_mul", "num_div", "int_cast", "num_coalesce", "aggr", "error_aggr", "num_if_statement", "age_conv", "datediff"])}
     string_add: string "+" string
     num_add.1: num "+" num | "(" num "+" num ")"
     num_sub.1: num "-" num | "(" num "-" num ")"
@@ -352,6 +352,8 @@ def make_grammar(columns):
     dt_month_conv: /month/i "(" datetime ")"
     dt_quarter_conv: /quarter/i "(" datetime ")"
     dt_year_conv: /year/i "(" datetime ")"
+    /// date->int
+    datediff: /datediff/i "(" date "," date ")"
     // col->string
     string_cast: /string/i "(" col ")"
     string_substr: /substr/i "(" string "," [num ("," num)?] ")"

--- a/recipe/schemas/transformers.py
+++ b/recipe/schemas/transformers.py
@@ -355,6 +355,17 @@ class TransformToSQLAlchemyExpression(Transformer):
     def timedelta(self):
         pass
 
+    def datediff(self, _, dt1, dt2):
+        if self.drivername == "bigquery":
+            return func.date_diff(dt1, dt2, text("day"))
+        elif self.drivername == "sqlite":
+            return cast(func.julianday(dt1), Integer()) - cast(
+                func.julianday(dt2), Integer()
+            )
+        else:
+            # This works for postgres and mssql
+            return func.datediff(text("day"), dt1, dt2)
+
     # Booleans
 
     def and_boolean(self, left_boolean, AND, right_boolean):

--- a/recipe/schemas/validators.py
+++ b/recipe/schemas/validators.py
@@ -128,6 +128,21 @@ class SQLALchemyValidator(Visitor):
         if self.forbid_aggregation:
             self._add_error("Aggregations are not allowed in this field.", tree)
 
+    def string_aggr(self, tree):
+        self.found_aggregation = True
+        if self.forbid_aggregation:
+            self._add_error("Aggregations are not allowed in this field.", tree)
+
+    def date_aggr(self, tree):
+        self.found_aggregation = True
+        if self.forbid_aggregation:
+            self._add_error("Aggregations are not allowed in this field.", tree)
+
+    def datetime_aggr(self, tree):
+        self.found_aggregation = True
+        if self.forbid_aggregation:
+            self._add_error("Aggregations are not allowed in this field.", tree)
+
     def unknown_col(self, tree):
         """Column name doesn't exist in the data"""
         tok1 = tree.children[0]

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -264,10 +264,7 @@ class Shelf(object):
         """A string representation of the ingredients used in a recipe
         ordered by Dimensions, Metrics, Filters, then Havings
         """
-        lines = []
-        # sort the ingredients by type
-        for ingredient in sorted(self.values()):
-            lines.append(ingredient.describe())
+        lines = [ingredient.describe() for ingredient in sorted(self.values())]
         return "\n".join(lines)
 
     def use(self, ingredient):
@@ -345,6 +342,8 @@ class Shelf(object):
                 if not d[k].error.get("extra"):
                     d[k].error["extra"] = {}
                 d[k].error["extra"]["ingredient_name"] = k
+
+        # TODO: Evaluate how and if we're using select_from
         shelf = cls(d, select_from=selectable)
         if builder and ingredient_cache is not None:
             builder.save_cache()

--- a/tests/test_shelf_from_config.py
+++ b/tests/test_shelf_from_config.py
@@ -1306,9 +1306,36 @@ math:
 parentheses:
     kind: Metric
     field: "@count_star / (@count_star + (12.0 / 2.0))"
+maxdate:
+    kind: Metric
+    field: max(test_date)
+mindate:
+    kind: Metric
+    field: min(test_date)
+datediff:
+    kind: Metric
+    field: datediff(max(test_date), min(test_date))
 """,
             self.scores_with_nulls_table,
         )
+
+        # Test datediff
+        recipe = self.recipe(shelf=shelf).metrics("maxdate", "mindate", "datediff")
+        self.assertRecipeSQL(
+            recipe,
+            """SELECT CAST(julianday(max(scores_with_nulls.test_date)) AS INTEGER) - CAST(julianday(min(scores_with_nulls.test_date)) AS INTEGER) AS datediff,
+       max(scores_with_nulls.test_date) AS maxdate,
+       min(scores_with_nulls.test_date) AS mindate
+FROM scores_with_nulls""",
+        )
+        self.assertRecipeCSV(
+            recipe,
+            """
+            datediff,maxdate,mindate
+            31,2005-02-02,2005-01-02
+            """,
+        )
+
         recipe = self.recipe(shelf=shelf).metrics("count_star")
         self.assertRecipeSQL(
             recipe,


### PR DESCRIPTION
## Changes

- Add a datediff function returning int.
- Improve aggregation support
- 

### Datediff

Here's a sample datediff expression that yields an integer.

```
datediff:
    kind: Metric
    field: datediff(max(test_date), min(test_date))
```

### Aggregation

Aggregation was not validated correctly for non numeric expressions. This could generate invalid sql. We were also requiring metrics to be numbers. However, it's very possible to have a "metrical" expression like `max(birth_date)`.