### PR TITLE
Pass builder to shelf

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.35.1 (2023-04-20)
+-----------------------------------------
+* Allow expression builder to be passed to Shelf.from_config constructor.
+
 v0.35.0 (2023-04-09)
 -----------------------------------------
 * Add PaginateCountOver, a simpler pagination counter

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -134,9 +134,6 @@ def make_column_collection_for_selectable(
     """
     from recipe import Recipe
 
-    print("\nMaking cc for selectable")
-    print("sel is", selectable, type(selectable))
-
     if isinstance(selectable, Recipe):
         selectable = selectable.subquery()
 

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -134,6 +134,9 @@ def make_column_collection_for_selectable(
     """
     from recipe import Recipe
 
+    print("\nMaking cc for selectable")
+    print("sel is", selectable, type(selectable))
+
     if isinstance(selectable, Recipe):
         selectable = selectable.subquery()
 

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -143,7 +143,9 @@ def make_column_collection_for_selectable(
     elif hasattr(selectable, "c") and isinstance(selectable.c, ColumnCollection):
         column_iterable = selectable.c
     else:
-        raise Exception("Selectable does not have columns")
+        raise Exception(
+            f"Selectable must be a Table or ColumnCollection, this is a {type(selectable)}"
+        )
 
     columns = []
     for sqla_col in column_iterable:

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -307,6 +307,12 @@ class Shelf(object):
         """
         constants = constants or {}
 
+        print("\nMaking shelf from config")
+        print("sel", selectable, type(selectable))
+        print("cache", ingredient_cache, type(ingredient_cache))
+        print("extra_selectables", extra_selectables, type(extra_selectables))
+        print("constants", constants, type(constants))
+
         try:
             validated_shelf = normalize_schema(shelf_schema, obj, allow_unknown=True)
         except E.SureError as e:

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -350,7 +350,7 @@ class Shelf(object):
                 d[k].error["extra"]["ingredient_name"] = k
 
         # TODO: Evaluate how and if we're using select_from
-        shelf = cls(d, select_from=selectable)
+        shelf = cls(d, select_from=builder.selectable)
         if builder and ingredient_cache is not None:
             builder.save_cache()
 

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -286,6 +286,7 @@ class Shelf(object):
         ingredient_constructor=None,
         metadata=None,
         *,
+        builder=None,
         ingredient_cache=None,
         extra_selectables=None,
         constants=None,
@@ -301,17 +302,11 @@ class Shelf(object):
             order to introspect its schema, we must have the SQLAlchemy
             MetaData object to associate it with.
         :param ingredient_cache: An optional cache for improving parse times
-        :param extra_selectables: A dict with keys of namespace and selectable
+        :param extra_selectables: A list of (selectable, namespace) tuples.
             these are extra selectables that can be used in expressions
         :return: A shelf that contains the ingredients defined in obj.
         """
         constants = constants or {}
-
-        print("\nMaking shelf from config")
-        print("sel", selectable, type(selectable))
-        print("cache", ingredient_cache, type(ingredient_cache))
-        print("extra_selectables", extra_selectables, type(extra_selectables))
-        print("constants", constants, type(constants))
 
         try:
             validated_shelf = normalize_schema(shelf_schema, obj, allow_unknown=True)
@@ -319,12 +314,13 @@ class Shelf(object):
             raise BadIngredient(str(e))
 
         d = {}
-        builder = SQLAlchemyBuilder.get_builder(
-            selectable=selectable,
-            cache=ingredient_cache,
-            extra_selectables=extra_selectables,
-            constants=constants,
-        )
+        if builder is None:
+            builder = SQLAlchemyBuilder.get_builder(
+                selectable=selectable,
+                cache=ingredient_cache,
+                extra_selectables=extra_selectables,
+                constants=constants,
+            )
 
         for k, v in validated_shelf.items():
             d[k] = ingredient_from_validated_dict(v, selectable, builder=builder)


### PR DESCRIPTION
Allow builders to be passed to Shelf.from_config. This can speed up shelf construction.