### PR TITLE
Handle snowflake timestamp types

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.1
+current_version = 0.35.2
 commit = True
 tag = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.35.2 (2023-06-01)
+-----------------------------------------
+* Allow snowflake timestamps in expressions
+
 v0.35.1 (2023-04-20)
 -----------------------------------------
 * Allow expression builder to be passed to Shelf.from_config constructor.

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/recipe
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.35.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.35.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.35.1...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.35.2...master
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Overview
 
 .. |commits-since| image:: https://img.shields.io/github/commits-since/chrisgemignani/recipe/v0.35.2.svg
     :alt: Commits since latest release
-    :target: https://github.com/chrisgemignani/recipe/compare/v0.35.2...master
+    :target: https://github.com/chrisgemignani/recipe/compare/v0.35.2...main
 
 .. |downloads| image:: https://img.shields.io/pypi/dm/recipe.svg
     :alt: PyPI Package monthly downloads

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Recipe"
 year = "2019"
 author = "Chris Gemignani"
 copyright = "{0}, {1}".format(year, author)
-version = release = "0.35.1"
+version = release = "0.35.2"
 
 pygments_style = "trac"
 templates_path = ["."]

--- a/recipe/__init__.py
+++ b/recipe/__init__.py
@@ -51,7 +51,7 @@ class NullHandler(logging.Handler):
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-__version__ = "0.35.1"
+__version__ = "0.35.2"
 
 __all__ = [
     "BadIngredient",

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -45,6 +45,11 @@ class Col:
                 datatype = "num"
             elif isinstance(sqla_col.type, Boolean):
                 datatype = "bool"
+            elif str(sqla_col.type).startswith("TIMESTAMP"):
+                # This check is to support snowflake which uses custom
+                # types for timestamps that are not derived from sqlalchemy
+                # types.
+                datatype = "datetime"
             else:
                 datatype = "unusable"
             return cls(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install = [
 
 setup(
     name="recipe",
-    version="0.35.1",
+    version="0.35.2",
     description="A construction kit for SQL",
     long_description=(open("README.rst").read()),
     author="Chris Gemignani",


### PR DESCRIPTION
Snowflake uses custom types for TIMESTAMP_NTZ, TIMESTAMP_TZ, TIMESTAMP_LTZ. These are not in the sqlalchemy type hierarchy, so we considered them unusable types. This PR allows these types to be treated as datetime.

https://github.com/snowflakedb/snowflake-sqlalchemy/blob/v1.2.4/custom_types.py