### PR TITLE
Allow spaces in column names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+v0.35.4 (2023-06-12)
+-----------------------------------------
+* Support expressions for database column names that contain spaces
+
 v0.35.3 (2023-06-12)
 -----------------------------------------
 * Fix default group by strategy for dimensions in snowflake and mssql databases

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -96,7 +96,10 @@ class Col:
         return f"{self.namespace}\\.{self.name}" if self.namespace else self.name
 
     def as_rule(self):
-        return f'    {self.rule_name}: "[" + /{self.field_name}/i + "]" | /{self.field_name}/i'
+        if " " in self.field_name:
+            return f'    {self.rule_name}: "[" + /{self.field_name}/i + "]"'
+        else:
+            return f'    {self.rule_name}: "[" + /{self.field_name}/i + "]" | /{self.field_name}/i'
 
 
 @attr.s

--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -12,7 +12,7 @@ from sqlalchemy.sql.sqltypes import Numeric
 SLOG = structlog.get_logger(__name__)
 
 
-VALID_COLUMN_RE = re.compile("^\w+$")
+VALID_COLUMN_RE = re.compile("^\w[\w ]*$")
 
 
 def is_valid_column(colname: str) -> bool:

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -1179,16 +1179,21 @@ class TestIsValidColumn(GrammarTestCase):
             "this_that_and_other",
             "_other",
             "THIS_that_",
+            "that ",
+            "TH AT  ",
+            "x",
+            "_",
+            "5",
+            "_5",
         ]
         for v in good_values:
             self.assertTrue(is_valid_column(v))
 
         bad_values = [
-            " this",
-            "that ",
-            " THIS",
-            "TH AT  ",
             "for_slackbot}_organization_name",
+            " this",
+            " THIS",
+            "this_that-and-other",
         ]
         for v in bad_values:
             self.assertFalse(is_valid_column(v))


### PR DESCRIPTION
Allow column names with spaces in expression syntax. These must be surrounded by square brackets `sum([Sales Tax])`