### PR TITLE
Add extract(datepart, date) and add an optional datepart to datediff

### DIFF
--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -289,7 +289,7 @@ def make_grammar(columns):
     {gather_columns("datetime_end.1", columns, "datetime", additional_rules=["datetime_end_conv", "datetime_aggr"])}
     {gather_columns("boolean.1", columns, "bool", additional_rules=["TRUE", "FALSE", "bool_expr", "date_bool_expr", "datetime_bool_expr", "str_like_expr", "vector_expr", "between_expr", "date_between_expr", "datetime_between_expr", "not_boolean", "or_boolean", "and_boolean", "paren_boolean", "intelligent_date_expr", "intelligent_datetime_expr"])}
     {gather_columns("string.1", columns, "str", additional_rules=["ESCAPED_STRING", "string_add", "string_cast", "string_coalesce", "string_substr", "string_if_statement", "string_aggr"])}
-    {gather_columns("num.1", columns, "num", additional_rules=["NUMBER", "num_add", "num_sub", "num_mul", "num_div", "int_cast", "num_coalesce", "aggr", "error_aggr", "num_if_statement", "age_conv", "datediff"])}
+    {gather_columns("num.1", columns, "num", additional_rules=["NUMBER", "num_add", "num_sub", "num_mul", "num_div", "int_cast", "num_coalesce", "aggr", "error_aggr", "num_if_statement", "age_conv", "datediff", "extract"])}
     string_add: string "+" string
     num_add.1: num "+" num | "(" num "+" num ")"
     num_sub.1: num "-" num | "(" num "-" num ")"
@@ -363,7 +363,8 @@ def make_grammar(columns):
     dt_quarter_conv: /quarter/i "(" datetime ")"
     dt_year_conv: /year/i "(" datetime ")"
     /// date->int
-    datediff: /datediff/i "(" date "," date ")"
+    datediff: /datediff/i "(" date "," date ("," DATEPART )? ")"
+    extract: /extract/i "(" DATEPART "," (date | datetime) ")"
     // col->string
     string_cast: /string/i "(" col ")"
     string_substr: /substr/i "(" string "," [num ("," num)?] ")"
@@ -431,6 +432,8 @@ def make_grammar(columns):
     IF: /IF/i
     INTELLIGENT_DATE_OFFSET: /prior/i | /last/i | /previous/i | /current/i | /this/i | /next/i
     INTELLIGENT_DATE_UNITS: /ytd/i | /year/i | /qtr/i | /month/i | /mtd/i | /day/i
+    DATEPART: /dayofweek/i | /day/i | /dayofyear/i | /week/i | /week/i "(" WEEKDAY ")" | /month/i | /quarter/i | /year/i | /isoyear/i | /isoweek/i
+    WEEKDAY: /monday/i | /tuesday/i | /wednesday/i | /thursday/i | /friday/i | /saturday/i | /sunday/i
     COMMENT: /#.*/
 
     %import common.CNAME                       -> NAME

--- a/recipe/schemas/transformers.py
+++ b/recipe/schemas/transformers.py
@@ -355,16 +355,25 @@ class TransformToSQLAlchemyExpression(Transformer):
     def timedelta(self):
         pass
 
-    def datediff(self, _, dt1, dt2):
+    def datediff(self, _, dt1, dt2, datepart="day"):
         if self.drivername == "bigquery":
-            return func.date_diff(dt1, dt2, text("day"))
+            return func.date_diff(dt1, dt2, text(datepart))
         elif self.drivername == "sqlite":
             return cast(func.julianday(dt1), Integer()) - cast(
                 func.julianday(dt2), Integer()
             )
         else:
             # This works for postgres and mssql
-            return func.datediff(text("day"), dt1, dt2)
+            return func.datediff(text(datepart), dt1, dt2)
+
+    def extract(self, _, datepart, dt):
+        if self.drivername == "bigquery":
+            return func.extract(text(datepart), dt)
+        elif self.drivername == "sqlite":
+            raise GrammarError("Sqlite does not support extract")
+        else:
+            # This works for postgres and mssql
+            return func.extract(text(datepart), dt)
 
     # Booleans
 

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -891,6 +891,16 @@ class TestDataTypesTableDatesInBigquery(TestDataTypesTableDates):
         quarter([test_date]) > date("2020-12-30")        -> date_trunc(datatypes.test_date, quarter) > '2020-12-30'
         year([test_date]) > date("2020-12-30")           -> date_trunc(datatypes.test_date, year) > '2020-12-30'
         date([test_datetime])                            -> datetime(timestamp_trunc(datatypes.test_datetime, day))
+        datediff([test_date], [test_date])               -> date_diff(datatypes.test_date, datatypes.test_date, day)
+        datediff([test_date], [test_date], day)          -> date_diff(datatypes.test_date, datatypes.test_date, day)
+        datediff([test_date], [test_date], week)         -> date_diff(datatypes.test_date, datatypes.test_date, week)
+        datediff([test_date], [test_date], year)         -> date_diff(datatypes.test_date, datatypes.test_date, year)
+        datediff([test_date], [test_date], week(monday)) -> date_diff(datatypes.test_date, datatypes.test_date, week(monday))
+        # Extract works on both dates and datetimes
+        extract(day, [test_date])                        -> EXTRACT(day FROM datatypes.test_date)
+        extract(week(monday), [test_date])               -> EXTRACT(week(monday) FROM datatypes.test_date)
+        extract(day, [test_datetime])                    -> EXTRACT(day FROM datatypes.test_datetime)
+        extract(week(monday), [test_datetime])           -> EXTRACT(week(monday) FROM datatypes.test_datetime)
         """
 
         for field, expected_sql in self.examples(good_examples):


### PR DESCRIPTION
Enhance functions relating to dates

`datediff` can take an optional third parameter DATEPART like `datediff(endDate, startDate, dayofyear)` and returns an integer value.

DATEPART can be one of dayofweek, day, dayofyear, week, week(WEEKDAY), month, quarter, year, isoyear, isoweek

`extract` takes a DATEPART and a date like `extract(dayofweek, enddate)`

This lets us write an expression like this

```
1 + datediff(endDate, startDate) 
- 2 * datediff(endDate, StartDate, week) 
- if(extract(dayofweek, startDate)=1, 1, 0) 
- if(extract(dayofweek, endDate)=7, 1, 0)
```

This calculates the number of weekdays between two dates!