### PR TITLE
Add last_day support for bigquery/snowflake

### DIFF
--- a/recipe/schemas/expression_grammar.py
+++ b/recipe/schemas/expression_grammar.py
@@ -283,7 +283,7 @@ def make_grammar(columns):
     {make_columns_grammar(columns)}
 
     {gather_columns("unusable_col", columns, "unusable")}
-    {gather_columns("date.1", columns, "date", additional_rules=["date_conv", "date_fn", "day_conv", "week_conv", "month_conv", "quarter_conv", "year_conv", "dt_day_conv", "dt_week_conv", "dt_month_conv", "dt_quarter_conv", "dt_year_conv", "datetime_to_date_conv", "date_aggr", "date_if_statement", "date_coalesce"])}
+    {gather_columns("date.1", columns, "date", additional_rules=["date_conv", "date_fn", "day_conv", "week_conv", "month_conv", "quarter_conv", "year_conv", "dt_day_conv", "dt_week_conv", "dt_month_conv", "dt_quarter_conv", "dt_year_conv", "datetime_to_date_conv", "date_aggr", "date_if_statement", "date_coalesce", "lastday"])}
     {gather_columns("datetime.2", columns, "datetime", additional_rules=["datetime_conv", "datetime_if_statement", "datetime_coalesce"])}
     // Datetimes that are converted to the end of day
     {gather_columns("datetime_end.1", columns, "datetime", additional_rules=["datetime_end_conv", "datetime_aggr"])}
@@ -365,6 +365,7 @@ def make_grammar(columns):
     /// date->int
     datediff: /datediff/i "(" date "," date ("," DATEPART )? ")"
     extract: /extract/i "(" DATEPART "," (date | datetime) ")"
+    lastday: /lastday/i "(" (date | datetime) ("," DATEPART )? ")"
     // col->string
     string_cast: /string/i "(" col ")"
     string_substr: /substr/i "(" string "," [num ("," num)?] ")"

--- a/recipe/schemas/transformers.py
+++ b/recipe/schemas/transformers.py
@@ -375,6 +375,12 @@ class TransformToSQLAlchemyExpression(Transformer):
             # This works for postgres and mssql
             return func.extract(text(datepart), dt)
 
+    def lastday(self, _, dt, datepart="month"):
+        if self.drivername in ("bigquery", "snowflake"):
+            return func.last_day(dt, text(datepart))
+        else:
+            raise GrammarError(f"{self.drivername} does not support lastday")
+
     # Booleans
 
     def and_boolean(self, left_boolean, AND, right_boolean):

--- a/tests/test_expression_grammar.py
+++ b/tests/test_expression_grammar.py
@@ -891,6 +891,7 @@ class TestDataTypesTableDatesInBigquery(TestDataTypesTableDates):
         quarter([test_date]) > date("2020-12-30")        -> date_trunc(datatypes.test_date, quarter) > '2020-12-30'
         year([test_date]) > date("2020-12-30")           -> date_trunc(datatypes.test_date, year) > '2020-12-30'
         date([test_datetime])                            -> datetime(timestamp_trunc(datatypes.test_datetime, day))
+        # Datediff works on dates and defaults to day
         datediff([test_date], [test_date])               -> date_diff(datatypes.test_date, datatypes.test_date, day)
         datediff([test_date], [test_date], day)          -> date_diff(datatypes.test_date, datatypes.test_date, day)
         datediff([test_date], [test_date], week)         -> date_diff(datatypes.test_date, datatypes.test_date, week)
@@ -901,6 +902,9 @@ class TestDataTypesTableDatesInBigquery(TestDataTypesTableDates):
         extract(week(monday), [test_date])               -> EXTRACT(week(monday) FROM datatypes.test_date)
         extract(day, [test_datetime])                    -> EXTRACT(day FROM datatypes.test_datetime)
         extract(week(monday), [test_datetime])           -> EXTRACT(week(monday) FROM datatypes.test_datetime)
+        # Last day works on both dates and datetimes and defaults to month
+        lastday([test_datetime], week(monday))           -> last_day(datatypes.test_datetime, week(monday))
+        lastday([test_date])                             -> last_day(datatypes.test_date, month)
         """
 
         for field, expected_sql in self.examples(good_examples):


### PR DESCRIPTION
Add support for lastday(date, DATEPART=month). This converts a date to the last date of a period.

```
lastday("2020-01-14") -> "2020-01-31"
lastday("2023-05-15", YEAR) -> "2023-12-31"
```

This is only supported in bigquery and snowflake.