### PR TITLE
Use SelectParts class to gather elements when building a query

### DIFF
--- a/recipe/ingredients.py
+++ b/recipe/ingredients.py
@@ -9,7 +9,8 @@ from recipe.utils.datatype import (
     determine_datatype,
     datatype_from_column_expression,
 )
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
 ALLOWED_OPERATORS = set(
     [
@@ -38,6 +39,12 @@ def is_nested_condition(v) -> bool:
 def contains_complex_values(v: List) -> bool:
     """Check if any of the values in a list requires special handling to filter on"""
     return None in v or any(map(is_nested_condition, v))
+
+
+class Join:
+    selectables: Optional[List] = None
+    # A boolean expression that will be used to join this ingredient to the query
+    join_expression: Optional[str] = None
 
 
 @total_ordering
@@ -122,7 +129,8 @@ class Ingredient(object):
         self.column_suffixes = kwargs.pop("column_suffixes", None)
         self.cache_context = kwargs.pop("cache_context", "")
         self.datatype = kwargs.pop("datatype", None)
-        self.datatype_by_role = kwargs.pop("datatype_by_role", dict())
+        self.datatype_by_role = kwargs.pop("datatype_by_role", {})
+        self.join = None
         self.anonymize = False
         self.roles = {}
         self._labels = []


### PR DESCRIPTION
The goal of this PR is to improve joins between multiple tables when defining ingredients from config. In particular, I'd like to be able to seamlessly use google public data to merge in geography. 

Currently this is accomplished by defining an explicit extra_selectable. For this example imagine we have a base table with

```
state,sex,age,pop2000
```

and a extra_selectable with two columns

```
NAME,geography
 ^ this is state name

The extra config for Shelf from_config is 

extra_selectables:
 - namespace: states
   table: geodata.statedata
```

We can make an ingredient like

```
place:
  field: state
  filter: state = states.NAME
  geography_field: states.geography
```

Instead of doing this we'd like to have a registry that can build a more intelligent join. The first phase of this work is making an ingredient actively aware of what joins it needs. 

TODO:

- [ ] Build a multi-table join in brew_select_parts

  