### PR TITLE
Ensure that order_bys get properly quoted

### DIFF
--- a/recipe/schemas/builders.py
+++ b/recipe/schemas/builders.py
@@ -76,10 +76,7 @@ class SQLAlchemyBuilder:
         """
         self.selectable = selectable
         # Database driver
-        try:
-            self.drivername = selectable.metadata.bind.url.drivername
-        except Exception:
-            self.drivername = "unknown"
+        self.drivername = selectable.bind.url.drivername
 
         self.cache = cache
 

--- a/recipe/schemas/builders.py
+++ b/recipe/schemas/builders.py
@@ -74,6 +74,11 @@ class SQLAlchemyBuilder:
               namespace string.
             cache (cache): An optional cache.
         """
+        from recipe.core import Recipe
+
+        if isinstance(selectable, Recipe):
+            selectable = selectable.subquery()
+
         self.selectable = selectable
         # Database driver
         self.drivername = selectable.bind.url.drivername

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -351,7 +351,7 @@ class Shelf(object):
                     d[k].error["extra"] = {}
                 d[k].error["extra"]["ingredient_name"] = k
 
-        engine = builder.selectable.metadata.bind
+        engine = builder.selectable.bind
 
         # TODO: Evaluate how and if we're using select_from
         shelf = cls(d, select_from=builder.selectable, engine=engine)

--- a/recipe/shelf.py
+++ b/recipe/shelf.py
@@ -90,7 +90,7 @@ class SelectParts:
         for key in self.raw_order_by_keys:
             with contextlib.suppress(BadRecipe):
                 ingr = shelf.find(key, (Dimension, Metric))
-                for c in ingr.order_by_columns:
+                for c in ingr.order_by_columns(engine=shelf.Meta.engine):
                     # Avoid duplicate order by columns
                     if str(c) not in [str(o) for o in validated_order_bys]:
                         validated_order_bys[c] = None
@@ -118,6 +118,7 @@ class Shelf(object):
         select_from = None
         ingredient_order = []
         metadata = None
+        engine = None
 
     def __init__(self, *args, **kwargs):
         self.Meta = type(self).Meta()
@@ -125,6 +126,7 @@ class Shelf(object):
         self.Meta.table = kwargs.pop("table", None)
         self.Meta.select_from = kwargs.pop("select_from", None)
         self.Meta.metadata = kwargs.pop("metadata", None)
+        self.Meta.engine = kwargs.pop("engine", None)
         self._ingredients = {}
         self.update(*args, **kwargs)
 
@@ -349,8 +351,10 @@ class Shelf(object):
                     d[k].error["extra"] = {}
                 d[k].error["extra"]["ingredient_name"] = k
 
+        engine = builder.selectable.metadata.bind
+
         # TODO: Evaluate how and if we're using select_from
-        shelf = cls(d, select_from=builder.selectable)
+        shelf = cls(d, select_from=builder.selectable, engine=engine)
         if builder and ingredient_cache is not None:
             builder.save_cache()
 
@@ -474,7 +478,7 @@ class Shelf(object):
         for key in order_by_keys:
             try:
                 ingr = self.find(key, (Dimension, Metric))
-                for c in ingr.order_by_columns:
+                for c in ingr.order_by_columns(engine=self.Meta.engine):
                     # Avoid duplicate order by columns
                     if str(c) not in [str(o) for o in order_bys]:
                         order_bys[c] = None

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -84,23 +84,23 @@ class IngredientsTestCase(RecipeTestCase):
             column_suffixes=("_a", "_b"),
         )
         self.assertEqual(
-            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns],
+            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns()],
             ["foo_b", "foo_a"],
         )
         multi_column_ingr_with_suffixes.ordering = "desc"
         self.assertEqual(
-            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns],
+            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns()],
             ["foo_b DESC", "foo_a DESC"],
         )
         multi_column_ingr_with_suffixes.ordering = ""
         multi_column_ingr_with_suffixes.group_by_strategy = "none"
         self.assertEqual(
-            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns],
+            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns()],
             ["foo.last", "foo.first"],
         )
         multi_column_ingr_with_suffixes.ordering = "desc"
         self.assertEqual(
-            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns],
+            [str(tc) for tc in multi_column_ingr_with_suffixes.order_by_columns()],
             ["foo.last DESC", "foo.first DESC"],
         )
 
@@ -571,13 +571,13 @@ class TestDimension(RecipeTestCase):
 
     def test_dimension_order_by(self):
         d = Dimension(self.basic_table.c.first)
-        self.assertEqual(len(list(d.order_by_columns)), 1)
+        self.assertEqual(len(list(d.order_by_columns())), 1)
 
         # Dimension with different id and value expressions
         d = Dimension(self.basic_table.c.first, id_expression=self.basic_table.c.last)
-        self.assertEqual(len(list(d.order_by_columns)), 2)
+        self.assertEqual(len(list(d.order_by_columns())), 2)
         # Order by value expression then id expression
-        self.assertEqual(list(map(str, d.order_by_columns)), [d.id, d.id + "_id"])
+        self.assertEqual(list(map(str, d.order_by_columns())), [d.id, d.id + "_id"])
 
         # Extra roles DO participate in ordering
         d = Dimension(
@@ -586,9 +586,9 @@ class TestDimension(RecipeTestCase):
             age_expression=self.basic_table.c.age,
             id="moo",
         )
-        self.assertEqual(len(list(d.order_by_columns)), 3)
+        self.assertEqual(len(list(d.order_by_columns())), 3)
         self.assertEqual(
-            list(map(str, d.order_by_columns)), ["moo_age", "moo", "moo_id"]
+            list(map(str, d.order_by_columns())), ["moo_age", "moo", "moo_id"]
         )
 
         # Extra roles DO participate in ordering, order_by_expression is always first
@@ -599,9 +599,9 @@ class TestDimension(RecipeTestCase):
             order_by_expression=self.basic_table.c.age,
             id="moo",
         )
-        self.assertEqual(len(list(d.order_by_columns)), 4)
+        self.assertEqual(len(list(d.order_by_columns())), 4)
         self.assertEqual(
-            list(map(str, d.order_by_columns)),
+            list(map(str, d.order_by_columns())),
             ["moo_order_by", "moo_age", "moo", "moo_id"],
         )
 
@@ -612,9 +612,9 @@ class TestDimension(RecipeTestCase):
             order_by_expression=self.basic_table.c.age,
             id="moo",
         )
-        self.assertEqual(len(list(d.order_by_columns)), 4)
+        self.assertEqual(len(list(d.order_by_columns())), 4)
         self.assertEqual(
-            list(map(str, d.order_by_columns)),
+            list(map(str, d.order_by_columns())),
             ["moo_order_by", "moo_zed", "moo", "moo_id"],
         )
 
@@ -627,9 +627,9 @@ class TestDimension(RecipeTestCase):
             ordering="desc",
             id="moo",
         )
-        self.assertEqual(len(list(d.order_by_columns)), 4)
+        self.assertEqual(len(list(d.order_by_columns())), 4)
         self.assertEqual(
-            list(map(str, d.order_by_columns)),
+            list(map(str, d.order_by_columns())),
             ["moo_order_by DESC", "moo_zed DESC", "moo DESC", "moo_id DESC"],
         )
 


### PR DESCRIPTION
When ordering by labels, we need to ensure the labels are properly quoted.